### PR TITLE
[codex] expand long messages from ellipsis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.test-build/
 src-tauri/target/
 .DS_Store
 *.log

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",
+    "test:message-preview": "rm -rf .test-build && tsc --target ES2020 --module NodeNext --moduleResolution NodeNext --skipLibCheck --strict --outDir .test-build --noEmit false src/message-preview.ts && node --test tests/message-preview.test.mjs",
     "build": "tsc && vite build",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -21,10 +21,11 @@ import { APP_DISPLAY_NAME } from "../branding";
 import { isCompactFollowupMessage, wasEdited } from "../message-grouping";
 import { messageShareLink, messageToMarkdown } from "../message-share";
 import { Agent, AgentActivity, AgentRun, AgentWorkItem, Artifact, Channel, DraftAttachment, Message, OwnerProfile, TASK_STATUSES, Task, ThreadReplySummary } from "../types";
-import { agentForMessageSender, deletedAgentForMessageSender, firstLines, formatClockTime, formatDateDivider, formatTime, isSameCalendarDay, ownerAsAvatarAgent, visibleAgentDescription, visibleChannelDescription } from "../ui-utils";
+import { agentForMessageSender, deletedAgentForMessageSender, formatClockTime, formatDateDivider, formatTime, isSameCalendarDay, ownerAsAvatarAgent, visibleAgentDescription, visibleChannelDescription } from "../ui-utils";
 import { ActivityProgressDock, activeProgressByAgent } from "./ActivityProgressDock";
 import { AgentAvatar, AgentAvatarWithProfile } from "./AgentAvatar";
 import { DraftAttachmentsPreview } from "./DraftAttachmentsPreview";
+import { ExpandableMessageMarkdown } from "./ExpandableMessageMarkdown";
 import { MessageActionMenu } from "./MessageActionMenu";
 import { MessageAttachments } from "./MessageAttachments";
 import { MessageArtifacts } from "./MessageArtifacts";
@@ -629,7 +630,7 @@ export function Conversation({
                         <Bookmark size={14} />
                       </button>
                     </div>
-                    {message.delivery_state !== "streaming" && <MessageMarkdown body={firstLines(message.body)} />}
+                    {message.delivery_state !== "streaming" && <ExpandableMessageMarkdown body={message.body} />}
                     <MessageAttachments attachments={message.attachments} />
                     <MessageArtifacts artifacts={message.artifacts} onOpenArtifact={openArtifact} />
                     {message.delivery_state === "error" && (

--- a/src/components/ExpandableMessageMarkdown.tsx
+++ b/src/components/ExpandableMessageMarkdown.tsx
@@ -1,0 +1,40 @@
+import { useState, type MouseEvent, type PointerEvent } from "react";
+import { createMessagePreview } from "../message-preview";
+import { MessageMarkdown } from "./MessageMarkdown";
+
+type ExpandableMessageMarkdownProps = {
+  body: string;
+  previewLines?: number;
+};
+
+function isolateExpandEvent(event: MouseEvent<HTMLButtonElement> | PointerEvent<HTMLButtonElement>) {
+  event.stopPropagation();
+}
+
+export function ExpandableMessageMarkdown({ body, previewLines = 8 }: ExpandableMessageMarkdownProps) {
+  const [expanded, setExpanded] = useState(false);
+  const preview = createMessagePreview(body, previewLines);
+
+  if (expanded || !preview.truncated) {
+    return <MessageMarkdown body={body} />;
+  }
+
+  return (
+    <>
+      <MessageMarkdown body={preview.body} />
+      <button
+        type="button"
+        className="message-expand-toggle"
+        aria-label="Show full message"
+        title="Show full message"
+        onPointerDown={isolateExpandEvent}
+        onClick={(event) => {
+          isolateExpandEvent(event);
+          setExpanded(true);
+        }}
+      >
+        …
+      </button>
+    </>
+  );
+}

--- a/src/message-preview.ts
+++ b/src/message-preview.ts
@@ -1,0 +1,12 @@
+export type MessagePreview = {
+  body: string;
+  truncated: boolean;
+};
+
+export function createMessagePreview(text: string, lines = 8): MessagePreview {
+  const split = text.trim().split("\n");
+  return {
+    body: split.slice(0, lines).join("\n"),
+    truncated: split.length > lines,
+  };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1768,6 +1768,29 @@ mark {
   background: rgba(10, 132, 255, 0.14);
 }
 
+.message-expand-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 2px 0 0;
+  padding: 0 5px 2px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #6e6e73;
+  font: inherit;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.message-expand-toggle:hover,
+.message-expand-toggle:focus-visible {
+  background: rgba(10, 132, 255, 0.1);
+  color: var(--accent);
+}
+
 .message-attachments {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(132px, 260px));

--- a/src/ui-utils.ts
+++ b/src/ui-utils.ts
@@ -1,3 +1,4 @@
+import { createMessagePreview } from "./message-preview";
 import { Agent, AgentForm, Message, OwnerProfile, RUNTIME_PRESETS } from "./types";
 
 export function ownerAsAvatarAgent(profile: OwnerProfile) {
@@ -213,8 +214,8 @@ export function isSameCalendarDay(left: string, right: string) {
 }
 
 export function firstLines(text: string, lines = 8) {
-  const split = text.trim().split("\n");
-  return split.slice(0, lines).join("\n") + (split.length > lines ? "\n..." : "");
+  const preview = createMessagePreview(text, lines);
+  return preview.body + (preview.truncated ? "\n..." : "");
 }
 
 export function agentRequestSourceLabel(sourceKind: string, taskNumber?: number | null) {

--- a/tests/message-preview.test.mjs
+++ b/tests/message-preview.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+const { createMessagePreview } = await import("../.test-build/message-preview.js");
+
+test("createMessagePreview returns the full message when it fits", () => {
+  const preview = createMessagePreview("one\ntwo", 3);
+
+  assert.deepEqual(preview, {
+    body: "one\ntwo",
+    truncated: false,
+  });
+});
+
+test("createMessagePreview reports truncated bodies without appending ellipsis text", () => {
+  const preview = createMessagePreview("one\ntwo\nthree\nfour", 3);
+
+  assert.deepEqual(preview, {
+    body: "one\ntwo\nthree",
+    truncated: true,
+  });
+});


### PR DESCRIPTION
## Summary
- Add a message preview helper that reports whether a body was truncated separately from the preview text.
- Render root channel messages with a clickable `…` control when the body exceeds the preview line limit.
- Keep existing excerpt behavior for inbox/search/sidebar previews by routing `firstLines` through the new helper.

## Validation
- `npm run test:message-preview`
- `npm run build`
