### PR TITLE
Fix mobile web streaming reply latency

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14170,7 +14170,9 @@ mod tests {
         assert!(prompt.contains("stable user preferences"));
         assert!(prompt.contains("Before long-running work, update Active Context"));
         assert!(prompt.contains("Turn startup sequence:"));
-        assert!(prompt.contains("Use history-read or message-search only when"));
+        assert!(
+            prompt.contains("Use history-read or message-search when older channel/thread context")
+        );
         assert!(prompt.contains("Reply briefly to direct greetings"));
         assert!(prompt.contains("Agent context tools"));
         assert!(prompt.contains("inbox-list"));

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -559,7 +559,21 @@ async fn api_events(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
             }
         }
     };
-    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+    let response = Sse::new(stream)
+        .keep_alive(KeepAlive::default())
+        .into_response();
+    let (mut parts, body) = response.into_parts();
+    parts.headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-cache, no-transform"),
+    );
+    parts
+        .headers
+        .insert(header::CONNECTION, HeaderValue::from_static("keep-alive"));
+    parts
+        .headers
+        .insert("x-accel-buffering", HeaderValue::from_static("no"));
+    Ok(Response::from_parts(parts, body))
 }
 
 async fn api_attachment(

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -676,7 +676,7 @@ export function Conversation({
                         <Bookmark size={14} />
                       </button>
                     </div>
-                    {message.delivery_state !== "streaming" && (
+                    {(message.delivery_state !== "streaming" || visibleMessageBody.trim().length > 0) ? (
                       <>
                         <div className={isLongChannelMessage && !isChannelMessageExpanded ? "message-long-preview collapsed" : "message-long-preview"}>
                           <MessageMarkdown body={visibleMessageBody} />
@@ -696,9 +696,12 @@ export function Conversation({
                           </button>
                         )}
                       </>
-                    )}
+                    ) : null}
                     <MessageAttachments attachments={message.attachments} />
                     <MessageArtifacts artifacts={message.artifacts} onOpenArtifact={openArtifact} />
+                    {message.delivery_state === "streaming" && visibleMessageBody.trim().length > 0 && (
+                      <div className="message-stream-state">Streaming response</div>
+                    )}
                     {message.delivery_state === "error" && (
                       <div className="message-stream-state error">Response interrupted</div>
                     )}

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -449,9 +449,12 @@ export function ThreadPanel({
                           <Bookmark size={14} />
                         </button>
                       </div>
-                      {activeRoot.delivery_state !== "streaming" && <MessageMarkdown body={activeRoot.body} />}
+                      {(activeRoot.delivery_state !== "streaming" || activeRoot.body.trim().length > 0) && <MessageMarkdown body={activeRoot.body} />}
                       <MessageAttachments attachments={activeRoot.attachments} />
                       <MessageArtifacts artifacts={activeRoot.artifacts} onOpenArtifact={openArtifact} />
+                      {activeRoot.delivery_state === "streaming" && activeRoot.body.trim().length > 0 && (
+                        <div className="message-stream-state">Streaming response</div>
+                      )}
                       {activeRoot.delivery_state === "error" && (
                         <div className="message-stream-state error">Response interrupted</div>
                       )}
@@ -673,9 +676,12 @@ export function ThreadPanel({
                           <Bookmark size={14} />
                         </button>
                       </div>
-                      {reply.delivery_state !== "streaming" && <MessageMarkdown body={reply.body} />}
+                      {(reply.delivery_state !== "streaming" || reply.body.trim().length > 0) && <MessageMarkdown body={reply.body} />}
                       <MessageAttachments attachments={reply.attachments} />
                       <MessageArtifacts artifacts={reply.artifacts} onOpenArtifact={openArtifact} />
+                      {reply.delivery_state === "streaming" && reply.body.trim().length > 0 && (
+                        <div className="message-stream-state">Streaming response</div>
+                      )}
                       {reply.delivery_state === "error" && (
                         <div className="message-stream-state error">Response interrupted</div>
                       )}

--- a/src/message-grouping.ts
+++ b/src/message-grouping.ts
@@ -17,7 +17,7 @@ export function messageHasVisibleContent(message: Message) {
 export function isProgressOnlyMessage(message: Message) {
   if (!messageRunId(message)) return false;
   if (message.sender_role === "owner" || message.sender_role === "system") return false;
-  if (message.delivery_state === "streaming") return true;
+  if (message.delivery_state === "streaming") return !messageHasVisibleContent(message);
   return message.delivery_state === "complete" && !messageHasVisibleContent(message);
 }
 


### PR DESCRIPTION
## Summary
- Show streaming agent replies in the chat/thread surfaces as soon as they have visible body text instead of hiding them as progress-only placeholders until completion.
- Keep empty streaming placeholders in the progress dock so startup/status messages stay compact.
- Add no-cache/no-transform and no-buffering headers to the web SSE endpoint to reduce buffering over Tailscale/proxy/mobile browser paths.
- Update a stale prompt assertion so the existing Rust test suite matches current prompt wording.

## Verification
- npm run build
- cargo check
- cargo test