### PR TITLE
Fix mention autocomplete token boundary

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3101,7 +3101,7 @@ fn extract_agent_mentions(body: &str) -> Vec<String> {
         if body[..idx]
             .chars()
             .next_back()
-            .map(|prev| prev.is_ascii_alphanumeric() || prev == '_' || prev == '-' || prev == '.')
+            .map(|prev| prev.is_ascii_alphanumeric() || prev == '_' || prev == '-')
             .unwrap_or(false)
         {
             continue;
@@ -14463,6 +14463,12 @@ mod tests {
     fn extracts_unique_agent_mentions() {
         let mentions = extract_agent_mentions("ping @Hancock and @agent-2, then @Hancock again");
         assert_eq!(mentions, vec!["Hancock", "agent-2"]);
+    }
+
+    #[test]
+    fn extracts_mentions_after_non_ascii_text_and_punctuation() {
+        let mentions = extract_agent_mentions("请@agent看一下，或者（@reviewer）再看 end.@observer");
+        assert_eq!(mentions, vec!["agent", "reviewer", "observer"]);
     }
 
     #[test]

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -12,28 +12,31 @@ export type TokenMentionState = MentionState & {
   kind: MentionKind;
 };
 
-export function getMentionState(text: string, cursor: number): MentionState | null {
+function isMentionBoundary(text: string, markerIndex: number) {
+  if (markerIndex === 0) return true;
+  const previous = text[markerIndex - 1];
+  return !/[A-Za-z0-9_-]/.test(previous);
+}
+
+function getTokenMentionState(text: string, cursor: number, marker: "@" | "#"): MentionState | null {
   const beforeCursor = text.slice(0, cursor);
-  const match = beforeCursor.match(/(^|\s)@([A-Za-z0-9_-]*)$/);
-  if (!match) return null;
-  const query = match[2] ?? "";
+  const match = beforeCursor.match(new RegExp(`\\${marker}([A-Za-z0-9_-]*)$`));
+  if (!match || match.index === undefined) return null;
+  if (!isMentionBoundary(beforeCursor, match.index)) return null;
+  const query = match[1] ?? "";
   return {
     query,
-    start: cursor - query.length - 1,
+    start: match.index,
     end: cursor,
   };
 }
 
+export function getMentionState(text: string, cursor: number): MentionState | null {
+  return getTokenMentionState(text, cursor, "@");
+}
+
 export function getChannelMentionState(text: string, cursor: number): MentionState | null {
-  const beforeCursor = text.slice(0, cursor);
-  const match = beforeCursor.match(/(^|\s)#([A-Za-z0-9_-]*)$/);
-  if (!match) return null;
-  const query = match[2] ?? "";
-  return {
-    query,
-    start: cursor - query.length - 1,
-    end: cursor,
-  };
+  return getTokenMentionState(text, cursor, "#");
 }
 
 export function insertAgentMention(text: string, state: MentionState, handle: string) {
@@ -82,7 +85,7 @@ export function filterMentionChannels(channels: Channel[], query: string) {
 
 export function mentionedAgentsForBody(body: string, agents: Agent[]) {
   return agents.filter((agent) => {
-    const pattern = new RegExp(`(^|\\s)@${escapeRegExp(agent.handle)}(?=$|\\s|[.,;:!?])`);
+    const pattern = new RegExp(`(^|[^A-Za-z0-9_-])@${escapeRegExp(agent.handle)}(?=$|\\s|[.,;:!?])`);
     return pattern.test(body);
   });
 }


### PR DESCRIPTION
Closes #20

## Summary
- Relax composer mention token detection so `@` and `#` autocomplete can open after non-ASCII text or punctuation, not only after whitespace.
- Keep ASCII word/email protection by rejecting markers that follow letters, digits, `_`, or `-`.
- Align owner-side mention detection with backend dispatch parsing so autocomplete and actual dispatch use the same boundary semantics.
- Add a backend parser regression test for mentions after non-ASCII text and punctuation.

## Why
The previous frontend regex required `@` to be at start-of-text or after whitespace. That made natural inline mentions fail in common writing styles where users type text immediately followed by a mention. The fix keeps email-like text such as `name@example.com` and word-middle text such as `abc@agent` from becoming mentions while allowing punctuation and non-ASCII text before the marker.

## Validation
- `npm run build`
- `cargo test extract -- --nocapture`

## Privacy
The issue, PR description, and test data use generic example handles only.