### PR TITLE
Surface Claude provider retries

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -74,7 +74,7 @@ const UI_REFRESH_EVENT: &str = "lantor://refresh";
 const LANTOR_CONTEXT_TOOL_ENV: &str = "LANTOR_CONTEXT_TOOL";
 const STREAMING_MESSAGE_BODY_LIMIT: usize = 200_000;
 const CLAUDE_MAX_RETRIES_ENV: &str = "ANTHROPIC_MAX_RETRIES";
-const DEFAULT_CLAUDE_MAX_RETRIES: &str = "3";
+const DEFAULT_CLAUDE_MAX_RETRIES: &str = "5";
 const STREAMING_TRUNCATION_MARKER: &str = "\n\n[stream truncated by Lantor]";
 const DISPATCH_MESSAGE_BODY_LIMIT: usize = 4 * 1024;
 const CLAUDE_THREAD_CONTEXT_MESSAGE_LIMIT: i64 = 16;
@@ -6850,7 +6850,7 @@ fn activity_phase(kind: &str) -> &'static str {
         "file_edit" => "file_edit",
         "tools" => "tools",
         "error" | "event_error" | "run_error" => "error",
-        "run" | "usage" => "runtime",
+        "run" | "run_retry" | "usage" => "runtime",
         "dispatch" | "mention" | "dm" | "task" | "schedule" | "channel" | "membership" => "work",
         "profile" | "memory" => "profile",
         _ => "acting",
@@ -6864,6 +6864,7 @@ fn normalize_agent_activity_kind(kind: Option<&str>) -> &'static str {
         Some("file_edit") | Some("editing_file") => "file_edit",
         Some("tools") | Some("tool") => "tools",
         Some("error") => "error",
+        Some("run_retry") => "run_retry",
         Some("task") => "task",
         Some("message") => "message",
         Some("dispatch") => "dispatch",
@@ -6889,7 +6890,7 @@ fn activity_status(kind: &str, title: &str) -> &'static str {
                 || lowered.contains("rejected")))
     {
         "error"
-    } else if lowered.contains("warning") {
+    } else if kind == "run_retry" || lowered.contains("warning") {
         "warning"
     } else if lowered.contains("cancel") || lowered.contains("stop") || lowered.contains("stopping")
     {
@@ -10637,14 +10638,14 @@ fn claude_api_retry_detail(value: &Value) -> String {
         .get("error_status")
         .or_else(|| value.pointer("/error/status"))
         .and_then(Value::as_i64)
-        .map(|status| status.to_string());
+        .map(claude_api_retry_status_label);
     let error = value
         .get("error")
         .or_else(|| value.pointer("/error/type"))
         .or_else(|| value.pointer("/error/error"))
         .and_then(Value::as_str);
 
-    let mut parts = vec!["Claude provider request failed; retrying automatically".to_owned()];
+    let mut parts = vec!["Lantor will retry automatically; no action needed".to_owned()];
     match (attempt, max_retries) {
         (Some(attempt), Some(max_retries)) => {
             parts.push(format!("attempt {attempt}/{max_retries}"));
@@ -10655,7 +10656,7 @@ fn claude_api_retry_detail(value: &Value) -> String {
         _ => {}
     }
     if let Some(status) = status {
-        parts.push(format!("status {status}"));
+        parts.push(status);
     }
     if let Some(error) = error {
         parts.push(format!("error {error}"));
@@ -10664,12 +10665,20 @@ fn claude_api_retry_detail(value: &Value) -> String {
     truncate_activity_detail(&parts.join(" · "))
 }
 
+fn claude_api_retry_status_label(status: i64) -> String {
+    match status {
+        429 => "status 429 (rate limited)".to_owned(),
+        529 => "status 529 (overloaded)".to_owned(),
+        _ => format!("status {status}"),
+    }
+}
+
 fn claude_stream_event_activity(value: &Value) -> Option<(&'static str, &'static str, String)> {
     match value.get("type").and_then(Value::as_str)? {
         "system" => match value.get("subtype").and_then(Value::as_str) {
             Some("init") => Some(("run", "Runtime ready", "Claude stream connected".to_owned())),
             Some("api_retry") => Some((
-                "run_error",
+                "run_retry",
                 "Claude provider retrying",
                 claude_api_retry_detail(value),
             )),
@@ -10685,7 +10694,7 @@ fn claude_stream_event_activity(value: &Value) -> Option<(&'static str, &'static
                 None
             } else {
                 Some((
-                    "run_error",
+                    "run_retry",
                     "Waiting on rate limit",
                     format!("status={status}"),
                 ))
@@ -15980,6 +15989,7 @@ mod tests {
     #[test]
     fn marks_runtime_warning_activity_as_warning_status() {
         assert_eq!(activity_status("run", "Runtime warning"), "warning");
+        assert_eq!(activity_status("run_retry", "Claude provider retrying"), "warning");
         assert_eq!(activity_status("error", "Error output"), "error");
         assert_eq!(
             activity_status("thinking", "Investigating Activity ERROR"),
@@ -16180,10 +16190,18 @@ mod tests {
                 "error": "rate_limit"
             })),
             Some((
-                "run_error",
+                "run_retry",
                 "Claude provider retrying",
-                "Claude provider request failed; retrying automatically · attempt 2/3 · status 529 · error rate_limit"
+                "Lantor will retry automatically; no action needed · attempt 2/3 · status 529 (overloaded) · error rate_limit"
                     .to_owned()
+            ))
+        );
+        assert_eq!(
+            claude_stream_event_activity(&json!({"type": "system", "subtype": "api_retry"})),
+            Some((
+                "run_retry",
+                "Claude provider retrying",
+                "Lantor will retry automatically; no action needed".to_owned()
             ))
         );
         assert_eq!(
@@ -16191,6 +16209,16 @@ mod tests {
                 &json!({"type": "rate_limit_event", "rate_limit_info": {"status": "allowed"}})
             ),
             None
+        );
+        assert_eq!(
+            claude_stream_event_activity(
+                &json!({"type": "rate_limit_event", "rate_limit_info": {"status": "limited"}})
+            ),
+            Some((
+                "run_retry",
+                "Waiting on rate limit",
+                "status=limited".to_owned()
+            ))
         );
         assert_eq!(
             claude_stream_event_activity(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -73,6 +73,8 @@ const SUPERVISOR_WAKE_CHANNEL: &str = "lantor_supervisor_wake";
 const UI_REFRESH_EVENT: &str = "lantor://refresh";
 const LANTOR_CONTEXT_TOOL_ENV: &str = "LANTOR_CONTEXT_TOOL";
 const STREAMING_MESSAGE_BODY_LIMIT: usize = 200_000;
+const CLAUDE_MAX_RETRIES_ENV: &str = "ANTHROPIC_MAX_RETRIES";
+const DEFAULT_CLAUDE_MAX_RETRIES: &str = "3";
 const STREAMING_TRUNCATION_MARKER: &str = "\n\n[stream truncated by Lantor]";
 const DISPATCH_MESSAGE_BODY_LIMIT: usize = 4 * 1024;
 const CLAUDE_THREAD_CONTEXT_MESSAGE_LIMIT: i64 = 16;
@@ -10622,14 +10624,54 @@ fn claude_result_error(value: &Value) -> Option<String> {
         .or_else(|| Some("Claude stream-json result reported an error".to_owned()))
 }
 
+fn claude_api_retry_detail(value: &Value) -> String {
+    let attempt = value
+        .get("attempt")
+        .or_else(|| value.pointer("/retry/attempt"))
+        .and_then(Value::as_i64);
+    let max_retries = value
+        .get("max_retries")
+        .or_else(|| value.pointer("/retry/max_retries"))
+        .and_then(Value::as_i64);
+    let status = value
+        .get("error_status")
+        .or_else(|| value.pointer("/error/status"))
+        .and_then(Value::as_i64)
+        .map(|status| status.to_string());
+    let error = value
+        .get("error")
+        .or_else(|| value.pointer("/error/type"))
+        .or_else(|| value.pointer("/error/error"))
+        .and_then(Value::as_str);
+
+    let mut parts = vec!["Claude provider request failed; retrying automatically".to_owned()];
+    match (attempt, max_retries) {
+        (Some(attempt), Some(max_retries)) => {
+            parts.push(format!("attempt {attempt}/{max_retries}"));
+        }
+        (Some(attempt), None) => {
+            parts.push(format!("attempt {attempt}"));
+        }
+        _ => {}
+    }
+    if let Some(status) = status {
+        parts.push(format!("status {status}"));
+    }
+    if let Some(error) = error {
+        parts.push(format!("error {error}"));
+    }
+
+    truncate_activity_detail(&parts.join(" · "))
+}
+
 fn claude_stream_event_activity(value: &Value) -> Option<(&'static str, &'static str, String)> {
     match value.get("type").and_then(Value::as_str)? {
         "system" => match value.get("subtype").and_then(Value::as_str) {
             Some("init") => Some(("run", "Runtime ready", "Claude stream connected".to_owned())),
             Some("api_retry") => Some((
                 "run_error",
-                "Retrying request",
-                truncate_activity_detail(&value.to_string()),
+                "Claude provider retrying",
+                claude_api_retry_detail(value),
             )),
             Some(_) => None,
             None => None,
@@ -10738,7 +10780,7 @@ async fn get_or_spawn_warm_claude_runtime(
 
 fn claude_streaming_command_text(model: &str) -> String {
     format!(
-        "claude -p --model {model} --output-format stream-json --input-format stream-json --include-partial-messages --verbose --permission-mode bypassPermissions"
+        "{CLAUDE_MAX_RETRIES_ENV}={DEFAULT_CLAUDE_MAX_RETRIES} claude -p --model {model} --output-format stream-json --input-format stream-json --include-partial-messages --verbose --permission-mode bypassPermissions"
     )
 }
 
@@ -10793,7 +10835,8 @@ async fn spawn_warm_claude_runtime(
         .arg("--include-partial-messages")
         .arg("--verbose")
         .arg("--permission-mode")
-        .arg("bypassPermissions");
+        .arg("bypassPermissions")
+        .env(CLAUDE_MAX_RETRIES_ENV, DEFAULT_CLAUDE_MAX_RETRIES);
     configure_agent_identity_env(&mut command, agent_id, handle);
     configure_agent_context_tool_env(&mut command);
     #[cfg(unix)]
@@ -16126,6 +16169,22 @@ mod tests {
         assert_eq!(
             claude_stream_event_activity(&json!({"type": "system", "subtype": "init"})),
             Some(("run", "Runtime ready", "Claude stream connected".to_owned()))
+        );
+        assert_eq!(
+            claude_stream_event_activity(&json!({
+                "type": "system",
+                "subtype": "api_retry",
+                "attempt": 2,
+                "max_retries": 3,
+                "error_status": 529,
+                "error": "rate_limit"
+            })),
+            Some((
+                "run_error",
+                "Claude provider retrying",
+                "Claude provider request failed; retrying automatically · attempt 2/3 · status 529 · error rate_limit"
+                    .to_owned()
+            ))
         );
         assert_eq!(
             claude_stream_event_activity(

--- a/src/components/ActivityProgressDock.tsx
+++ b/src/components/ActivityProgressDock.tsx
@@ -64,6 +64,8 @@ function phaseLabel(phase: string) {
       return "Using tools";
     case "runtime":
       return "Runtime";
+    case "run_retry":
+      return "Retrying";
     case "work":
       return "Request";
     case "error":

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -71,6 +71,7 @@ const ACTIVITY_PHASE_LABELS: Record<string, string> = {
   task: "Acting",
   event_error: "Error",
   run_error: "Error",
+  run_retry: "Retrying",
 };
 
 const DEFAULT_THREAD_PANEL_WIDTH = 420;

--- a/src/styles.css
+++ b/src/styles.css
@@ -5007,6 +5007,11 @@ body.resizing-column * {
   box-shadow: 0 0 0 3px rgba(255, 212, 59, 0.14);
 }
 
+.activity-dot[data-kind="run_retry"] {
+  background: #ff9f0a;
+  box-shadow: 0 0 0 3px rgba(255, 159, 10, 0.16);
+}
+
 .activity-dot[data-kind="error"],
 .activity-dot[data-kind="event_error"],
 .activity-dot[data-kind="run_error"] {


### PR DESCRIPTION
Closes #24

## Summary
- Set a bounded default Claude CLI retry budget with `ANTHROPIC_MAX_RETRIES=3` for spawned warm stream-json processes.
- Make Claude `api_retry` stream events visible as `Claude provider retrying` activities instead of a generic retry label/raw JSON blob.
- Include structured retry details when available: attempt, max retries, provider status, and error class.
- Add coverage for the `api_retry` activity mapping.

## Why
When Claude returns provider-side retry events such as overload/rate-limit responses before any assistant tokens arrive, the agent can look silently stuck and hold its queue behind a long CLI retry loop. This hotfix does not implement the full recovery state machine; it makes the failure mode shorter and more legible.

## Validation
- `cargo fmt`
- `cargo test parses_claude_stream_json_events -- --nocapture`
- `npm run build`

## Follow-up issues
- #22: provider retry watchdog with classified recovery policy
- #23: user-facing stalled-run UX and queued follow-ups

## Privacy
No local handles, paths, provider credentials, or conversation-specific private details are included in the issue or PR body.