### PR TITLE
Localize composer draft state

### DIFF
--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -69,7 +69,7 @@ type ConversationProps = {
   setDraft: (value: string) => void;
   addDraftAttachments: (files: FileList | File[]) => void;
   removeDraftAttachment: (id: string) => void;
-  sendRootMessage: (asTask?: boolean) => void;
+  sendRootMessage: (asTask?: boolean, bodyOverride?: string, attachmentsOverride?: DraftAttachment[]) => void;
   openAgentDetail: (agent: Agent) => void;
   openArtifact: (artifact: Artifact) => void;
   shareBaseUrl: string | null;
@@ -164,33 +164,17 @@ export function Conversation({
   focusedMessageId,
   onToggleMessageSaved,
 }: ConversationProps) {
-  const [sendAsTask, setSendAsTask] = useState(false);
-  const [isComposerDragOver, setIsComposerDragOver] = useState(false);
   const [showChannelActions, setShowChannelActions] = useState(false);
   const [messageMenu, setMessageMenu] = useState<MessageMenuState>(null);
   const [expandedChannelMessageIds, setExpandedChannelMessageIds] = useState<Set<string>>(() => new Set());
-  const composerDragDepthRef = useRef(0);
-  const taskToggleHandledAtRef = useRef(0);
   const messageListRef = useRef<HTMLDivElement | null>(null);
   const shouldFollowMessagesRef = useRef(true);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const isDm = channel?.kind === "dm";
   const dmAgent = isDm ? agents.find((agent) => agent.id === channel?.dm_agent_id) ?? null : null;
   function openLinkedAgentDetail(handle: string) {
     const agent = agents.find((candidate) => candidate.handle.toLowerCase() === handle.toLowerCase());
     if (agent) openAgentDetail(agent);
   }
-  const {
-    mentionState,
-    mentionIndex,
-    mentionCandidates,
-    refreshMentionState,
-    chooseMention,
-    handleMentionKeyDown,
-    closeMentionPicker,
-    focusComposer,
-  } = useMentionPicker({ agents, channels, value: draft, setValue: setDraft, textareaRef });
   const activeReplyProgressByRoot = useMemo<Record<string, ReturnType<typeof activeProgressByAgent>>>(() => {
     if (!channel) return {};
     return Object.fromEntries(
@@ -247,110 +231,8 @@ export function Conversation({
     return Boolean(window.getSelection()?.toString().trim());
   }
 
-  function handleComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
-    if (isImeComposing(event)) return;
-    if (handleMentionKeyDown(event)) return;
-    if (event.key === "Enter" && !event.shiftKey) {
-      event.preventDefault();
-      submitComposer();
-    }
-  }
-
-  // Mobile WebViews (iOS WKWebView, Android WebView) dismiss the soft keyboard
-  // when a tap blurs the focused textarea, and the first tap is consumed by the
-  // dismissal so the button doesn't fire. Calling preventDefault on mousedown
-  // (which is non-passive in React) keeps focus on the textarea so the click
-  // fires reliably on the first tap.
-  function preserveComposerFocus(event: ReactMouseEvent<HTMLElement>) {
-    if (textareaRef.current && document.activeElement === textareaRef.current) {
-      event.preventDefault();
-    }
-  }
-
-  // Toggle eagerly on pointer/mouse down so the active highlight flips before
-  // the synthesized click. We dedupe via a timestamp ref and let click handle
-  // keyboard activation (Enter/Space), where down events do not fire.
-  function handleTaskToggleMouseDown(event: ReactMouseEvent<HTMLElement>) {
-    if (Date.now() - taskToggleHandledAtRef.current < 600) return;
-    preserveComposerFocus(event);
-    if (!channel) return;
-    taskToggleHandledAtRef.current = Date.now();
-    setSendAsTask((current) => !current);
-  }
-
-  function handleTaskTogglePointerDown(event: ReactPointerEvent<HTMLButtonElement>) {
-    if (event.pointerType === "mouse") return;
-    if (!channel) return;
-    event.preventDefault();
-    event.stopPropagation();
-    taskToggleHandledAtRef.current = Date.now();
-    setSendAsTask((current) => !current);
-  }
-
-  function handleTaskToggleClick() {
-    if (!channel) return;
-    if (Date.now() - taskToggleHandledAtRef.current < 600) return;
-    setSendAsTask((current) => !current);
-  }
-
-  function submitComposer() {
-    if (!channel || (!draft.trim() && draftAttachments.length === 0)) return;
-    sendRootMessage(isDm ? false : sendAsTask);
-    closeMentionPicker();
-    focusComposer();
-  }
-
   function shouldOpenThreadFromMessageClick() {
     return window.matchMedia("(max-width: 760px)").matches;
-  }
-
-  function hasDraggedFiles(event: DragEvent<HTMLElement>) {
-    return Array.from(event.dataTransfer.types).includes("Files");
-  }
-
-  function handleComposerDragEnter(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    composerDragDepthRef.current += 1;
-    event.dataTransfer.dropEffect = channel ? "copy" : "none";
-    if (channel) setIsComposerDragOver(true);
-  }
-
-  function handleComposerDragOver(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    event.dataTransfer.dropEffect = channel ? "copy" : "none";
-    if (channel) setIsComposerDragOver(true);
-  }
-
-  function handleComposerDragLeave(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    composerDragDepthRef.current = Math.max(0, composerDragDepthRef.current - 1);
-    if (composerDragDepthRef.current === 0) setIsComposerDragOver(false);
-  }
-
-  function handleComposerDrop(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    composerDragDepthRef.current = 0;
-    setIsComposerDragOver(false);
-    if (!channel || event.dataTransfer.files.length === 0) return;
-    addDraftAttachments(event.dataTransfer.files);
-    focusComposer();
-  }
-
-  function handleComposerPaste(event: ClipboardEvent<HTMLTextAreaElement>) {
-    const imageFiles = Array.from(event.clipboardData.files).filter((file) => file.type.startsWith("image/"));
-    if (imageFiles.length === 0) return;
-    event.preventDefault();
-    if (!channel) return;
-    addDraftAttachments(imageFiles);
-    focusComposer();
   }
 
   function renderReplyParticipantAvatar(message: Message) {
@@ -366,13 +248,10 @@ export function Conversation({
 
   useEffect(() => {
     if (!isDm) return;
-    setSendAsTask(false);
     if (activeTab === "tasks") setActiveTab("chat");
   }, [activeTab, isDm, setActiveTab]);
 
   useEffect(() => {
-    composerDragDepthRef.current = 0;
-    setIsComposerDragOver(false);
     setShowChannelActions(false);
     setMessageMenu(null);
   }, [channel?.id]);
@@ -900,117 +779,19 @@ export function Conversation({
       )}
 
       {activeTab === "chat" && (
-        <footer
-          className={`composer ${isComposerDragOver ? "drag-over" : ""}`}
-          onDragEnter={handleComposerDragEnter}
-          onDragOver={handleComposerDragOver}
-          onDragLeave={handleComposerDragLeave}
-          onDrop={handleComposerDrop}
-        >
-          {mentionState && mentionCandidates.length > 0 && (
-            <div className="mention-picker">
-              {mentionCandidates.map((candidate, index) => (
-                <button
-                  key={`${candidate.kind}:${candidate.id}`}
-                  className={index === mentionIndex ? "active" : ""}
-                  onMouseDown={(event) => {
-                    event.preventDefault();
-                    chooseMention(candidate);
-                  }}
-                >
-                  {candidate.kind === "agent" ? (
-                    <>
-                      <AgentAvatar agent={candidate.agent} size="sm" title={`@${candidate.agent.handle}`} />
-                      <span className="mention-picker-copy">
-                        <strong>{candidate.agent.display_name}</strong>
-                        <small>@{candidate.agent.handle}</small>
-                        {visibleAgentDescription(candidate.agent.description) && <em>{visibleAgentDescription(candidate.agent.description)}</em>}
-                      </span>
-                    </>
-                  ) : (
-                    <>
-                      <span className="mention-picker-channel-icon" aria-hidden="true">
-                        <Hash size={16} />
-                      </span>
-                      <span className="mention-picker-copy">
-                        <strong>#{candidate.channel.name}</strong>
-                        <small>Channel</small>
-                        {visibleChannelDescription(candidate.channel.description) && <em>{visibleChannelDescription(candidate.channel.description)}</em>}
-                      </span>
-                    </>
-                  )}
-                </button>
-              ))}
-            </div>
-          )}
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            className="file-input-hidden"
-            onChange={(event) => {
-              if (event.target.files) addDraftAttachments(event.target.files);
-              event.target.value = "";
-            }}
-          />
-          <DraftAttachmentsPreview attachments={draftAttachments} onRemove={removeDraftAttachment} />
-          <textarea
-            ref={textareaRef}
-            value={draft}
-            onChange={(event) => {
-              setDraft(event.target.value);
-              refreshMentionState(event.target.value, event.target.selectionStart);
-            }}
-            onSelect={(event) => refreshMentionState(draft, event.currentTarget.selectionStart)}
-            onKeyDown={handleComposerKeyDown}
-            onPaste={handleComposerPaste}
-            disabled={!channel}
-            placeholder={
-              channel
-                ? isDm
-                  ? `Message @${dmAgent?.handle || "agent"}`
-                  : `Message #${channel.name} - type @ or # to mention`
-                : "Create a channel before messaging"
-            }
-          />
-          <div className="composer-actions">
-            <button
-              type="button"
-              className="attach-button"
-              disabled={!channel}
-              onMouseDown={preserveComposerFocus}
-              onClick={() => fileInputRef.current?.click()}
-            >
-              <Paperclip size={16} />
-            </button>
-            {!isDm && (
-              <button
-                type="button"
-                className={`task-toggle ${sendAsTask ? "active" : ""}`}
-                title={sendAsTask ? "Send next message as a normal message" : "Send next message as a task"}
-                aria-label={sendAsTask ? "Send next message as a normal message" : "Send next message as a task"}
-                aria-pressed={sendAsTask}
-                disabled={!channel}
-                onPointerDown={handleTaskTogglePointerDown}
-                onMouseDown={handleTaskToggleMouseDown}
-                onClick={handleTaskToggleClick}
-              >
-                <Flag size={15} />
-                <span>Task</span>
-              </button>
-            )}
-            <button
-              className="send"
-              title={sendAsTask && !isDm ? "Create task" : "Send message"}
-              aria-label={sendAsTask && !isDm ? "Create task" : "Send message"}
-              disabled={!channel || (!draft.trim() && draftAttachments.length === 0)}
-              onMouseDown={preserveComposerFocus}
-              onClick={submitComposer}
-            >
-              <Send size={17} />
-            </button>
-          </div>
-        </footer>
+        <ConversationComposer
+          channel={channel}
+          isDm={isDm}
+          dmAgent={dmAgent}
+          agents={agents}
+          channels={channels}
+          draft={draft}
+          draftAttachments={draftAttachments}
+          setDraft={setDraft}
+          addDraftAttachments={addDraftAttachments}
+          removeDraftAttachment={removeDraftAttachment}
+          sendRootMessage={sendRootMessage}
+        />
       )}
     </section>
   );
@@ -1063,4 +844,317 @@ export function Conversation({
       </article>
     );
   }
+}
+
+type ConversationComposerProps = {
+  channel: Channel | null;
+  isDm: boolean;
+  dmAgent: Agent | null;
+  agents: Agent[];
+  channels: Channel[];
+  draft: string;
+  draftAttachments: DraftAttachment[];
+  setDraft: (value: string) => void;
+  addDraftAttachments: (files: FileList | File[]) => void;
+  removeDraftAttachment: (id: string) => void;
+  sendRootMessage: (asTask?: boolean, bodyOverride?: string, attachmentsOverride?: DraftAttachment[]) => void;
+};
+
+function hasDraggedFiles(event: DragEvent<HTMLElement>) {
+  return Array.from(event.dataTransfer.types).includes("Files");
+}
+
+function useBufferedComposerText(draft: string, resetKey: string | null | undefined, setDraft: (value: string) => void) {
+  const [text, setText] = useState(draft);
+  const textRef = useRef(draft);
+  const committedRef = useRef(draft);
+  const setDraftRef = useRef(setDraft);
+
+  useEffect(() => {
+    setDraftRef.current = setDraft;
+  }, [setDraft]);
+
+  useEffect(() => {
+    textRef.current = draft;
+    committedRef.current = draft;
+    setText(draft);
+  }, [draft, resetKey]);
+
+  useEffect(() => {
+    return () => {
+      if (textRef.current === committedRef.current) return;
+      committedRef.current = textRef.current;
+      setDraftRef.current(textRef.current);
+    };
+  }, [resetKey]);
+
+  function updateText(value: string) {
+    textRef.current = value;
+    setText(value);
+  }
+
+  function commitText(value = textRef.current) {
+    if (value === committedRef.current) return;
+    committedRef.current = value;
+    setDraftRef.current(value);
+  }
+
+  function markCommitted(value: string) {
+    textRef.current = value;
+    committedRef.current = value;
+    setText(value);
+  }
+
+  return { text, updateText, commitText, markCommitted };
+}
+
+function ConversationComposer({
+  channel,
+  isDm,
+  dmAgent,
+  agents,
+  channels,
+  draft,
+  draftAttachments,
+  setDraft,
+  addDraftAttachments,
+  removeDraftAttachment,
+  sendRootMessage,
+}: ConversationComposerProps) {
+  const [sendAsTask, setSendAsTask] = useState(false);
+  const [isComposerDragOver, setIsComposerDragOver] = useState(false);
+  const composerDragDepthRef = useRef(0);
+  const taskToggleHandledAtRef = useRef(0);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const { text, updateText, commitText, markCommitted } = useBufferedComposerText(draft, channel?.id, setDraft);
+  const {
+    mentionState,
+    mentionIndex,
+    mentionCandidates,
+    refreshMentionState,
+    chooseMention,
+    handleMentionKeyDown,
+    closeMentionPicker,
+    focusComposer,
+  } = useMentionPicker({ agents, channels, value: text, setValue: updateText, textareaRef });
+
+  useEffect(() => {
+    if (isDm) setSendAsTask(false);
+  }, [isDm]);
+
+  useEffect(() => {
+    composerDragDepthRef.current = 0;
+    setIsComposerDragOver(false);
+    closeMentionPicker();
+  }, [channel?.id]);
+
+  // Mobile WebViews dismiss the soft keyboard when a tap blurs the focused
+  // textarea, and the first tap is consumed by the dismissal.
+  function preserveComposerFocus(event: ReactMouseEvent<HTMLElement>) {
+    if (textareaRef.current && document.activeElement === textareaRef.current) {
+      event.preventDefault();
+    }
+  }
+
+  function handleTaskToggleMouseDown(event: ReactMouseEvent<HTMLElement>) {
+    if (Date.now() - taskToggleHandledAtRef.current < 600) return;
+    preserveComposerFocus(event);
+    if (!channel) return;
+    taskToggleHandledAtRef.current = Date.now();
+    setSendAsTask((current) => !current);
+  }
+
+  function handleTaskTogglePointerDown(event: ReactPointerEvent<HTMLButtonElement>) {
+    if (event.pointerType === "mouse") return;
+    if (!channel) return;
+    event.preventDefault();
+    event.stopPropagation();
+    taskToggleHandledAtRef.current = Date.now();
+    setSendAsTask((current) => !current);
+  }
+
+  function handleTaskToggleClick() {
+    if (!channel) return;
+    if (Date.now() - taskToggleHandledAtRef.current < 600) return;
+    setSendAsTask((current) => !current);
+  }
+
+  function submitComposer() {
+    if (!channel || (!text.trim() && draftAttachments.length === 0)) return;
+    const body = text;
+    markCommitted("");
+    sendRootMessage(isDm ? false : sendAsTask, body, draftAttachments);
+    closeMentionPicker();
+    focusComposer();
+  }
+
+  function handleComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (isImeComposing(event)) return;
+    if (handleMentionKeyDown(event)) return;
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      submitComposer();
+    }
+  }
+
+  function handleComposerDragEnter(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    composerDragDepthRef.current += 1;
+    event.dataTransfer.dropEffect = channel ? "copy" : "none";
+    if (channel) setIsComposerDragOver(true);
+  }
+
+  function handleComposerDragOver(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = channel ? "copy" : "none";
+    if (channel) setIsComposerDragOver(true);
+  }
+
+  function handleComposerDragLeave(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    composerDragDepthRef.current = Math.max(0, composerDragDepthRef.current - 1);
+    if (composerDragDepthRef.current === 0) setIsComposerDragOver(false);
+  }
+
+  function handleComposerDrop(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    composerDragDepthRef.current = 0;
+    setIsComposerDragOver(false);
+    if (!channel || event.dataTransfer.files.length === 0) return;
+    addDraftAttachments(event.dataTransfer.files);
+    focusComposer();
+  }
+
+  function handleComposerPaste(event: ClipboardEvent<HTMLTextAreaElement>) {
+    const imageFiles = Array.from(event.clipboardData.files).filter((file) => file.type.startsWith("image/"));
+    if (imageFiles.length === 0) return;
+    event.preventDefault();
+    if (!channel) return;
+    addDraftAttachments(imageFiles);
+    focusComposer();
+  }
+
+  return (
+    <footer
+      className={`composer ${isComposerDragOver ? "drag-over" : ""}`}
+      onDragEnter={handleComposerDragEnter}
+      onDragOver={handleComposerDragOver}
+      onDragLeave={handleComposerDragLeave}
+      onDrop={handleComposerDrop}
+    >
+      {mentionState && mentionCandidates.length > 0 && (
+        <div className="mention-picker">
+          {mentionCandidates.map((candidate, index) => (
+            <button
+              key={`${candidate.kind}:${candidate.id}`}
+              className={index === mentionIndex ? "active" : ""}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                chooseMention(candidate);
+              }}
+            >
+              {candidate.kind === "agent" ? (
+                <>
+                  <AgentAvatar agent={candidate.agent} size="sm" title={`@${candidate.agent.handle}`} />
+                  <span className="mention-picker-copy">
+                    <strong>{candidate.agent.display_name}</strong>
+                    <small>@{candidate.agent.handle}</small>
+                    {visibleAgentDescription(candidate.agent.description) && <em>{visibleAgentDescription(candidate.agent.description)}</em>}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span className="mention-picker-channel-icon" aria-hidden="true">
+                    <Hash size={16} />
+                  </span>
+                  <span className="mention-picker-copy">
+                    <strong>#{candidate.channel.name}</strong>
+                    <small>Channel</small>
+                    {visibleChannelDescription(candidate.channel.description) && <em>{visibleChannelDescription(candidate.channel.description)}</em>}
+                  </span>
+                </>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        className="file-input-hidden"
+        onChange={(event) => {
+          if (event.target.files) addDraftAttachments(event.target.files);
+          event.target.value = "";
+        }}
+      />
+      <DraftAttachmentsPreview attachments={draftAttachments} onRemove={removeDraftAttachment} />
+      <textarea
+        ref={textareaRef}
+        value={text}
+        onChange={(event) => {
+          updateText(event.target.value);
+          refreshMentionState(event.target.value, event.target.selectionStart);
+        }}
+        onBlur={() => commitText()}
+        onSelect={(event) => refreshMentionState(text, event.currentTarget.selectionStart)}
+        onKeyDown={handleComposerKeyDown}
+        onPaste={handleComposerPaste}
+        disabled={!channel}
+        placeholder={
+          channel
+            ? isDm
+              ? `Message @${dmAgent?.handle || "agent"}`
+              : `Message #${channel.name} - type @ or # to mention`
+            : "Create a channel before messaging"
+        }
+      />
+      <div className="composer-actions">
+        <button
+          type="button"
+          className="attach-button"
+          disabled={!channel}
+          onMouseDown={preserveComposerFocus}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <Paperclip size={16} />
+        </button>
+        {!isDm && (
+          <button
+            type="button"
+            className={`task-toggle ${sendAsTask ? "active" : ""}`}
+            title={sendAsTask ? "Send next message as a normal message" : "Send next message as a task"}
+            aria-label={sendAsTask ? "Send next message as a normal message" : "Send next message as a task"}
+            aria-pressed={sendAsTask}
+            disabled={!channel}
+            onPointerDown={handleTaskTogglePointerDown}
+            onMouseDown={handleTaskToggleMouseDown}
+            onClick={handleTaskToggleClick}
+          >
+            <Flag size={15} />
+            <span>Task</span>
+          </button>
+        )}
+        <button
+          className="send"
+          title={sendAsTask && !isDm ? "Create task" : "Send message"}
+          aria-label={sendAsTask && !isDm ? "Create task" : "Send message"}
+          disabled={!channel || (!text.trim() && draftAttachments.length === 0)}
+          onMouseDown={preserveComposerFocus}
+          onClick={submitComposer}
+        >
+          <Send size={17} />
+        </button>
+      </div>
+    </footer>
+  );
 }

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -70,7 +70,7 @@ type ThreadPanelProps = {
   setReplyDraft: (value: string) => void;
   addReplyAttachments: (files: FileList | File[]) => void;
   removeReplyAttachment: (id: string) => void;
-  sendReply: () => void;
+  sendReply: (bodyOverride?: string, attachmentsOverride?: DraftAttachment[]) => void;
   openAgentDetail: (agent: Agent) => void;
   openArtifact: (artifact: Artifact) => void;
   shareBaseUrl: string | null;
@@ -118,15 +118,11 @@ export function ThreadPanel({
   onToggleMessageSaved,
   onResizeStart,
 }: ThreadPanelProps) {
-  const [isReplyDragOver, setIsReplyDragOver] = useState(false);
   const [showBackToBottom, setShowBackToBottom] = useState(false);
   const [messageMenu, setMessageMenu] = useState<MessageMenuState>(null);
   const [tapFocusedMessageId, setTapFocusedMessageId] = useState<string | null>(null);
-  const replyDragDepthRef = useRef(0);
   const threadScrollRef = useRef<HTMLDivElement | null>(null);
   const shouldFollowThreadRef = useRef(true);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
   function openLinkedAgentDetail(handle: string) {
     const agent = agents.find((candidate) => candidate.handle.toLowerCase() === handle.toLowerCase());
     if (agent) openAgentDetail(agent);
@@ -141,16 +137,6 @@ export function ThreadPanel({
       ? `Thread in DM with @${dmAgent?.handle || "agent"}`
       : `Thread in #${channel.name}`
     : `${APP_DISPLAY_NAME} thread`;
-  const {
-    mentionState,
-    mentionIndex,
-    mentionCandidates,
-    refreshMentionState,
-    chooseMention,
-    handleMentionKeyDown,
-    closeMentionPicker,
-    focusComposer,
-  } = useMentionPicker({ agents, channels, value: replyDraft, setValue: setReplyDraft, textareaRef });
   const lastReply = replies[replies.length - 1] ?? null;
 
   function isThreadScrollAtBottom(element: HTMLDivElement) {
@@ -188,74 +174,7 @@ export function ThreadPanel({
     });
   }
 
-  function handleReplyKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
-    if (isImeComposing(event)) return;
-    if (handleMentionKeyDown(event)) return;
-    if (event.key === "Enter" && !event.shiftKey) {
-      event.preventDefault();
-      submitReply();
-    }
-  }
-
-  function submitReply() {
-    if (!activeRoot || (!replyDraft.trim() && replyAttachments.length === 0)) return;
-    sendReply();
-    closeMentionPicker();
-    focusComposer();
-  }
-
-  function hasDraggedFiles(event: DragEvent<HTMLElement>) {
-    return Array.from(event.dataTransfer.types).includes("Files");
-  }
-
-  function handleReplyDragEnter(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    replyDragDepthRef.current += 1;
-    event.dataTransfer.dropEffect = activeRoot ? "copy" : "none";
-    if (activeRoot) setIsReplyDragOver(true);
-  }
-
-  function handleReplyDragOver(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    event.dataTransfer.dropEffect = activeRoot ? "copy" : "none";
-    if (activeRoot) setIsReplyDragOver(true);
-  }
-
-  function handleReplyDragLeave(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    replyDragDepthRef.current = Math.max(0, replyDragDepthRef.current - 1);
-    if (replyDragDepthRef.current === 0) setIsReplyDragOver(false);
-  }
-
-  function handleReplyDrop(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    replyDragDepthRef.current = 0;
-    setIsReplyDragOver(false);
-    if (!activeRoot || event.dataTransfer.files.length === 0) return;
-    addReplyAttachments(event.dataTransfer.files);
-    focusComposer();
-  }
-
-  function handleReplyPaste(event: ClipboardEvent<HTMLTextAreaElement>) {
-    const imageFiles = Array.from(event.clipboardData.files).filter((file) => file.type.startsWith("image/"));
-    if (imageFiles.length === 0) return;
-    event.preventDefault();
-    if (!activeRoot) return;
-    addReplyAttachments(imageFiles);
-    focusComposer();
-  }
-
   useEffect(() => {
-    replyDragDepthRef.current = 0;
-    setIsReplyDragOver(false);
     setMessageMenu(null);
     setTapFocusedMessageId(null);
   }, [activeRoot?.id]);
@@ -727,96 +646,274 @@ export function ThreadPanel({
           )}
         </div>
 
-        <section
-          className={`reply-composer ${isReplyDragOver ? "drag-over" : ""}`}
-          onDragEnter={handleReplyDragEnter}
-          onDragOver={handleReplyDragOver}
-          onDragLeave={handleReplyDragLeave}
-          onDrop={handleReplyDrop}
-        >
-          {mentionState && mentionCandidates.length > 0 && (
-            <div className="mention-picker">
-              {mentionCandidates.map((candidate, index) => (
-                <button
-                  key={`${candidate.kind}:${candidate.id}`}
-                  className={index === mentionIndex ? "active" : ""}
-                  onMouseDown={(event) => {
-                    event.preventDefault();
-                    chooseMention(candidate);
-                  }}
-                >
-                  {candidate.kind === "agent" ? (
-                    <>
-                      <AgentAvatar agent={candidate.agent} size="sm" title={`@${candidate.agent.handle}`} />
-                      <span className="mention-picker-copy">
-                        <strong>{candidate.agent.display_name}</strong>
-                        <small>@{candidate.agent.handle}</small>
-                        {visibleAgentDescription(candidate.agent.description) && <em>{visibleAgentDescription(candidate.agent.description)}</em>}
-                      </span>
-                    </>
-                  ) : (
-                    <>
-                      <span className="mention-picker-channel-icon" aria-hidden="true">
-                        <Hash size={16} />
-                      </span>
-                      <span className="mention-picker-copy">
-                        <strong>#{candidate.channel.name}</strong>
-                        <small>Channel</small>
-                        {visibleChannelDescription(candidate.channel.description) && <em>{visibleChannelDescription(candidate.channel.description)}</em>}
-                      </span>
-                    </>
-                  )}
-                </button>
-              ))}
-            </div>
-          )}
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            className="file-input-hidden"
-            onChange={(event) => {
-              if (event.target.files) addReplyAttachments(event.target.files);
-              event.target.value = "";
-            }}
-          />
-          <DraftAttachmentsPreview attachments={replyAttachments} onRemove={removeReplyAttachment} />
-          <textarea
-            ref={textareaRef}
-            value={replyDraft}
-            onChange={(event) => {
-              setReplyDraft(event.target.value);
-              refreshMentionState(event.target.value, event.target.selectionStart);
-            }}
-            onSelect={(event) => refreshMentionState(replyDraft, event.currentTarget.selectionStart)}
-            onKeyDown={handleReplyKeyDown}
-            onPaste={handleReplyPaste}
-            disabled={!activeRoot}
-            placeholder={activeRoot ? isDm ? `Reply to @${dmAgent?.handle || "agent"}` : "Reply in thread" : "Select a thread to reply"}
-          />
-          <div className="reply-composer-actions">
-            <button
-              type="button"
-              className="attach-button"
-              disabled={!activeRoot}
-              onClick={() => fileInputRef.current?.click()}
-            >
-              <Paperclip size={15} />
-            </button>
-            <button
-              type="button"
-              className="reply-send"
-              title="Send reply"
-              aria-label="Send reply"
-              disabled={!activeRoot || (!replyDraft.trim() && replyAttachments.length === 0)}
-              onClick={submitReply}
-            >
-              <Send size={17} />
-            </button>
-          </div>
-        </section>
+        <ThreadReplyComposer
+          activeRoot={activeRoot}
+          isDm={isDm}
+          dmAgent={dmAgent}
+          agents={agents}
+          channels={channels}
+          replyDraft={replyDraft}
+          replyAttachments={replyAttachments}
+          setReplyDraft={setReplyDraft}
+          addReplyAttachments={addReplyAttachments}
+          removeReplyAttachment={removeReplyAttachment}
+          sendReply={sendReply}
+        />
       </section>
 
     </aside>
+  );
+}
+
+type ThreadReplyComposerProps = {
+  activeRoot: Message | null;
+  isDm: boolean;
+  dmAgent: Agent | null;
+  agents: Agent[];
+  channels: Channel[];
+  replyDraft: string;
+  replyAttachments: DraftAttachment[];
+  setReplyDraft: (value: string) => void;
+  addReplyAttachments: (files: FileList | File[]) => void;
+  removeReplyAttachment: (id: string) => void;
+  sendReply: (bodyOverride?: string, attachmentsOverride?: DraftAttachment[]) => void;
+};
+
+function hasDraggedFiles(event: DragEvent<HTMLElement>) {
+  return Array.from(event.dataTransfer.types).includes("Files");
+}
+
+function useBufferedComposerText(draft: string, resetKey: string | null | undefined, setDraft: (value: string) => void) {
+  const [text, setText] = useState(draft);
+  const textRef = useRef(draft);
+  const committedRef = useRef(draft);
+  const setDraftRef = useRef(setDraft);
+
+  useEffect(() => {
+    setDraftRef.current = setDraft;
+  }, [setDraft]);
+
+  useEffect(() => {
+    textRef.current = draft;
+    committedRef.current = draft;
+    setText(draft);
+  }, [draft, resetKey]);
+
+  useEffect(() => {
+    return () => {
+      if (textRef.current === committedRef.current) return;
+      committedRef.current = textRef.current;
+      setDraftRef.current(textRef.current);
+    };
+  }, [resetKey]);
+
+  function updateText(value: string) {
+    textRef.current = value;
+    setText(value);
+  }
+
+  function commitText(value = textRef.current) {
+    if (value === committedRef.current) return;
+    committedRef.current = value;
+    setDraftRef.current(value);
+  }
+
+  function markCommitted(value: string) {
+    textRef.current = value;
+    committedRef.current = value;
+    setText(value);
+  }
+
+  return { text, updateText, commitText, markCommitted };
+}
+
+function ThreadReplyComposer({
+  activeRoot,
+  isDm,
+  dmAgent,
+  agents,
+  channels,
+  replyDraft,
+  replyAttachments,
+  setReplyDraft,
+  addReplyAttachments,
+  removeReplyAttachment,
+  sendReply,
+}: ThreadReplyComposerProps) {
+  const [isReplyDragOver, setIsReplyDragOver] = useState(false);
+  const replyDragDepthRef = useRef(0);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const { text, updateText, commitText, markCommitted } = useBufferedComposerText(replyDraft, activeRoot?.id, setReplyDraft);
+  const {
+    mentionState,
+    mentionIndex,
+    mentionCandidates,
+    refreshMentionState,
+    chooseMention,
+    handleMentionKeyDown,
+    closeMentionPicker,
+    focusComposer,
+  } = useMentionPicker({ agents, channels, value: text, setValue: updateText, textareaRef });
+
+  useEffect(() => {
+    replyDragDepthRef.current = 0;
+    setIsReplyDragOver(false);
+    closeMentionPicker();
+  }, [activeRoot?.id]);
+
+  function submitReply() {
+    if (!activeRoot || (!text.trim() && replyAttachments.length === 0)) return;
+    const body = text;
+    markCommitted("");
+    sendReply(body, replyAttachments);
+    closeMentionPicker();
+    focusComposer();
+  }
+
+  function handleReplyKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (isImeComposing(event)) return;
+    if (handleMentionKeyDown(event)) return;
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      submitReply();
+    }
+  }
+
+  function handleReplyDragEnter(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    replyDragDepthRef.current += 1;
+    event.dataTransfer.dropEffect = activeRoot ? "copy" : "none";
+    if (activeRoot) setIsReplyDragOver(true);
+  }
+
+  function handleReplyDragOver(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = activeRoot ? "copy" : "none";
+    if (activeRoot) setIsReplyDragOver(true);
+  }
+
+  function handleReplyDragLeave(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    replyDragDepthRef.current = Math.max(0, replyDragDepthRef.current - 1);
+    if (replyDragDepthRef.current === 0) setIsReplyDragOver(false);
+  }
+
+  function handleReplyDrop(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    replyDragDepthRef.current = 0;
+    setIsReplyDragOver(false);
+    if (!activeRoot || event.dataTransfer.files.length === 0) return;
+    addReplyAttachments(event.dataTransfer.files);
+    focusComposer();
+  }
+
+  function handleReplyPaste(event: ClipboardEvent<HTMLTextAreaElement>) {
+    const imageFiles = Array.from(event.clipboardData.files).filter((file) => file.type.startsWith("image/"));
+    if (imageFiles.length === 0) return;
+    event.preventDefault();
+    if (!activeRoot) return;
+    addReplyAttachments(imageFiles);
+    focusComposer();
+  }
+
+  return (
+    <section
+      className={`reply-composer ${isReplyDragOver ? "drag-over" : ""}`}
+      onDragEnter={handleReplyDragEnter}
+      onDragOver={handleReplyDragOver}
+      onDragLeave={handleReplyDragLeave}
+      onDrop={handleReplyDrop}
+    >
+      {mentionState && mentionCandidates.length > 0 && (
+        <div className="mention-picker">
+          {mentionCandidates.map((candidate, index) => (
+            <button
+              key={`${candidate.kind}:${candidate.id}`}
+              className={index === mentionIndex ? "active" : ""}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                chooseMention(candidate);
+              }}
+            >
+              {candidate.kind === "agent" ? (
+                <>
+                  <AgentAvatar agent={candidate.agent} size="sm" title={`@${candidate.agent.handle}`} />
+                  <span className="mention-picker-copy">
+                    <strong>{candidate.agent.display_name}</strong>
+                    <small>@{candidate.agent.handle}</small>
+                    {visibleAgentDescription(candidate.agent.description) && <em>{visibleAgentDescription(candidate.agent.description)}</em>}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span className="mention-picker-channel-icon" aria-hidden="true">
+                    <Hash size={16} />
+                  </span>
+                  <span className="mention-picker-copy">
+                    <strong>#{candidate.channel.name}</strong>
+                    <small>Channel</small>
+                    {visibleChannelDescription(candidate.channel.description) && <em>{visibleChannelDescription(candidate.channel.description)}</em>}
+                  </span>
+                </>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        className="file-input-hidden"
+        onChange={(event) => {
+          if (event.target.files) addReplyAttachments(event.target.files);
+          event.target.value = "";
+        }}
+      />
+      <DraftAttachmentsPreview attachments={replyAttachments} onRemove={removeReplyAttachment} />
+      <textarea
+        ref={textareaRef}
+        value={text}
+        onChange={(event) => {
+          updateText(event.target.value);
+          refreshMentionState(event.target.value, event.target.selectionStart);
+        }}
+        onBlur={() => commitText()}
+        onSelect={(event) => refreshMentionState(text, event.currentTarget.selectionStart)}
+        onKeyDown={handleReplyKeyDown}
+        onPaste={handleReplyPaste}
+        disabled={!activeRoot}
+        placeholder={activeRoot ? isDm ? `Reply to @${dmAgent?.handle || "agent"}` : "Reply in thread" : "Select a thread to reply"}
+      />
+      <div className="reply-composer-actions">
+        <button
+          type="button"
+          className="attach-button"
+          disabled={!activeRoot}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <Paperclip size={15} />
+        </button>
+        <button
+          type="button"
+          className="reply-send"
+          title="Send reply"
+          aria-label="Send reply"
+          disabled={!activeRoot || (!text.trim() && replyAttachments.length === 0)}
+          onClick={submitReply}
+        >
+          <Send size={17} />
+        </button>
+      </div>
+    </section>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2517,10 +2517,11 @@ function App() {
     });
   }
 
-  async function sendRootMessage(asTask = false) {
-    if (!channel || (!draft.trim() && draftAttachments.length === 0)) return;
-    const body = draft.trim();
-    const attachments = draftAttachments;
+  async function sendRootMessage(asTask = false, bodyOverride?: string, attachmentsOverride?: DraftAttachment[]) {
+    const rawBody = bodyOverride ?? draft;
+    const attachments = attachmentsOverride ?? draftAttachments;
+    if (!channel || (!rawBody.trim() && attachments.length === 0)) return;
+    const body = rawBody.trim();
     const sendAsTask = channel.kind === "dm" ? false : asTask;
     const optimisticId = addOptimisticOwnerMessage(channel.id, null, body, sendAsTask, attachments);
     updateRootComposerDraft(channel.id, () => EMPTY_COMPOSER_DRAFT);
@@ -2558,10 +2559,11 @@ function App() {
     }
   }
 
-  async function sendReply() {
-    if (!channel || !activeRoot || (!replyDraft.trim() && replyAttachments.length === 0)) return;
-    const body = replyDraft.trim();
-    const attachments = replyAttachments;
+  async function sendReply(bodyOverride?: string, attachmentsOverride?: DraftAttachment[]) {
+    const rawBody = bodyOverride ?? replyDraft;
+    const attachments = attachmentsOverride ?? replyAttachments;
+    if (!channel || !activeRoot || (!rawBody.trim() && attachments.length === 0)) return;
+    const body = rawBody.trim();
     const optimisticId = addOptimisticOwnerMessage(channel.id, activeRoot.id, body, false, attachments);
     updateReplyComposerDraft(activeRoot.id, () => EMPTY_COMPOSER_DRAFT);
     try {


### PR DESCRIPTION
## Summary

Depends on #27.

Moves the production main composer and thread reply composer to local buffered text state. Per-keystroke input now updates the small composer component instead of pushing every draft character into the top-level app state and re-rendering the full conversation or thread surface.

The parent draft is still synchronized on blur, unmount/channel switch, and send, so existing draft persistence and send flows are preserved.

## Scope

- Main channel/DM composer draft text is localized in `ConversationComposer`.
- Thread reply draft text is localized in `ThreadReplyComposer`.
- `sendRootMessage` and `sendReply` accept explicit body/attachment overrides so send can use the freshest local text without waiting for a parent state sync.
- Existing behaviors kept: Enter-to-send, IME guard, `@agent` and `#channel` mention picker, file picker, paste image attachments, drag/drop attachments, task toggle, and optimistic send restore on failure.

## Benchmark

Using #27's mechanism benchmark, this PR moves the production typing path from the `root-coupled` strategy toward the `buffered` strategy.

Representative local stress numbers:

```text
main-plain-stress:                root p95 ~75ms/key -> buffered ~0.008ms/key, large tree commits 40 -> 0, long tasks 8 -> 0
thread-plain-stress:              root p95 ~49ms/key -> buffered ~0.007ms/key, large tree commits 40 -> 0, long tasks 1-2 -> 0
main-agent-mention-stress:        root p95 ~75ms/key -> buffered ~0.063ms/key, large tree commits 24 -> 0, long tasks 4 -> 0
main-channel-autocomplete-stress: root p95 ~73ms/key -> buffered ~0.056ms/key, large tree commits 24 -> 0, long tasks 4 -> 0
```

The benchmark is synthetic and isolates the React render mechanism; it is not a browser INP substitute. The key review point is that the app code no longer routes every keystroke through the broad conversation/thread tree.

## Verification

- `npm run build`
- `npm run bench:composer`
