### PR TITLE
Localize composer draft state

### DIFF
--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -70,7 +70,7 @@ type ConversationProps = {
   setDraft: (value: string) => void;
   addDraftAttachments: (files: FileList | File[]) => void;
   removeDraftAttachment: (id: string) => void;
-  sendRootMessage: (asTask?: boolean) => void;
+  sendRootMessage: (asTask?: boolean, bodyOverride?: string, attachmentsOverride?: DraftAttachment[]) => void;
   openAgentDetail: (agent: Agent) => void;
   openArtifact: (artifact: Artifact) => void;
   shareBaseUrl: string | null;
@@ -165,17 +165,11 @@ export function Conversation({
   focusedMessageId,
   onToggleMessageSaved,
 }: ConversationProps) {
-  const [sendAsTask, setSendAsTask] = useState(false);
-  const [isComposerDragOver, setIsComposerDragOver] = useState(false);
   const [showChannelActions, setShowChannelActions] = useState(false);
   const [messageMenu, setMessageMenu] = useState<MessageMenuState>(null);
   const [expandedChannelMessageIds, setExpandedChannelMessageIds] = useState<Set<string>>(() => new Set());
-  const composerDragDepthRef = useRef(0);
-  const taskToggleHandledAtRef = useRef(0);
   const messageListRef = useRef<HTMLDivElement | null>(null);
   const shouldFollowMessagesRef = useRef(true);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const channelActionsRef = useRef<HTMLDivElement | null>(null);
   const isDm = channel?.kind === "dm";
   const dmAgent = isDm ? agents.find((agent) => agent.id === channel?.dm_agent_id) ?? null : null;
@@ -183,17 +177,6 @@ export function Conversation({
     const agent = agents.find((candidate) => candidate.handle.toLowerCase() === handle.toLowerCase());
     if (agent) openAgentDetail(agent);
   }
-  const {
-    mentionState,
-    mentionIndex,
-    mentionCandidates,
-    refreshMentionState,
-    chooseMention,
-    handleMentionKeyDown,
-    closeMentionPicker,
-    focusComposer,
-  } = useMentionPicker({ agents, channels, value: draft, setValue: setDraft, textareaRef });
-  useAutoGrowTextarea(textareaRef, draft);
   const activeReplyProgressByRoot = useMemo<Record<string, ReturnType<typeof activeProgressByAgent>>>(() => {
     if (!channel) return {};
     return Object.fromEntries(
@@ -250,110 +233,8 @@ export function Conversation({
     return Boolean(window.getSelection()?.toString().trim());
   }
 
-  function handleComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
-    if (isImeComposing(event)) return;
-    if (handleMentionKeyDown(event)) return;
-    if (event.key === "Enter" && !event.shiftKey) {
-      event.preventDefault();
-      submitComposer();
-    }
-  }
-
-  // Mobile WebViews (iOS WKWebView, Android WebView) dismiss the soft keyboard
-  // when a tap blurs the focused textarea, and the first tap is consumed by the
-  // dismissal so the button doesn't fire. Calling preventDefault on mousedown
-  // (which is non-passive in React) keeps focus on the textarea so the click
-  // fires reliably on the first tap.
-  function preserveComposerFocus(event: ReactMouseEvent<HTMLElement>) {
-    if (textareaRef.current && document.activeElement === textareaRef.current) {
-      event.preventDefault();
-    }
-  }
-
-  // Toggle eagerly on pointer/mouse down so the active highlight flips before
-  // the synthesized click. We dedupe via a timestamp ref and let click handle
-  // keyboard activation (Enter/Space), where down events do not fire.
-  function handleTaskToggleMouseDown(event: ReactMouseEvent<HTMLElement>) {
-    if (Date.now() - taskToggleHandledAtRef.current < 600) return;
-    preserveComposerFocus(event);
-    if (!channel) return;
-    taskToggleHandledAtRef.current = Date.now();
-    setSendAsTask((current) => !current);
-  }
-
-  function handleTaskTogglePointerDown(event: ReactPointerEvent<HTMLButtonElement>) {
-    if (event.pointerType === "mouse") return;
-    if (!channel) return;
-    event.preventDefault();
-    event.stopPropagation();
-    taskToggleHandledAtRef.current = Date.now();
-    setSendAsTask((current) => !current);
-  }
-
-  function handleTaskToggleClick() {
-    if (!channel) return;
-    if (Date.now() - taskToggleHandledAtRef.current < 600) return;
-    setSendAsTask((current) => !current);
-  }
-
-  function submitComposer() {
-    if (!channel || (!draft.trim() && draftAttachments.length === 0)) return;
-    sendRootMessage(isDm ? false : sendAsTask);
-    closeMentionPicker();
-    focusComposer();
-  }
-
   function shouldOpenThreadFromMessageClick() {
     return window.matchMedia("(max-width: 760px)").matches;
-  }
-
-  function hasDraggedFiles(event: DragEvent<HTMLElement>) {
-    return Array.from(event.dataTransfer.types).includes("Files");
-  }
-
-  function handleComposerDragEnter(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    composerDragDepthRef.current += 1;
-    event.dataTransfer.dropEffect = channel ? "copy" : "none";
-    if (channel) setIsComposerDragOver(true);
-  }
-
-  function handleComposerDragOver(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    event.dataTransfer.dropEffect = channel ? "copy" : "none";
-    if (channel) setIsComposerDragOver(true);
-  }
-
-  function handleComposerDragLeave(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    composerDragDepthRef.current = Math.max(0, composerDragDepthRef.current - 1);
-    if (composerDragDepthRef.current === 0) setIsComposerDragOver(false);
-  }
-
-  function handleComposerDrop(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    composerDragDepthRef.current = 0;
-    setIsComposerDragOver(false);
-    if (!channel || event.dataTransfer.files.length === 0) return;
-    addDraftAttachments(event.dataTransfer.files);
-    focusComposer();
-  }
-
-  function handleComposerPaste(event: ClipboardEvent<HTMLTextAreaElement>) {
-    const imageFiles = Array.from(event.clipboardData.files).filter((file) => file.type.startsWith("image/"));
-    if (imageFiles.length === 0) return;
-    event.preventDefault();
-    if (!channel) return;
-    addDraftAttachments(imageFiles);
-    focusComposer();
   }
 
   function renderReplyParticipantAvatar(message: Message) {
@@ -369,13 +250,10 @@ export function Conversation({
 
   useEffect(() => {
     if (!isDm) return;
-    setSendAsTask(false);
     if (activeTab === "tasks") setActiveTab("chat");
   }, [activeTab, isDm, setActiveTab]);
 
   useEffect(() => {
-    composerDragDepthRef.current = 0;
-    setIsComposerDragOver(false);
     setShowChannelActions(false);
     setMessageMenu(null);
   }, [channel?.id]);
@@ -925,117 +803,19 @@ export function Conversation({
       )}
 
       {activeTab === "chat" && (
-        <footer
-          className={`composer ${isComposerDragOver ? "drag-over" : ""}`}
-          onDragEnter={handleComposerDragEnter}
-          onDragOver={handleComposerDragOver}
-          onDragLeave={handleComposerDragLeave}
-          onDrop={handleComposerDrop}
-        >
-          {mentionState && mentionCandidates.length > 0 && (
-            <div className="mention-picker">
-              {mentionCandidates.map((candidate, index) => (
-                <button
-                  key={`${candidate.kind}:${candidate.id}`}
-                  className={index === mentionIndex ? "active" : ""}
-                  onMouseDown={(event) => {
-                    event.preventDefault();
-                    chooseMention(candidate);
-                  }}
-                >
-                  {candidate.kind === "agent" ? (
-                    <>
-                      <AgentAvatar agent={candidate.agent} size="sm" title={`@${candidate.agent.handle}`} />
-                      <span className="mention-picker-copy">
-                        <strong>{candidate.agent.display_name}</strong>
-                        <small>@{candidate.agent.handle}</small>
-                        {visibleAgentDescription(candidate.agent.description) && <em>{visibleAgentDescription(candidate.agent.description)}</em>}
-                      </span>
-                    </>
-                  ) : (
-                    <>
-                      <span className="mention-picker-channel-icon" aria-hidden="true">
-                        <Hash size={16} />
-                      </span>
-                      <span className="mention-picker-copy">
-                        <strong>#{candidate.channel.name}</strong>
-                        <small>Channel</small>
-                        {visibleChannelDescription(candidate.channel.description) && <em>{visibleChannelDescription(candidate.channel.description)}</em>}
-                      </span>
-                    </>
-                  )}
-                </button>
-              ))}
-            </div>
-          )}
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            className="file-input-hidden"
-            onChange={(event) => {
-              if (event.target.files) addDraftAttachments(event.target.files);
-              event.target.value = "";
-            }}
-          />
-          <DraftAttachmentsPreview attachments={draftAttachments} onRemove={removeDraftAttachment} />
-          <textarea
-            ref={textareaRef}
-            value={draft}
-            onChange={(event) => {
-              setDraft(event.target.value);
-              refreshMentionState(event.target.value, event.target.selectionStart);
-            }}
-            onSelect={(event) => refreshMentionState(draft, event.currentTarget.selectionStart)}
-            onKeyDown={handleComposerKeyDown}
-            onPaste={handleComposerPaste}
-            disabled={!channel}
-            placeholder={
-              channel
-                ? isDm
-                  ? `Message @${dmAgent?.handle || "agent"}`
-                  : `Message #${channel.name} - type @ or # to mention`
-                : "Create a channel before messaging"
-            }
-          />
-          <div className="composer-actions">
-            <button
-              type="button"
-              className="attach-button"
-              disabled={!channel}
-              onMouseDown={preserveComposerFocus}
-              onClick={() => fileInputRef.current?.click()}
-            >
-              <Paperclip size={16} />
-            </button>
-            {!isDm && (
-              <button
-                type="button"
-                className={`task-toggle ${sendAsTask ? "active" : ""}`}
-                title={sendAsTask ? "Send next message as a normal message" : "Send next message as a task"}
-                aria-label={sendAsTask ? "Send next message as a normal message" : "Send next message as a task"}
-                aria-pressed={sendAsTask}
-                disabled={!channel}
-                onPointerDown={handleTaskTogglePointerDown}
-                onMouseDown={handleTaskToggleMouseDown}
-                onClick={handleTaskToggleClick}
-              >
-                <Flag size={15} />
-                <span>Task</span>
-              </button>
-            )}
-            <button
-              className="send"
-              title={sendAsTask && !isDm ? "Create task" : "Send message"}
-              aria-label={sendAsTask && !isDm ? "Create task" : "Send message"}
-              disabled={!channel || (!draft.trim() && draftAttachments.length === 0)}
-              onMouseDown={preserveComposerFocus}
-              onClick={submitComposer}
-            >
-              <Send size={17} />
-            </button>
-          </div>
-        </footer>
+        <ConversationComposer
+          channel={channel}
+          isDm={isDm}
+          dmAgent={dmAgent}
+          agents={agents}
+          channels={channels}
+          draft={draft}
+          draftAttachments={draftAttachments}
+          setDraft={setDraft}
+          addDraftAttachments={addDraftAttachments}
+          removeDraftAttachment={removeDraftAttachment}
+          sendRootMessage={sendRootMessage}
+        />
       )}
     </section>
   );
@@ -1088,4 +868,318 @@ export function Conversation({
       </article>
     );
   }
+}
+
+type ConversationComposerProps = {
+  channel: Channel | null;
+  isDm: boolean;
+  dmAgent: Agent | null;
+  agents: Agent[];
+  channels: Channel[];
+  draft: string;
+  draftAttachments: DraftAttachment[];
+  setDraft: (value: string) => void;
+  addDraftAttachments: (files: FileList | File[]) => void;
+  removeDraftAttachment: (id: string) => void;
+  sendRootMessage: (asTask?: boolean, bodyOverride?: string, attachmentsOverride?: DraftAttachment[]) => void;
+};
+
+function hasDraggedFiles(event: DragEvent<HTMLElement>) {
+  return Array.from(event.dataTransfer.types).includes("Files");
+}
+
+function useBufferedComposerText(draft: string, resetKey: string | null | undefined, setDraft: (value: string) => void) {
+  const [text, setText] = useState(draft);
+  const textRef = useRef(draft);
+  const committedRef = useRef(draft);
+  const setDraftRef = useRef(setDraft);
+
+  useEffect(() => {
+    setDraftRef.current = setDraft;
+  }, [setDraft]);
+
+  useEffect(() => {
+    textRef.current = draft;
+    committedRef.current = draft;
+    setText(draft);
+  }, [draft, resetKey]);
+
+  useEffect(() => {
+    return () => {
+      if (textRef.current === committedRef.current) return;
+      committedRef.current = textRef.current;
+      setDraftRef.current(textRef.current);
+    };
+  }, [resetKey]);
+
+  function updateText(value: string) {
+    textRef.current = value;
+    setText(value);
+  }
+
+  function commitText(value = textRef.current) {
+    if (value === committedRef.current) return;
+    committedRef.current = value;
+    setDraftRef.current(value);
+  }
+
+  function markCommitted(value: string) {
+    textRef.current = value;
+    committedRef.current = value;
+    setText(value);
+  }
+
+  return { text, updateText, commitText, markCommitted };
+}
+
+function ConversationComposer({
+  channel,
+  isDm,
+  dmAgent,
+  agents,
+  channels,
+  draft,
+  draftAttachments,
+  setDraft,
+  addDraftAttachments,
+  removeDraftAttachment,
+  sendRootMessage,
+}: ConversationComposerProps) {
+  const [sendAsTask, setSendAsTask] = useState(false);
+  const [isComposerDragOver, setIsComposerDragOver] = useState(false);
+  const composerDragDepthRef = useRef(0);
+  const taskToggleHandledAtRef = useRef(0);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const { text, updateText, commitText, markCommitted } = useBufferedComposerText(draft, channel?.id, setDraft);
+  const {
+    mentionState,
+    mentionIndex,
+    mentionCandidates,
+    refreshMentionState,
+    chooseMention,
+    handleMentionKeyDown,
+    closeMentionPicker,
+    focusComposer,
+  } = useMentionPicker({ agents, channels, value: text, setValue: updateText, textareaRef });
+  useAutoGrowTextarea(textareaRef, text);
+
+  useEffect(() => {
+    if (isDm) setSendAsTask(false);
+  }, [isDm]);
+
+  useEffect(() => {
+    composerDragDepthRef.current = 0;
+    setIsComposerDragOver(false);
+    closeMentionPicker();
+  }, [channel?.id]);
+
+  // Mobile WebViews dismiss the soft keyboard when a tap blurs the focused
+  // textarea, and the first tap is consumed by the dismissal.
+  function preserveComposerFocus(event: ReactMouseEvent<HTMLElement>) {
+    if (textareaRef.current && document.activeElement === textareaRef.current) {
+      event.preventDefault();
+    }
+  }
+
+  function handleTaskToggleMouseDown(event: ReactMouseEvent<HTMLElement>) {
+    if (Date.now() - taskToggleHandledAtRef.current < 600) return;
+    preserveComposerFocus(event);
+    if (!channel) return;
+    taskToggleHandledAtRef.current = Date.now();
+    setSendAsTask((current) => !current);
+  }
+
+  function handleTaskTogglePointerDown(event: ReactPointerEvent<HTMLButtonElement>) {
+    if (event.pointerType === "mouse") return;
+    if (!channel) return;
+    event.preventDefault();
+    event.stopPropagation();
+    taskToggleHandledAtRef.current = Date.now();
+    setSendAsTask((current) => !current);
+  }
+
+  function handleTaskToggleClick() {
+    if (!channel) return;
+    if (Date.now() - taskToggleHandledAtRef.current < 600) return;
+    setSendAsTask((current) => !current);
+  }
+
+  function submitComposer() {
+    if (!channel || (!text.trim() && draftAttachments.length === 0)) return;
+    const body = text;
+    markCommitted("");
+    sendRootMessage(isDm ? false : sendAsTask, body, draftAttachments);
+    closeMentionPicker();
+    focusComposer();
+  }
+
+  function handleComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (isImeComposing(event)) return;
+    if (handleMentionKeyDown(event)) return;
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      submitComposer();
+    }
+  }
+
+  function handleComposerDragEnter(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    composerDragDepthRef.current += 1;
+    event.dataTransfer.dropEffect = channel ? "copy" : "none";
+    if (channel) setIsComposerDragOver(true);
+  }
+
+  function handleComposerDragOver(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = channel ? "copy" : "none";
+    if (channel) setIsComposerDragOver(true);
+  }
+
+  function handleComposerDragLeave(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    composerDragDepthRef.current = Math.max(0, composerDragDepthRef.current - 1);
+    if (composerDragDepthRef.current === 0) setIsComposerDragOver(false);
+  }
+
+  function handleComposerDrop(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    composerDragDepthRef.current = 0;
+    setIsComposerDragOver(false);
+    if (!channel || event.dataTransfer.files.length === 0) return;
+    addDraftAttachments(event.dataTransfer.files);
+    focusComposer();
+  }
+
+  function handleComposerPaste(event: ClipboardEvent<HTMLTextAreaElement>) {
+    const imageFiles = Array.from(event.clipboardData.files).filter((file) => file.type.startsWith("image/"));
+    if (imageFiles.length === 0) return;
+    event.preventDefault();
+    if (!channel) return;
+    addDraftAttachments(imageFiles);
+    focusComposer();
+  }
+
+  return (
+    <footer
+      className={`composer ${isComposerDragOver ? "drag-over" : ""}`}
+      onDragEnter={handleComposerDragEnter}
+      onDragOver={handleComposerDragOver}
+      onDragLeave={handleComposerDragLeave}
+      onDrop={handleComposerDrop}
+    >
+      {mentionState && mentionCandidates.length > 0 && (
+        <div className="mention-picker">
+          {mentionCandidates.map((candidate, index) => (
+            <button
+              key={`${candidate.kind}:${candidate.id}`}
+              className={index === mentionIndex ? "active" : ""}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                chooseMention(candidate);
+              }}
+            >
+              {candidate.kind === "agent" ? (
+                <>
+                  <AgentAvatar agent={candidate.agent} size="sm" title={`@${candidate.agent.handle}`} />
+                  <span className="mention-picker-copy">
+                    <strong>{candidate.agent.display_name}</strong>
+                    <small>@{candidate.agent.handle}</small>
+                    {visibleAgentDescription(candidate.agent.description) && <em>{visibleAgentDescription(candidate.agent.description)}</em>}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span className="mention-picker-channel-icon" aria-hidden="true">
+                    <Hash size={16} />
+                  </span>
+                  <span className="mention-picker-copy">
+                    <strong>#{candidate.channel.name}</strong>
+                    <small>Channel</small>
+                    {visibleChannelDescription(candidate.channel.description) && <em>{visibleChannelDescription(candidate.channel.description)}</em>}
+                  </span>
+                </>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        className="file-input-hidden"
+        onChange={(event) => {
+          if (event.target.files) addDraftAttachments(event.target.files);
+          event.target.value = "";
+        }}
+      />
+      <DraftAttachmentsPreview attachments={draftAttachments} onRemove={removeDraftAttachment} />
+      <textarea
+        ref={textareaRef}
+        value={text}
+        onChange={(event) => {
+          updateText(event.target.value);
+          refreshMentionState(event.target.value, event.target.selectionStart);
+        }}
+        onBlur={() => commitText()}
+        onSelect={(event) => refreshMentionState(text, event.currentTarget.selectionStart)}
+        onKeyDown={handleComposerKeyDown}
+        onPaste={handleComposerPaste}
+        disabled={!channel}
+        placeholder={
+          channel
+            ? isDm
+              ? `Message @${dmAgent?.handle || "agent"}`
+              : `Message #${channel.name} - type @ or # to mention`
+            : "Create a channel before messaging"
+        }
+      />
+      <div className="composer-actions">
+        <button
+          type="button"
+          className="attach-button"
+          disabled={!channel}
+          onMouseDown={preserveComposerFocus}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <Paperclip size={16} />
+        </button>
+        {!isDm && (
+          <button
+            type="button"
+            className={`task-toggle ${sendAsTask ? "active" : ""}`}
+            title={sendAsTask ? "Send next message as a normal message" : "Send next message as a task"}
+            aria-label={sendAsTask ? "Send next message as a normal message" : "Send next message as a task"}
+            aria-pressed={sendAsTask}
+            disabled={!channel}
+            onPointerDown={handleTaskTogglePointerDown}
+            onMouseDown={handleTaskToggleMouseDown}
+            onClick={handleTaskToggleClick}
+          >
+            <Flag size={15} />
+            <span>Task</span>
+          </button>
+        )}
+        <button
+          className="send"
+          title={sendAsTask && !isDm ? "Create task" : "Send message"}
+          aria-label={sendAsTask && !isDm ? "Create task" : "Send message"}
+          disabled={!channel || (!text.trim() && draftAttachments.length === 0)}
+          onMouseDown={preserveComposerFocus}
+          onClick={submitComposer}
+        >
+          <Send size={17} />
+        </button>
+      </div>
+    </footer>
+  );
 }

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -71,7 +71,7 @@ type ThreadPanelProps = {
   setReplyDraft: (value: string) => void;
   addReplyAttachments: (files: FileList | File[]) => void;
   removeReplyAttachment: (id: string) => void;
-  sendReply: () => void;
+  sendReply: (bodyOverride?: string, attachmentsOverride?: DraftAttachment[]) => void;
   openAgentDetail: (agent: Agent) => void;
   openArtifact: (artifact: Artifact) => void;
   shareBaseUrl: string | null;
@@ -119,15 +119,11 @@ export function ThreadPanel({
   onToggleMessageSaved,
   onResizeStart,
 }: ThreadPanelProps) {
-  const [isReplyDragOver, setIsReplyDragOver] = useState(false);
   const [showBackToBottom, setShowBackToBottom] = useState(false);
   const [messageMenu, setMessageMenu] = useState<MessageMenuState>(null);
   const [tapFocusedMessageId, setTapFocusedMessageId] = useState<string | null>(null);
-  const replyDragDepthRef = useRef(0);
   const threadScrollRef = useRef<HTMLDivElement | null>(null);
   const shouldFollowThreadRef = useRef(true);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
   function openLinkedAgentDetail(handle: string) {
     const agent = agents.find((candidate) => candidate.handle.toLowerCase() === handle.toLowerCase());
     if (agent) openAgentDetail(agent);
@@ -142,17 +138,6 @@ export function ThreadPanel({
       ? `Thread in DM with @${dmAgent?.handle || "agent"}`
       : `Thread in #${channel.name}`
     : `${APP_DISPLAY_NAME} thread`;
-  const {
-    mentionState,
-    mentionIndex,
-    mentionCandidates,
-    refreshMentionState,
-    chooseMention,
-    handleMentionKeyDown,
-    closeMentionPicker,
-    focusComposer,
-  } = useMentionPicker({ agents, channels, value: replyDraft, setValue: setReplyDraft, textareaRef });
-  useAutoGrowTextarea(textareaRef, replyDraft);
   const lastReply = replies[replies.length - 1] ?? null;
 
   function isThreadScrollAtBottom(element: HTMLDivElement) {
@@ -190,74 +175,7 @@ export function ThreadPanel({
     });
   }
 
-  function handleReplyKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
-    if (isImeComposing(event)) return;
-    if (handleMentionKeyDown(event)) return;
-    if (event.key === "Enter" && !event.shiftKey) {
-      event.preventDefault();
-      submitReply();
-    }
-  }
-
-  function submitReply() {
-    if (!activeRoot || (!replyDraft.trim() && replyAttachments.length === 0)) return;
-    sendReply();
-    closeMentionPicker();
-    focusComposer();
-  }
-
-  function hasDraggedFiles(event: DragEvent<HTMLElement>) {
-    return Array.from(event.dataTransfer.types).includes("Files");
-  }
-
-  function handleReplyDragEnter(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    replyDragDepthRef.current += 1;
-    event.dataTransfer.dropEffect = activeRoot ? "copy" : "none";
-    if (activeRoot) setIsReplyDragOver(true);
-  }
-
-  function handleReplyDragOver(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    event.dataTransfer.dropEffect = activeRoot ? "copy" : "none";
-    if (activeRoot) setIsReplyDragOver(true);
-  }
-
-  function handleReplyDragLeave(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    replyDragDepthRef.current = Math.max(0, replyDragDepthRef.current - 1);
-    if (replyDragDepthRef.current === 0) setIsReplyDragOver(false);
-  }
-
-  function handleReplyDrop(event: DragEvent<HTMLElement>) {
-    if (!hasDraggedFiles(event)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    replyDragDepthRef.current = 0;
-    setIsReplyDragOver(false);
-    if (!activeRoot || event.dataTransfer.files.length === 0) return;
-    addReplyAttachments(event.dataTransfer.files);
-    focusComposer();
-  }
-
-  function handleReplyPaste(event: ClipboardEvent<HTMLTextAreaElement>) {
-    const imageFiles = Array.from(event.clipboardData.files).filter((file) => file.type.startsWith("image/"));
-    if (imageFiles.length === 0) return;
-    event.preventDefault();
-    if (!activeRoot) return;
-    addReplyAttachments(imageFiles);
-    focusComposer();
-  }
-
   useEffect(() => {
-    replyDragDepthRef.current = 0;
-    setIsReplyDragOver(false);
     setMessageMenu(null);
     setTapFocusedMessageId(null);
   }, [activeRoot?.id]);
@@ -729,96 +647,275 @@ export function ThreadPanel({
           )}
         </div>
 
-        <section
-          className={`reply-composer ${isReplyDragOver ? "drag-over" : ""}`}
-          onDragEnter={handleReplyDragEnter}
-          onDragOver={handleReplyDragOver}
-          onDragLeave={handleReplyDragLeave}
-          onDrop={handleReplyDrop}
-        >
-          {mentionState && mentionCandidates.length > 0 && (
-            <div className="mention-picker">
-              {mentionCandidates.map((candidate, index) => (
-                <button
-                  key={`${candidate.kind}:${candidate.id}`}
-                  className={index === mentionIndex ? "active" : ""}
-                  onMouseDown={(event) => {
-                    event.preventDefault();
-                    chooseMention(candidate);
-                  }}
-                >
-                  {candidate.kind === "agent" ? (
-                    <>
-                      <AgentAvatar agent={candidate.agent} size="sm" title={`@${candidate.agent.handle}`} />
-                      <span className="mention-picker-copy">
-                        <strong>{candidate.agent.display_name}</strong>
-                        <small>@{candidate.agent.handle}</small>
-                        {visibleAgentDescription(candidate.agent.description) && <em>{visibleAgentDescription(candidate.agent.description)}</em>}
-                      </span>
-                    </>
-                  ) : (
-                    <>
-                      <span className="mention-picker-channel-icon" aria-hidden="true">
-                        <Hash size={16} />
-                      </span>
-                      <span className="mention-picker-copy">
-                        <strong>#{candidate.channel.name}</strong>
-                        <small>Channel</small>
-                        {visibleChannelDescription(candidate.channel.description) && <em>{visibleChannelDescription(candidate.channel.description)}</em>}
-                      </span>
-                    </>
-                  )}
-                </button>
-              ))}
-            </div>
-          )}
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            className="file-input-hidden"
-            onChange={(event) => {
-              if (event.target.files) addReplyAttachments(event.target.files);
-              event.target.value = "";
-            }}
-          />
-          <DraftAttachmentsPreview attachments={replyAttachments} onRemove={removeReplyAttachment} />
-          <textarea
-            ref={textareaRef}
-            value={replyDraft}
-            onChange={(event) => {
-              setReplyDraft(event.target.value);
-              refreshMentionState(event.target.value, event.target.selectionStart);
-            }}
-            onSelect={(event) => refreshMentionState(replyDraft, event.currentTarget.selectionStart)}
-            onKeyDown={handleReplyKeyDown}
-            onPaste={handleReplyPaste}
-            disabled={!activeRoot}
-            placeholder={activeRoot ? isDm ? `Reply to @${dmAgent?.handle || "agent"}` : "Reply in thread" : "Select a thread to reply"}
-          />
-          <div className="reply-composer-actions">
-            <button
-              type="button"
-              className="attach-button"
-              disabled={!activeRoot}
-              onClick={() => fileInputRef.current?.click()}
-            >
-              <Paperclip size={15} />
-            </button>
-            <button
-              type="button"
-              className="reply-send"
-              title="Send reply"
-              aria-label="Send reply"
-              disabled={!activeRoot || (!replyDraft.trim() && replyAttachments.length === 0)}
-              onClick={submitReply}
-            >
-              <Send size={17} />
-            </button>
-          </div>
-        </section>
+        <ThreadReplyComposer
+          activeRoot={activeRoot}
+          isDm={isDm}
+          dmAgent={dmAgent}
+          agents={agents}
+          channels={channels}
+          replyDraft={replyDraft}
+          replyAttachments={replyAttachments}
+          setReplyDraft={setReplyDraft}
+          addReplyAttachments={addReplyAttachments}
+          removeReplyAttachment={removeReplyAttachment}
+          sendReply={sendReply}
+        />
       </section>
 
     </aside>
+  );
+}
+
+type ThreadReplyComposerProps = {
+  activeRoot: Message | null;
+  isDm: boolean;
+  dmAgent: Agent | null;
+  agents: Agent[];
+  channels: Channel[];
+  replyDraft: string;
+  replyAttachments: DraftAttachment[];
+  setReplyDraft: (value: string) => void;
+  addReplyAttachments: (files: FileList | File[]) => void;
+  removeReplyAttachment: (id: string) => void;
+  sendReply: (bodyOverride?: string, attachmentsOverride?: DraftAttachment[]) => void;
+};
+
+function hasDraggedFiles(event: DragEvent<HTMLElement>) {
+  return Array.from(event.dataTransfer.types).includes("Files");
+}
+
+function useBufferedComposerText(draft: string, resetKey: string | null | undefined, setDraft: (value: string) => void) {
+  const [text, setText] = useState(draft);
+  const textRef = useRef(draft);
+  const committedRef = useRef(draft);
+  const setDraftRef = useRef(setDraft);
+
+  useEffect(() => {
+    setDraftRef.current = setDraft;
+  }, [setDraft]);
+
+  useEffect(() => {
+    textRef.current = draft;
+    committedRef.current = draft;
+    setText(draft);
+  }, [draft, resetKey]);
+
+  useEffect(() => {
+    return () => {
+      if (textRef.current === committedRef.current) return;
+      committedRef.current = textRef.current;
+      setDraftRef.current(textRef.current);
+    };
+  }, [resetKey]);
+
+  function updateText(value: string) {
+    textRef.current = value;
+    setText(value);
+  }
+
+  function commitText(value = textRef.current) {
+    if (value === committedRef.current) return;
+    committedRef.current = value;
+    setDraftRef.current(value);
+  }
+
+  function markCommitted(value: string) {
+    textRef.current = value;
+    committedRef.current = value;
+    setText(value);
+  }
+
+  return { text, updateText, commitText, markCommitted };
+}
+
+function ThreadReplyComposer({
+  activeRoot,
+  isDm,
+  dmAgent,
+  agents,
+  channels,
+  replyDraft,
+  replyAttachments,
+  setReplyDraft,
+  addReplyAttachments,
+  removeReplyAttachment,
+  sendReply,
+}: ThreadReplyComposerProps) {
+  const [isReplyDragOver, setIsReplyDragOver] = useState(false);
+  const replyDragDepthRef = useRef(0);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const { text, updateText, commitText, markCommitted } = useBufferedComposerText(replyDraft, activeRoot?.id, setReplyDraft);
+  const {
+    mentionState,
+    mentionIndex,
+    mentionCandidates,
+    refreshMentionState,
+    chooseMention,
+    handleMentionKeyDown,
+    closeMentionPicker,
+    focusComposer,
+  } = useMentionPicker({ agents, channels, value: text, setValue: updateText, textareaRef });
+  useAutoGrowTextarea(textareaRef, text);
+
+  useEffect(() => {
+    replyDragDepthRef.current = 0;
+    setIsReplyDragOver(false);
+    closeMentionPicker();
+  }, [activeRoot?.id]);
+
+  function submitReply() {
+    if (!activeRoot || (!text.trim() && replyAttachments.length === 0)) return;
+    const body = text;
+    markCommitted("");
+    sendReply(body, replyAttachments);
+    closeMentionPicker();
+    focusComposer();
+  }
+
+  function handleReplyKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (isImeComposing(event)) return;
+    if (handleMentionKeyDown(event)) return;
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      submitReply();
+    }
+  }
+
+  function handleReplyDragEnter(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    replyDragDepthRef.current += 1;
+    event.dataTransfer.dropEffect = activeRoot ? "copy" : "none";
+    if (activeRoot) setIsReplyDragOver(true);
+  }
+
+  function handleReplyDragOver(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = activeRoot ? "copy" : "none";
+    if (activeRoot) setIsReplyDragOver(true);
+  }
+
+  function handleReplyDragLeave(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    replyDragDepthRef.current = Math.max(0, replyDragDepthRef.current - 1);
+    if (replyDragDepthRef.current === 0) setIsReplyDragOver(false);
+  }
+
+  function handleReplyDrop(event: DragEvent<HTMLElement>) {
+    if (!hasDraggedFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    replyDragDepthRef.current = 0;
+    setIsReplyDragOver(false);
+    if (!activeRoot || event.dataTransfer.files.length === 0) return;
+    addReplyAttachments(event.dataTransfer.files);
+    focusComposer();
+  }
+
+  function handleReplyPaste(event: ClipboardEvent<HTMLTextAreaElement>) {
+    const imageFiles = Array.from(event.clipboardData.files).filter((file) => file.type.startsWith("image/"));
+    if (imageFiles.length === 0) return;
+    event.preventDefault();
+    if (!activeRoot) return;
+    addReplyAttachments(imageFiles);
+    focusComposer();
+  }
+
+  return (
+    <section
+      className={`reply-composer ${isReplyDragOver ? "drag-over" : ""}`}
+      onDragEnter={handleReplyDragEnter}
+      onDragOver={handleReplyDragOver}
+      onDragLeave={handleReplyDragLeave}
+      onDrop={handleReplyDrop}
+    >
+      {mentionState && mentionCandidates.length > 0 && (
+        <div className="mention-picker">
+          {mentionCandidates.map((candidate, index) => (
+            <button
+              key={`${candidate.kind}:${candidate.id}`}
+              className={index === mentionIndex ? "active" : ""}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                chooseMention(candidate);
+              }}
+            >
+              {candidate.kind === "agent" ? (
+                <>
+                  <AgentAvatar agent={candidate.agent} size="sm" title={`@${candidate.agent.handle}`} />
+                  <span className="mention-picker-copy">
+                    <strong>{candidate.agent.display_name}</strong>
+                    <small>@{candidate.agent.handle}</small>
+                    {visibleAgentDescription(candidate.agent.description) && <em>{visibleAgentDescription(candidate.agent.description)}</em>}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span className="mention-picker-channel-icon" aria-hidden="true">
+                    <Hash size={16} />
+                  </span>
+                  <span className="mention-picker-copy">
+                    <strong>#{candidate.channel.name}</strong>
+                    <small>Channel</small>
+                    {visibleChannelDescription(candidate.channel.description) && <em>{visibleChannelDescription(candidate.channel.description)}</em>}
+                  </span>
+                </>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        className="file-input-hidden"
+        onChange={(event) => {
+          if (event.target.files) addReplyAttachments(event.target.files);
+          event.target.value = "";
+        }}
+      />
+      <DraftAttachmentsPreview attachments={replyAttachments} onRemove={removeReplyAttachment} />
+      <textarea
+        ref={textareaRef}
+        value={text}
+        onChange={(event) => {
+          updateText(event.target.value);
+          refreshMentionState(event.target.value, event.target.selectionStart);
+        }}
+        onBlur={() => commitText()}
+        onSelect={(event) => refreshMentionState(text, event.currentTarget.selectionStart)}
+        onKeyDown={handleReplyKeyDown}
+        onPaste={handleReplyPaste}
+        disabled={!activeRoot}
+        placeholder={activeRoot ? isDm ? `Reply to @${dmAgent?.handle || "agent"}` : "Reply in thread" : "Select a thread to reply"}
+      />
+      <div className="reply-composer-actions">
+        <button
+          type="button"
+          className="attach-button"
+          disabled={!activeRoot}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <Paperclip size={15} />
+        </button>
+        <button
+          type="button"
+          className="reply-send"
+          title="Send reply"
+          aria-label="Send reply"
+          disabled={!activeRoot || (!text.trim() && replyAttachments.length === 0)}
+          onClick={submitReply}
+        >
+          <Send size={17} />
+        </button>
+      </div>
+    </section>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2538,10 +2538,11 @@ function App() {
     });
   }
 
-  async function sendRootMessage(asTask = false) {
-    if (!channel || (!draft.trim() && draftAttachments.length === 0)) return;
-    const body = draft.trim();
-    const attachments = draftAttachments;
+  async function sendRootMessage(asTask = false, bodyOverride?: string, attachmentsOverride?: DraftAttachment[]) {
+    const rawBody = bodyOverride ?? draft;
+    const attachments = attachmentsOverride ?? draftAttachments;
+    if (!channel || (!rawBody.trim() && attachments.length === 0)) return;
+    const body = rawBody.trim();
     const sendAsTask = channel.kind === "dm" ? false : asTask;
     const optimisticId = addOptimisticOwnerMessage(channel.id, null, body, sendAsTask, attachments);
     updateRootComposerDraft(channel.id, () => EMPTY_COMPOSER_DRAFT);
@@ -2579,10 +2580,11 @@ function App() {
     }
   }
 
-  async function sendReply() {
-    if (!channel || !activeRoot || (!replyDraft.trim() && replyAttachments.length === 0)) return;
-    const body = replyDraft.trim();
-    const attachments = replyAttachments;
+  async function sendReply(bodyOverride?: string, attachmentsOverride?: DraftAttachment[]) {
+    const rawBody = bodyOverride ?? replyDraft;
+    const attachments = attachmentsOverride ?? replyAttachments;
+    if (!channel || !activeRoot || (!rawBody.trim() && attachments.length === 0)) return;
+    const body = rawBody.trim();
     const optimisticId = addOptimisticOwnerMessage(channel.id, activeRoot.id, body, false, attachments);
     updateReplyComposerDraft(activeRoot.id, () => EMPTY_COMPOSER_DRAFT);
     try {


### PR DESCRIPTION
## Summary
- Ports the buffered composer draft optimization from the stacked PR onto current `main`.
- Keeps keystroke text local to the main/thread composer and syncs parent draft state on blur, unmount/channel switch, and send.
- Passes body/attachments overrides into `sendRootMessage` / `sendReply` so optimistic send and failure restore keep existing behavior.

## Measured Improvement

Measured with the existing `npm run bench:composer` SSR mechanism guard from #27. This compares the old root-coupled draft path against the new buffered composer path for per-keystroke render cost.

Default run config: `runs=5 warmup=5 sampleRepeats=3 seed=17 profile=all`.

| Scenario | Before: root p95 ms/key | After: buffered p95 ms/key | p95 reduction | Speedup |
|---|---:|---:|---:|---:|
| Main composer, plain typing, stress channel | 74.933 | 0.008 | -74.925ms / -99.99% | 9899.1x |
| Thread composer, plain typing, stress thread | 50.990 | 0.008 | -50.982ms / -99.98% | 6711.6x |
| Main composer, `@mention`, stress roster | 74.994 | 0.063 | -74.931ms / -99.92% | 1194.3x |
| Main composer, `#channel` autocomplete, stress channel list | 74.423 | 0.056 | -74.367ms / -99.92% | 1333.6x |

Additional guard signals:
- Buffered path had `0` long tasks in all four profiles.
- Buffered path had `0` large-tree commits in all four profiles.
- Root-coupled path had `24-40` large-tree commits per profile, matching the old per-keystroke root update behavior.

Interpretation: this PR removes the root-coupled conversation/thread render cost from composer keystrokes. The benchmark shows the targeted mechanism improved by roughly `1,194x-9,899x` depending on the path.

## Validation
- `npm run build`
- `npm run bench:composer -- --profile main-plain-stress --runs 3 --warmup 2`
- `npm run bench:composer`

## Boundary
This benchmark is the SSR mechanism guard from #27. It is not a browser INP / user-perceived latency measurement. If typing still feels laggy after this PR, the remaining bottleneck is likely in a different path such as DOM/layout/paint, IME, textarea auto-grow, mention picker work, streaming updates, or WebView scheduling. A follow-up browser benchmark should measure keystroke-to-next-paint directly.

## Notes
- This PR is based directly on `main`, not stacked on the benchmark branch.
- I left the unrelated local DM-search fix out of this commit.
