### PR TITLE
Add chat text size preference

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -6,7 +6,10 @@ export type ThemePreference = "auto" | "light" | "dark";
 type SettingsModalProps = {
   open: boolean;
   themePreference: ThemePreference;
+  chatFontSize: number;
+  chatFontSizeOptions: readonly number[];
   onThemePreferenceChange: (value: ThemePreference) => void;
+  onChatFontSizeChange: (value: number) => void;
   onClose: () => void;
 };
 
@@ -24,7 +27,10 @@ const THEME_OPTIONS: Array<{
 export function SettingsModal({
   open,
   themePreference,
+  chatFontSize,
+  chatFontSizeOptions,
   onThemePreferenceChange,
+  onChatFontSizeChange,
   onClose,
 }: SettingsModalProps) {
   return (
@@ -55,6 +61,23 @@ export function SettingsModal({
                 </button>
               );
             })}
+          </div>
+        </fieldset>
+        <fieldset className="settings-fieldset">
+          <legend>Chat text</legend>
+          <div className="chat-size-choice-grid">
+            {chatFontSizeOptions.map((size) => (
+              <button
+                type="button"
+                key={size}
+                className={chatFontSize === size ? "selected" : ""}
+                aria-pressed={chatFontSize === size}
+                onClick={() => onChatFontSizeChange(size)}
+              >
+                <strong style={{ fontSize: size }}>Aa</strong>
+                <small>{size}px</small>
+              </button>
+            ))}
           </div>
         </fieldset>
       </section>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -151,6 +151,9 @@ const THREAD_PANEL_WIDTH_STORAGE_KEY = "lantor.threadPanelWidth";
 const AGENT_DRAWER_WIDTH_STORAGE_KEY = "lantor.agentDrawerWidth";
 const SIDEBAR_WIDTH_STORAGE_KEY = "lantor.sidebarWidth";
 const THEME_PREFERENCE_STORAGE_KEY = "lantor.themePreference";
+const CHAT_FONT_SIZE_STORAGE_KEY = "lantor.chatFontSize";
+const CHAT_FONT_SIZE_OPTIONS = [15, 16, 17, 18] as const;
+const DEFAULT_CHAT_FONT_SIZE = 15;
 const MOBILE_EDGE_SWIPE_START_PX = 24;
 const MOBILE_EDGE_SWIPE_OPEN_PX = 72;
 const MOBILE_EDGE_SWIPE_MAX_VERTICAL_PX = 48;
@@ -447,6 +450,21 @@ function getStoredThemePreference(): ThemePreference {
   return stored === "light" || stored === "dark" || stored === "auto" ? stored : "auto";
 }
 
+function getStoredChatFontSize() {
+  const stored = Number(window.localStorage.getItem(CHAT_FONT_SIZE_STORAGE_KEY));
+  return CHAT_FONT_SIZE_OPTIONS.includes(stored as typeof CHAT_FONT_SIZE_OPTIONS[number])
+    ? stored
+    : DEFAULT_CHAT_FONT_SIZE;
+}
+
+function nextChatFontSize(current: number, direction: -1 | 1) {
+  const index = CHAT_FONT_SIZE_OPTIONS.findIndex((size) => size === current);
+  const fallbackIndex = CHAT_FONT_SIZE_OPTIONS.findIndex((size) => size === DEFAULT_CHAT_FONT_SIZE);
+  const currentIndex = index === -1 ? fallbackIndex : index;
+  const nextIndex = Math.min(CHAT_FONT_SIZE_OPTIONS.length - 1, Math.max(0, currentIndex + direction));
+  return CHAT_FONT_SIZE_OPTIONS[nextIndex];
+}
+
 async function attachmentUploads(attachments: DraftAttachment[]) {
   return Promise.all(attachments.map(async (attachment) => {
     const buffer = await attachment.file.arrayBuffer();
@@ -617,6 +635,7 @@ function App() {
   const [showOwnerProfileModal, setShowOwnerProfileModal] = useState(false);
   const [showSettingsModal, setShowSettingsModal] = useState(false);
   const [themePreference, setThemePreference] = useState<ThemePreference>(() => getStoredThemePreference());
+  const [chatFontSize, setChatFontSize] = useState(() => getStoredChatFontSize());
   const [showMobileSidebar, setShowMobileSidebar] = useState(() => isMobileViewport());
   const [mobileSidebarFocus, setMobileSidebarFocus] = useState<"home" | "dms">("home");
   const [mobileSidebarDragPx, setMobileSidebarDragPx] = useState(0);
@@ -1192,6 +1211,10 @@ function App() {
   }, [channelThreadMemory]);
 
   useEffect(() => {
+    window.localStorage.setItem(CHAT_FONT_SIZE_STORAGE_KEY, String(chatFontSize));
+  }, [chatFontSize]);
+
+  useEffect(() => {
     window.localStorage.setItem(THEME_PREFERENCE_STORAGE_KEY, themePreference);
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     const applyTheme = () => {
@@ -1218,6 +1241,19 @@ function App() {
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
       const modifier = event.metaKey || event.ctrlKey;
+
+      if (modifier && !event.altKey) {
+        const increase = event.key === "+" || event.key === "=" || event.code === "NumpadAdd";
+        const decrease = event.key === "-" || event.key === "_" || event.code === "NumpadSubtract";
+        const reset = event.key === "0" || event.code === "Numpad0";
+        if (increase || decrease || reset) {
+          event.preventDefault();
+          setChatFontSize((current) => (
+            reset ? DEFAULT_CHAT_FONT_SIZE : nextChatFontSize(current, increase ? 1 : -1)
+          ));
+          return;
+        }
+      }
 
       if (modifier && event.key.toLowerCase() === "k") {
         event.preventDefault();
@@ -3107,6 +3143,7 @@ function App() {
         "--sidebar-width": `${sidebarWidth}px`,
         "--thread-width": `${selectedAgent ? agentDrawerWidth : threadPanelWidth}px`,
         "--mobile-sidebar-drag": `${mobileSidebarDragPx}px`,
+        "--chat-font-size": `${chatFontSize}px`,
       } as CSSProperties}
     >
       <Sidebar
@@ -3209,7 +3246,10 @@ function App() {
       <SettingsModal
         open={showSettingsModal}
         themePreference={themePreference}
+        chatFontSize={chatFontSize}
+        chatFontSizeOptions={CHAT_FONT_SIZE_OPTIONS}
         onThemePreferenceChange={setThemePreference}
+        onChatFontSizeChange={setChatFontSize}
         onClose={() => setShowSettingsModal(false)}
       />
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -170,6 +170,7 @@ button,
   --surface-shadow: 0 24px 64px rgba(15, 23, 42, 0.18);
   --sidebar-width: 292px;
   --thread-width: 560px;
+  --chat-font-size: var(--type-size-message);
   display: grid;
   grid-template-columns: minmax(0, var(--sidebar-width)) minmax(0, 1fr) minmax(0, var(--thread-width));
   width: 100%;
@@ -2204,7 +2205,7 @@ mark {
 .reply-body {
   color: var(--ink-primary);
   font-family: var(--font-sans);
-  font-size: var(--type-size-message);
+  font-size: var(--chat-font-size);
   line-height: 1.48;
 }
 
@@ -3810,6 +3811,8 @@ mark {
   color: var(--ink-primary);
   caret-color: var(--accent);
   outline: none;
+  font-size: var(--chat-font-size);
+  line-height: 1.42;
 }
 
 .composer textarea::placeholder,
@@ -4949,6 +4952,49 @@ body.resizing-row * {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 8px;
+}
+
+.chat-size-choice-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.chat-size-choice-grid button {
+  display: grid;
+  min-width: 0;
+  min-height: 56px;
+  place-items: center;
+  gap: 2px;
+  padding: 8px 6px;
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  background: var(--panel-strong);
+  color: var(--muted);
+}
+
+.chat-size-choice-grid button.selected {
+  border-color: var(--accent);
+  background: var(--bg-selected-soft);
+  box-shadow: inset 0 0 0 1px var(--accent);
+  color: var(--accent);
+}
+
+.chat-size-choice-grid strong {
+  color: var(--ink);
+  font-weight: var(--type-weight-bold);
+  line-height: 1.1;
+}
+
+.chat-size-choice-grid small {
+  color: var(--muted);
+  font-size: var(--type-size-caption);
+  font-weight: var(--type-weight-semibold);
+}
+
+.chat-size-choice-grid button.selected strong,
+.chat-size-choice-grid button.selected small {
+  color: var(--accent);
 }
 
 .theme-choice-grid button {
@@ -8371,7 +8417,7 @@ body.resizing-row * {
   .message-body,
   .thread-message-content,
   .reply-body {
-    font-size: var(--type-size-control);
+    font-size: max(var(--type-size-control), var(--chat-font-size));
     line-height: 1.5;
     -webkit-user-select: text;
     user-select: text;
@@ -8487,8 +8533,8 @@ body.resizing-row * {
     max-height: 112px;
     padding: 12px 13px;
     border-radius: 16px;
-    font-size: var(--type-size-control);
-    line-height: 20px;
+    font-size: max(var(--type-size-control), var(--chat-font-size));
+    line-height: 1.35;
   }
 
   .composer-actions,


### PR DESCRIPTION
## Summary
- add a local four-level chat text size preference in Settings
- persist the value in localStorage as `lantor.chatFontSize`
- wire Cmd/Ctrl +/- to step through the same four levels, with Cmd/Ctrl+0 resetting to default
- apply the shared CSS variable to message text and root/thread composers

## Verification
- `git diff --check`
- `npm run build`