### PR TITLE
Add CI gate that blocks new raw color literals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Style token gate (no new raw color literals)
+        run: npm run lint:css-tokens
+
       - name: Build frontend
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:bench": "tsc && vite build --mode bench",
     "bench:composer": "node bench/composer-input-latency.mjs",
     "bench:composer:e2e": "node bench/composer-input-latency-e2e.mjs",
+    "lint:css-tokens": "node scripts/check-raw-colors.mjs",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build"

--- a/scripts/check-raw-colors.mjs
+++ b/scripts/check-raw-colors.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+// Style token gate: fails CI on any new raw color literal in src/styles.css
+// that is not in the baseline snapshot.
+//
+// Rationale: dark theme regressions keep happening because new components
+// land with hardcoded `#fff` / `rgba(255,255,255,…)` etc. and only later get
+// patched via :root[data-theme="dark"] overrides. This script enforces that
+// (a) the set of raw color literals can only shrink (or stay equal),
+// (b) any new literal must either be removed/replaced with a token, or
+// explicitly snapshotted via `npm run lint:css-tokens -- --update-baseline`.
+//
+// Fingerprint: { selector, property, literal, n } where n is the occurrence
+// index of that literal under the same (selector, property). Line numbers
+// are surfaced for human debugging but are NOT part of the fingerprint, so
+// inserting/removing unrelated rules does not invalidate the baseline.
+//
+// Excluded keywords: currentColor, transparent, inherit, initial, unset,
+// revert, none. Tokens via var(--…) are inherently safe and never matched.
+
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+const TARGET = path.join(REPO_ROOT, "src/styles.css");
+const BASELINE_PATH = path.join(REPO_ROOT, "scripts/styles-raw-color-baseline.json");
+
+const NAMED_COLORS = new Set([
+  "aliceblue","antiquewhite","aqua","aquamarine","azure","beige","bisque","black","blanchedalmond",
+  "blue","blueviolet","brown","burlywood","cadetblue","chartreuse","chocolate","coral","cornflowerblue",
+  "cornsilk","crimson","cyan","darkblue","darkcyan","darkgoldenrod","darkgray","darkgreen","darkgrey",
+  "darkkhaki","darkmagenta","darkolivegreen","darkorange","darkorchid","darkred","darksalmon",
+  "darkseagreen","darkslateblue","darkslategray","darkslategrey","darkturquoise","darkviolet",
+  "deeppink","deepskyblue","dimgray","dimgrey","dodgerblue","firebrick","floralwhite","forestgreen",
+  "fuchsia","gainsboro","ghostwhite","gold","goldenrod","gray","green","greenyellow","grey",
+  "honeydew","hotpink","indianred","indigo","ivory","khaki","lavender","lavenderblush","lawngreen",
+  "lemonchiffon","lightblue","lightcoral","lightcyan","lightgoldenrodyellow","lightgray","lightgreen",
+  "lightgrey","lightpink","lightsalmon","lightseagreen","lightskyblue","lightslategray","lightslategrey",
+  "lightsteelblue","lightyellow","lime","limegreen","linen","magenta","maroon","mediumaquamarine",
+  "mediumblue","mediumorchid","mediumpurple","mediumseagreen","mediumslateblue","mediumspringgreen",
+  "mediumturquoise","mediumvioletred","midnightblue","mintcream","mistyrose","moccasin","navajowhite",
+  "navy","oldlace","olive","olivedrab","orange","orangered","orchid","palegoldenrod","palegreen",
+  "paleturquoise","palevioletred","papayawhip","peachpuff","peru","pink","plum","powderblue",
+  "purple","rebeccapurple","red","rosybrown","royalblue","saddlebrown","salmon","sandybrown",
+  "seagreen","seashell","sienna","silver","skyblue","slateblue","slategray","slategrey","snow",
+  "springgreen","steelblue","tan","teal","thistle","tomato","turquoise","violet","wheat",
+  "white","whitesmoke","yellow","yellowgreen",
+]);
+
+// Properties whose values are expected to contain colors. Limits false
+// positives like `font-family: "Snow Display"` accidentally matching `snow`.
+const COLOR_PROPS = new Set([
+  "color","background","background-color","background-image","border","border-color",
+  "border-top","border-right","border-bottom","border-left","border-top-color",
+  "border-right-color","border-bottom-color","border-left-color","outline","outline-color",
+  "box-shadow","text-shadow","fill","stroke","caret-color","column-rule","column-rule-color",
+  "text-decoration","text-decoration-color","accent-color","scrollbar-color","-webkit-text-fill-color",
+]);
+
+function stripComments(css) {
+  // Replace comment bodies with spaces of the same length so line numbers stay stable.
+  return css.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "));
+}
+
+function lineOf(text, idx) {
+  let line = 1;
+  for (let i = 0; i < idx; i++) if (text.charCodeAt(i) === 10) line++;
+  return line;
+}
+
+// Walk a CSS source and yield rule bodies with their full selector chain.
+// `selectorChain` is an array; outer at-rules contribute their preamble
+// (e.g. `@media (max-width: 760px)`), normal selectors contribute themselves.
+function* iterRules(css) {
+  const stack = []; // entries: { selector, bodyStart }
+  let buf = "";
+  let bufStart = 0;
+  let i = 0;
+  while (i < css.length) {
+    const ch = css[i];
+    if (ch === "{") {
+      const sel = buf.trim();
+      buf = "";
+      bufStart = i + 1;
+      stack.push({ selector: sel, bodyStart: i + 1 });
+      i++;
+      continue;
+    }
+    if (ch === "}") {
+      const frame = stack.pop();
+      if (frame) {
+        const body = css.slice(frame.bodyStart, i);
+        // Only yield rules whose body has no further nested `{}` —
+        // those are "leaf" rule bodies that can contain declarations.
+        if (!body.includes("{")) {
+          const chain = stack.map((s) => s.selector);
+          chain.push(frame.selector);
+          yield { chain, body, bodyStart: frame.bodyStart };
+        }
+      }
+      buf = "";
+      bufStart = i + 1;
+      i++;
+      continue;
+    }
+    if (buf === "" && (ch === " " || ch === "\t" || ch === "\n" || ch === "\r" || ch === ";")) {
+      // Skip leading whitespace and stray semicolons at top level between rules.
+      bufStart = i + 1;
+      i++;
+      continue;
+    }
+    buf += ch;
+    i++;
+  }
+}
+
+// Parse a rule body into declarations. Returns array of { prop, value, valueOffset }
+// where valueOffset is the offset of the value within the body.
+function parseDecls(body) {
+  const decls = [];
+  // Split on `;` at depth 0 (outside parens). CSS doesn't have `{}` inside a
+  // declaration value so this is safe.
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i <= body.length; i++) {
+    const ch = body[i];
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    if (i === body.length || (ch === ";" && depth === 0)) {
+      const chunk = body.slice(start, i);
+      const colonIdx = chunk.indexOf(":");
+      if (colonIdx > 0) {
+        const prop = chunk.slice(0, colonIdx).trim().toLowerCase();
+        const valueOffset = start + colonIdx + 1;
+        const value = chunk.slice(colonIdx + 1);
+        if (prop && value && !prop.startsWith("--")) {
+          decls.push({ prop, value, valueOffset });
+        }
+      }
+      start = i + 1;
+    }
+  }
+  return decls;
+}
+
+// Find color literals in a property value. Returns array of { literal, offsetInValue }.
+function findColorLiterals(value) {
+  const hits = [];
+
+  // 1. Hex colors: #abc, #abcd, #aabbcc, #aabbccdd
+  const hexRe = /#[0-9a-fA-F]{3,8}\b/g;
+  let m;
+  while ((m = hexRe.exec(value))) {
+    const lit = m[0];
+    const len = lit.length - 1; // minus the '#'
+    if (len === 3 || len === 4 || len === 6 || len === 8) {
+      hits.push({ literal: lit.toLowerCase(), offsetInValue: m.index });
+    }
+  }
+
+  // 2. rgb(), rgba(), hsl(), hsla(), hwb(), lab(), lch(), oklab(), oklch(), color()
+  const fnRe = /\b(rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color)\s*\([^()]*\)/gi;
+  while ((m = fnRe.exec(value))) {
+    // Normalize whitespace inside the literal for stable fingerprinting.
+    const lit = m[0].replace(/\s+/g, " ").toLowerCase();
+    hits.push({ literal: lit, offsetInValue: m.index });
+  }
+
+  // 3. Named colors. Only consider identifier-shaped tokens; skip ones inside
+  // strings (font-family, content) by stripping quoted regions first.
+  const cleaned = value.replace(/"[^"]*"|'[^']*'/g, (s) => " ".repeat(s.length));
+  const wordRe = /\b([a-zA-Z]{3,20})\b/g;
+  while ((m = wordRe.exec(cleaned))) {
+    const word = m[1].toLowerCase();
+    if (NAMED_COLORS.has(word)) {
+      hits.push({ literal: word, offsetInValue: m.index });
+    }
+  }
+
+  // Sort by offset to keep occurrence indices stable across runs.
+  hits.sort((a, b) => a.offsetInValue - b.offsetInValue);
+  return hits;
+}
+
+function collectFingerprints(css) {
+  const stripped = stripComments(css);
+  const entries = []; // { selector, prop, literal, n, line }
+  const counts = new Map(); // key `${selector}\t${prop}\t${literal}` -> count
+
+  for (const rule of iterRules(stripped)) {
+    // Skip @keyframes step selectors like `from`, `to`, `50%` —
+    // their declarations may carry colors but are usually animation noise;
+    // still, treat them like normal rules under the @keyframes chain.
+    const selector = rule.chain.map((s) => s.replace(/\s+/g, " ")).join(" >> ");
+    if (!selector) continue;
+    if (selector.startsWith("@") && rule.chain.length === 1) continue; // pure at-rule preamble, no decls
+    const decls = parseDecls(rule.body);
+    for (const decl of decls) {
+      if (!COLOR_PROPS.has(decl.prop)) continue;
+      const hits = findColorLiterals(decl.value);
+      for (const hit of hits) {
+        const key = `${selector}\t${decl.prop}\t${hit.literal}`;
+        const n = counts.get(key) || 0;
+        counts.set(key, n + 1);
+        const absOffset = rule.bodyStart + decl.valueOffset + hit.offsetInValue;
+        entries.push({
+          selector,
+          prop: decl.prop,
+          literal: hit.literal,
+          n,
+          line: lineOf(stripped, absOffset),
+        });
+      }
+    }
+  }
+  return entries;
+}
+
+function fingerprintOf(e) {
+  return `${e.selector}\t${e.prop}\t${e.literal}\t${e.n}`;
+}
+
+function loadBaseline() {
+  if (!fs.existsSync(BASELINE_PATH)) return { fingerprints: [] };
+  return JSON.parse(fs.readFileSync(BASELINE_PATH, "utf8"));
+}
+
+function saveBaseline(entries) {
+  // Sort for deterministic diff
+  const sorted = entries
+    .map((e) => ({ selector: e.selector, prop: e.prop, literal: e.literal, n: e.n }))
+    .sort((a, b) =>
+      a.selector.localeCompare(b.selector) ||
+      a.prop.localeCompare(b.prop) ||
+      a.literal.localeCompare(b.literal) ||
+      a.n - b.n
+    );
+  fs.writeFileSync(
+    BASELINE_PATH,
+    JSON.stringify(
+      {
+        $schema: "raw-color-baseline/v1",
+        description:
+          "Snapshot of raw color literals tolerated in src/styles.css. Each entry is a (selector, property, literal, occurrence_index) tuple. CI fails when an entry not in this list appears in src/styles.css. Shrink this list as components migrate to semantic tokens (see docs/theme-tokens.md). Regenerate via: npm run lint:css-tokens -- --update-baseline",
+        fingerprints: sorted,
+      },
+      null,
+      2
+    ) + "\n"
+  );
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const update = args.includes("--update-baseline");
+
+  if (!fs.existsSync(TARGET)) {
+    console.error(`check-raw-colors: target not found: ${TARGET}`);
+    process.exit(2);
+  }
+  const css = fs.readFileSync(TARGET, "utf8");
+  const entries = collectFingerprints(css);
+
+  if (update) {
+    saveBaseline(entries);
+    console.log(`✓ baseline updated: ${entries.length} fingerprint(s) → ${path.relative(REPO_ROOT, BASELINE_PATH)}`);
+    return;
+  }
+
+  const baseline = loadBaseline();
+  const baselineSet = new Set(
+    (baseline.fingerprints || []).map((e) => `${e.selector}\t${e.prop}\t${e.literal}\t${e.n}`)
+  );
+  const currentSet = new Set(entries.map(fingerprintOf));
+
+  const newOnes = entries.filter((e) => !baselineSet.has(fingerprintOf(e)));
+  const removed = [...baselineSet].filter((fp) => !currentSet.has(fp));
+
+  if (newOnes.length === 0 && removed.length === 0) {
+    console.log(`✓ style token gate: ${entries.length} known raw color literal(s); none new.`);
+    return;
+  }
+
+  if (newOnes.length > 0) {
+    console.error("");
+    console.error("✗ style token gate: new raw color literal(s) detected in src/styles.css.");
+    console.error("");
+    console.error("  Raw color literals should be replaced with semantic CSS tokens");
+    console.error("  (e.g. var(--bg-panel), var(--ink-primary), var(--border-subtle)) so");
+    console.error("  light and dark themes resolve from a single source of truth.");
+    console.error("");
+    for (const e of newOnes) {
+      console.error(`  src/styles.css:${e.line}`);
+      console.error(`    selector : ${e.selector}`);
+      console.error(`    property : ${e.prop}`);
+      console.error(`    literal  : ${e.literal}${e.n > 0 ? `  (occurrence #${e.n + 1})` : ""}`);
+      console.error("");
+    }
+    console.error("  If this literal is truly unavoidable, add it explicitly by running:");
+    console.error("    npm run lint:css-tokens -- --update-baseline");
+    console.error("  and including the resulting baseline diff in your PR with justification.");
+    console.error("");
+  }
+
+  if (removed.length > 0) {
+    // Removals are good — they mean a literal was migrated to a token.
+    // But the baseline still references them, so we ask the author to refresh it.
+    console.error("✓ style token gate: detected literals removed (good!) but the baseline still");
+    console.error(`  references ${removed.length} stale fingerprint(s). Please refresh the baseline:`);
+    console.error("    npm run lint:css-tokens -- --update-baseline");
+    console.error("");
+  }
+
+  process.exit(newOnes.length > 0 ? 1 : 0);
+}
+
+main();

--- a/scripts/styles-raw-color-baseline.json
+++ b/scripts/styles-raw-color-baseline.json
@@ -1,0 +1,4434 @@
+{
+  "$schema": "raw-color-baseline/v1",
+  "description": "Snapshot of raw color literals tolerated in src/styles.css. Each entry is a (selector, property, literal, occurrence_index) tuple. CI fails when an entry not in this list appears in src/styles.css. Shrink this list as components migrate to semantic tokens (see docs/theme-tokens.md). Regenerate via: npm run lint:css-tokens -- --update-baseline",
+  "fingerprints": [
+    {
+      "selector": ":root",
+      "prop": "background",
+      "literal": "#e9eaec",
+      "n": 0
+    },
+    {
+      "selector": ":root",
+      "prop": "color",
+      "literal": "#121316",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .activity-feed-filters button.active",
+      "prop": "background",
+      "literal": "rgba(105, 170, 252, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .activity-feed-filters button.active",
+      "prop": "border-color",
+      "literal": "rgba(105, 170, 252, 0.32)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .activity-feed-row small b",
+      "prop": "background",
+      "literal": "rgba(52, 199, 89, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .activity-feed-row small b",
+      "prop": "color",
+      "literal": "#67d084",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .activity-feed-row-meta em",
+      "prop": "background",
+      "literal": "rgba(226, 232, 240, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .agent-inbox-row-title span, :root[data-theme=\"dark\"] .search-result-fallback-avatar, :root[data-theme=\"dark\"] .reminder-row-icon",
+      "prop": "background",
+      "literal": "rgba(226, 232, 240, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .agent-inbox-row-title span[data-status=\"active\"]",
+      "prop": "background",
+      "literal": "rgba(105, 170, 252, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .agent-inbox-row-title span[data-status=\"attention\"], :root[data-theme=\"dark\"] .thread-browser-follow:hover",
+      "prop": "background",
+      "literal": "rgba(255, 69, 58, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .agent-inbox-row-title span[data-status=\"attention\"], :root[data-theme=\"dark\"] .thread-browser-follow:hover",
+      "prop": "color",
+      "literal": "#ff8a80",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .agent-inbox-row-title span[data-status=\"done\"], :root[data-theme=\"dark\"] .thread-browser-follow",
+      "prop": "background",
+      "literal": "rgba(52, 199, 89, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .agent-inbox-row-title span[data-status=\"done\"], :root[data-theme=\"dark\"] .thread-browser-follow",
+      "prop": "color",
+      "literal": "#67d084",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .app",
+      "prop": "background",
+      "literal": "#0e1117",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .app",
+      "prop": "background",
+      "literal": "#101722",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .app",
+      "prop": "background",
+      "literal": "#151922",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .artifact-icon",
+      "prop": "background",
+      "literal": "rgba(52, 199, 89, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .artifact-icon",
+      "prop": "color",
+      "literal": "#67d084",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .artifact-render-error",
+      "prop": "background",
+      "literal": "rgba(255, 69, 58, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .artifact-render-error",
+      "prop": "border-color",
+      "literal": "rgba(255, 69, 58, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .artifact-render-error",
+      "prop": "color",
+      "literal": "#ffb4ab",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .markdown-body code",
+      "prop": "background",
+      "literal": "rgba(226, 232, 240, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .markdown-body pre, :root[data-theme=\"dark\"] .workspace-preview-raw",
+      "prop": "color",
+      "literal": "#eef2f7",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .message-artifact pre",
+      "prop": "color",
+      "literal": "#eef2f7",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .message-card:hover .message-long-preview.collapsed::after, :root[data-theme=\"dark\"] .message-card.focused .message-long-preview.collapsed::after, :root[data-theme=\"dark\"] .message-card.tap-focused .message-long-preview.collapsed::after, :root[data-theme=\"dark\"] .message-card[data-jump-focused=\"true\"] .message-long-preview.collapsed::after",
+      "prop": "background",
+      "literal": "#1f2631",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .message-card:hover .message-long-preview.collapsed::after, :root[data-theme=\"dark\"] .message-card.focused .message-long-preview.collapsed::after, :root[data-theme=\"dark\"] .message-card.tap-focused .message-long-preview.collapsed::after, :root[data-theme=\"dark\"] .message-card[data-jump-focused=\"true\"] .message-long-preview.collapsed::after",
+      "prop": "background",
+      "literal": "rgba(30, 36, 46, 0)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .message-card:hover, :root[data-theme=\"dark\"] .message-card.focused, :root[data-theme=\"dark\"] .message-card.tap-focused, :root[data-theme=\"dark\"] .reply-list article:hover, :root[data-theme=\"dark\"] .reply-list article.tap-focused, :root[data-theme=\"dark\"] .activity-run-step:hover, :root[data-theme=\"dark\"] .activity-run-step.expanded, :root[data-theme=\"dark\"] .activity-timeline-row:hover, :root[data-theme=\"dark\"] .activity-timeline-row.expanded",
+      "prop": "background",
+      "literal": "rgba(105, 170, 252, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .message-long-preview.collapsed::after",
+      "prop": "background",
+      "literal": "rgba(23, 27, 34, 0)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .search-backdrop",
+      "prop": "background",
+      "literal": "rgba(8, 11, 16, 0.72)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .search-filter-group button.active",
+      "prop": "background",
+      "literal": "rgba(105, 170, 252, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .search-filter-group button.active",
+      "prop": "border-color",
+      "literal": "rgba(105, 170, 252, 0.28)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .task-queue-section.unassigned, :root[data-theme=\"dark\"] .task-card.unassigned, :root[data-theme=\"dark\"] .reminder-row.fired",
+      "prop": "border-color",
+      "literal": "rgba(255, 177, 66, 0.28)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .task-unassigned-avatar",
+      "prop": "background",
+      "literal": "rgba(226, 232, 240, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .theme-choice-grid button.selected",
+      "prop": "background",
+      "literal": "rgba(105, 170, 252, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .theme-choice-grid button.selected",
+      "prop": "background",
+      "literal": "rgba(105, 170, 252, 0.24)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .theme-choice-grid button.selected",
+      "prop": "border-color",
+      "literal": "rgba(105, 170, 252, 0.72)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .theme-choice-grid button.selected",
+      "prop": "box-shadow",
+      "literal": "rgba(105, 170, 252, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ":root[data-theme=\"dark\"] .theme-choice-grid button.selected",
+      "prop": "box-shadow",
+      "literal": "rgba(105, 170, 252, 0.72)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot",
+      "prop": "background",
+      "literal": "#ffd43b",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot",
+      "prop": "border",
+      "literal": "#1f2937",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 212, 59, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot::after",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.24)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-kind=\"acting\"], .activity-dot[data-kind=\"event\"], .activity-dot[data-kind=\"message\"], .activity-dot[data-kind=\"task\"]",
+      "prop": "background",
+      "literal": "#32d74b",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-kind=\"acting\"], .activity-dot[data-kind=\"event\"], .activity-dot[data-kind=\"message\"], .activity-dot[data-kind=\"task\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(50, 215, 75, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-kind=\"command\"]",
+      "prop": "background",
+      "literal": "#ff9f0a",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-kind=\"command\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 159, 10, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-kind=\"error\"], .activity-dot[data-kind=\"event_error\"], .activity-dot[data-kind=\"run_error\"]",
+      "prop": "background",
+      "literal": "#ff453a",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-kind=\"error\"], .activity-dot[data-kind=\"event_error\"], .activity-dot[data-kind=\"run_error\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 69, 58, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-kind=\"file_edit\"]",
+      "prop": "background",
+      "literal": "#bf5af2",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-kind=\"file_edit\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(191, 90, 242, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-kind=\"run_retry\"]",
+      "prop": "background",
+      "literal": "#ff9f0a",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-kind=\"run_retry\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 159, 10, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-kind=\"thinking\"]",
+      "prop": "background",
+      "literal": "#64d2ff",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-kind=\"thinking\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(100, 210, 255, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-kind=\"tools\"]",
+      "prop": "background",
+      "literal": "#ffd43b",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-kind=\"tools\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 212, 59, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-status=\"error\"]",
+      "prop": "background",
+      "literal": "#ff453a",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-status=\"error\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 69, 58, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-status=\"success\"]",
+      "prop": "background",
+      "literal": "#34c759",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-status=\"success\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(52, 199, 89, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-status=\"warning\"]",
+      "prop": "background",
+      "literal": "#ff9f0a",
+      "n": 0
+    },
+    {
+      "selector": ".activity-dot[data-status=\"warning\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 159, 10, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-back, .activity-feed-mark-all, .activity-feed-dismiss-all",
+      "prop": "background",
+      "literal": "#f6f7f9",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-back, .activity-feed-mark-all, .activity-feed-dismiss-all",
+      "prop": "background",
+      "literal": "#ffffff",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-back, .activity-feed-mark-all, .activity-feed-dismiss-all",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-back, .activity-feed-mark-all, .activity-feed-dismiss-all",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.04)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-back, .activity-feed-mark-all, .activity-feed-dismiss-all",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.8)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-back, .activity-feed-mark-all, .activity-feed-dismiss-all",
+      "prop": "color",
+      "literal": "#656c78",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-back:hover, .activity-feed-mark-all:hover:not(:disabled), .activity-feed-dismiss-all:hover:not(:disabled)",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-back:hover, .activity-feed-mark-all:hover:not(:disabled), .activity-feed-dismiss-all:hover:not(:disabled)",
+      "prop": "color",
+      "literal": "#20242b",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-check, .activity-feed-dismiss",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-check, .activity-feed-dismiss",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-check:hover",
+      "prop": "background",
+      "literal": "rgba(52, 199, 89, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-check:hover",
+      "prop": "color",
+      "literal": "#168a36",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-dismiss-all:hover:not(:disabled)",
+      "prop": "border-color",
+      "literal": "rgba(196, 35, 29, 0.24)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-dismiss-all:hover:not(:disabled)",
+      "prop": "color",
+      "literal": "#c4231d",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-dismiss:hover",
+      "prop": "background",
+      "literal": "rgba(255, 59, 48, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-dismiss:hover",
+      "prop": "color",
+      "literal": "#c4231d",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-filters",
+      "prop": "background",
+      "literal": "rgba(248, 249, 251, 0.86)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-filters button",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-filters button",
+      "prop": "border",
+      "literal": "rgba(142, 142, 147, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-filters button.active",
+      "prop": "background",
+      "literal": "#eef0f4",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-filters button.active",
+      "prop": "border-color",
+      "literal": "rgba(20, 23, 31, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-filters button.active",
+      "prop": "color",
+      "literal": "#20242b",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-load-more button",
+      "prop": "background",
+      "literal": "#f6f7f9",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-load-more button",
+      "prop": "background",
+      "literal": "#ffffff",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-load-more button",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-load-more button",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.04)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-load-more button",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.8)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-load-more button",
+      "prop": "color",
+      "literal": "#20242b",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-load-more button:hover",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-panel",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.97)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-panel",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-panel",
+      "prop": "box-shadow",
+      "literal": "rgba(15, 23, 42, 0.24)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-row h3",
+      "prop": "color",
+      "literal": "#1d1c1d",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-row p",
+      "prop": "color",
+      "literal": "#1d1c1d",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-row small b",
+      "prop": "background",
+      "literal": "#f0f9f3",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-row small b",
+      "prop": "color",
+      "literal": "#167a36",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-row-meta em",
+      "prop": "background",
+      "literal": "#eef0f4",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-row-meta em",
+      "prop": "color",
+      "literal": "#4f5560",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-row-meta strong",
+      "prop": "color",
+      "literal": "#1d1c1d",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-row-shell + .activity-feed-row-shell",
+      "prop": "border-top",
+      "literal": "rgba(20, 23, 31, 0.06)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-row:hover",
+      "prop": "background",
+      "literal": "rgba(248, 248, 248, 0.72)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-unread-dot",
+      "prop": "background",
+      "literal": "#ff3b30",
+      "n": 0
+    },
+    {
+      "selector": ".activity-feed-unread-dot",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 59, 48, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-metadata b",
+      "prop": "color",
+      "literal": "#8e8e93",
+      "n": 0
+    },
+    {
+      "selector": ".activity-metadata span",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.72)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-metadata span",
+      "prop": "border",
+      "literal": "rgba(118, 118, 128, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-metadata span",
+      "prop": "color",
+      "literal": "#4b5563",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-avatar-stack .agent-avatar",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 22, 28, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-avatar-stack .agent-avatar",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.95)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-chevron",
+      "prop": "color",
+      "literal": "rgba(79, 95, 114, 0.7)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-copy small",
+      "prop": "color",
+      "literal": "rgba(79, 95, 114, 0.82)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-copy small em",
+      "prop": "color",
+      "literal": "rgba(79, 95, 114, 0.72)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-copy small span",
+      "prop": "color",
+      "literal": "rgba(37, 49, 67, 0.88)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-copy strong",
+      "prop": "color",
+      "literal": "#253143",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-dock",
+      "prop": "color",
+      "literal": "#4f5f72",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-dock summary",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.94)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-dock summary",
+      "prop": "box-shadow",
+      "literal": "rgba(15, 23, 42, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-dock summary[data-state=\"provider-retrying\"]",
+      "prop": "background",
+      "literal": "rgba(255, 250, 238, 0.98)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-dock summary[data-state=\"provider-retrying\"]",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.94)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-dock summary[data-state=\"provider-retrying\"]",
+      "prop": "border-color",
+      "literal": "rgba(255, 159, 10, 0.28)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-dock summary[data-state=\"provider-retrying\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(15, 23, 42, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-dock summary[data-state=\"provider-retrying\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 159, 10, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-history",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.96)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-history",
+      "prop": "border",
+      "literal": "rgba(17, 24, 39, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-history",
+      "prop": "box-shadow",
+      "literal": "rgba(15, 23, 42, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-history b",
+      "prop": "color",
+      "literal": "#39475a",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-history li[data-status=\"error\"] b",
+      "prop": "color",
+      "literal": "#a34828",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-history small",
+      "prop": "color",
+      "literal": "rgba(79, 95, 114, 0.74)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-history strong",
+      "prop": "color",
+      "literal": "#253143",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-history time",
+      "prop": "color",
+      "literal": "rgba(79, 95, 114, 0.62)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-source-chip",
+      "prop": "background",
+      "literal": "rgba(118, 118, 128, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-source-chip",
+      "prop": "border",
+      "literal": "rgba(118, 118, 128, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-source-chip",
+      "prop": "color",
+      "literal": "rgba(79, 95, 114, 0.78)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-source-chip[data-kind=\"run_retry\"]",
+      "prop": "background",
+      "literal": "rgba(255, 159, 10, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-source-chip[data-kind=\"run_retry\"]",
+      "prop": "border-color",
+      "literal": "rgba(255, 159, 10, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-progress-source-chip[data-kind=\"run_retry\"]",
+      "prop": "color",
+      "literal": "#8a5b00",
+      "n": 0
+    },
+    {
+      "selector": ".activity-provider-note",
+      "prop": "background",
+      "literal": "rgba(255, 159, 10, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-provider-note",
+      "prop": "border",
+      "literal": "rgba(255, 159, 10, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-provider-note",
+      "prop": "color",
+      "literal": "#6a5a20",
+      "n": 0
+    },
+    {
+      "selector": ".activity-queued-note, .activity-queued-summary",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.06)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-queued-note, .activity-queued-summary",
+      "prop": "border",
+      "literal": "rgba(10, 132, 255, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-raw",
+      "prop": "background",
+      "literal": "rgba(15, 23, 42, 0.04)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-raw",
+      "prop": "border",
+      "literal": "rgba(118, 118, 128, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-raw",
+      "prop": "color",
+      "literal": "#4b5563",
+      "n": 0
+    },
+    {
+      "selector": ".activity-run-card",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.78)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-run-card",
+      "prop": "border",
+      "literal": "rgba(118, 118, 128, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-run-card[data-provider-retrying=\"true\"]",
+      "prop": "background",
+      "literal": "rgba(255, 250, 238, 0.92)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-run-card[data-provider-retrying=\"true\"]",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.78)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-run-card[data-provider-retrying=\"true\"]",
+      "prop": "border-color",
+      "literal": "rgba(255, 159, 10, 0.24)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-run-head button",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".activity-run-head button",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-run-kicker b",
+      "prop": "background",
+      "literal": "rgba(255, 159, 10, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-run-kicker b",
+      "prop": "color",
+      "literal": "#8a5b00",
+      "n": 0
+    },
+    {
+      "selector": ".activity-run-kicker span, .activity-run-kicker b",
+      "prop": "background",
+      "literal": "rgba(118, 118, 128, 0.09)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-run-kicker span, .activity-run-kicker b",
+      "prop": "color",
+      "literal": "#5f6672",
+      "n": 0
+    },
+    {
+      "selector": ".activity-run-step time",
+      "prop": "color",
+      "literal": "#8e8e93",
+      "n": 0
+    },
+    {
+      "selector": ".activity-run-step:hover, .activity-run-step.expanded",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.68)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status",
+      "prop": "border",
+      "literal": "rgba(142, 142, 147, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status",
+      "prop": "color",
+      "literal": "#6b7280",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status.status-active",
+      "prop": "background",
+      "literal": "rgba(0, 122, 255, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status.status-active",
+      "prop": "border-color",
+      "literal": "rgba(0, 122, 255, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status.status-active",
+      "prop": "color",
+      "literal": "#007aff",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status.status-error",
+      "prop": "background",
+      "literal": "rgba(255, 69, 58, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status.status-error",
+      "prop": "border-color",
+      "literal": "rgba(255, 69, 58, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status.status-error",
+      "prop": "color",
+      "literal": "#c91810",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status.status-success",
+      "prop": "background",
+      "literal": "rgba(52, 199, 89, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status.status-success",
+      "prop": "border-color",
+      "literal": "rgba(52, 199, 89, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status.status-success",
+      "prop": "color",
+      "literal": "#1f9d4c",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status.status-warning",
+      "prop": "background",
+      "literal": "rgba(255, 159, 10, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status.status-warning",
+      "prop": "border-color",
+      "literal": "rgba(255, 159, 10, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-status.status-warning",
+      "prop": "color",
+      "literal": "#a25c00",
+      "n": 0
+    },
+    {
+      "selector": ".activity-structure-line",
+      "prop": "color",
+      "literal": "#8e8e93",
+      "n": 0
+    },
+    {
+      "selector": ".activity-structure-line span",
+      "prop": "background",
+      "literal": "rgba(118, 118, 128, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-timeline-body p",
+      "prop": "color",
+      "literal": "#7b7b81",
+      "n": 0
+    },
+    {
+      "selector": ".activity-timeline-row time",
+      "prop": "color",
+      "literal": "#8e8e93",
+      "n": 0
+    },
+    {
+      "selector": ".activity-timeline-row:hover, .activity-timeline-row.expanded",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.68)",
+      "n": 0
+    },
+    {
+      "selector": ".activity-timeline-row[data-kind=\"error\"] .activity-timeline-body p, .activity-timeline-row[data-kind=\"event_error\"] .activity-timeline-body p, .activity-timeline-row[data-kind=\"run_error\"] .activity-timeline-body p",
+      "prop": "color",
+      "literal": "#c91810",
+      "n": 0
+    },
+    {
+      "selector": ".activity-timeline-title span",
+      "prop": "color",
+      "literal": "#8e8e93",
+      "n": 0
+    },
+    {
+      "selector": ".activity-timeline-title strong",
+      "prop": "color",
+      "literal": "#0f172a",
+      "n": 0
+    },
+    {
+      "selector": ".agent-advanced-settings summary svg",
+      "prop": "color",
+      "literal": "rgba(20, 23, 31, 0.46)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-advanced-settings summary:hover, .agent-advanced-settings summary:focus-visible",
+      "prop": "background",
+      "literal": "rgba(20, 23, 31, 0.06)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-advanced-settings summary:hover, .agent-advanced-settings summary:focus-visible",
+      "prop": "color",
+      "literal": "#4f5560",
+      "n": 0
+    },
+    {
+      "selector": ".agent-autonomy-card",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-autonomy-card",
+      "prop": "background",
+      "literal": "rgba(100, 210, 255, 0.06)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-autonomy-card",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.82)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-autonomy-card",
+      "prop": "border",
+      "literal": "rgba(10, 132, 255, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar",
+      "prop": "box-shadow",
+      "literal": "rgba(0, 0, 0, 0.04)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 22, 28, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.42)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar-lg::after",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 22, 28, 0.24)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar-profile-card",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.97)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar-profile-card",
+      "prop": "border",
+      "literal": "rgba(20, 22, 28, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar-profile-card",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 22, 28, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar-profile-card",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 22, 28, 0.2)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar-profile-card",
+      "prop": "color",
+      "literal": "#1d1d1f",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar-profile-card-above::after",
+      "prop": "border-bottom",
+      "literal": "rgba(20, 22, 28, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar-profile-card-above::after",
+      "prop": "border-right",
+      "literal": "rgba(20, 22, 28, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar-profile-card-below::after",
+      "prop": "border-left",
+      "literal": "rgba(20, 22, 28, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar-profile-card-below::after",
+      "prop": "border-top",
+      "literal": "rgba(20, 22, 28, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar-profile-card::after",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.97)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar-profile-description",
+      "prop": "color",
+      "literal": "rgba(29, 29, 31, 0.7)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar-profile-handle, .agent-avatar-profile-role",
+      "prop": "color",
+      "literal": "rgba(29, 29, 31, 0.58)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar-profile-name",
+      "prop": "color",
+      "literal": "#111113",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar::after",
+      "prop": "background",
+      "literal": "#8e8e93",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar::after",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 22, 28, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar.status-deleted",
+      "prop": "box-shadow",
+      "literal": "rgba(0, 0, 0, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar.status-deleted",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 22, 28, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar.status-deleted",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.34)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar.status-deleted::after",
+      "prop": "background",
+      "literal": "#8e8e93",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar.status-error::after",
+      "prop": "background",
+      "literal": "#ff3b30",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar.status-idle::after",
+      "prop": "background",
+      "literal": "#34c759",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar.status-starting::after, .agent-avatar.status-queued::after, .agent-avatar.status-running::after, .agent-avatar.status-stopping::after",
+      "prop": "background",
+      "literal": "#ffb020",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar[data-agent-deleted=\"true\"]::before",
+      "prop": "background",
+      "literal": "rgba(58, 58, 60, 0.78)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-avatar[data-agent-deleted=\"true\"]::before",
+      "prop": "background",
+      "literal": "rgba(58, 58, 60, 0.78)",
+      "n": 1
+    },
+    {
+      "selector": ".agent-detail-hero",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.17)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-detail-hero",
+      "prop": "background",
+      "literal": "rgba(248, 249, 251, 0.82)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-detail-hero",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.96)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-detail-hero",
+      "prop": "background",
+      "literal": "rgba(52, 199, 89, 0.13)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-detail-hero",
+      "prop": "border",
+      "literal": "rgba(118, 118, 128, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-detail-hero",
+      "prop": "box-shadow",
+      "literal": "rgba(32, 36, 44, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-detail-tab:hover",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.78)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-detail-tab.active",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".agent-detail-tab.active",
+      "prop": "box-shadow",
+      "literal": "rgba(32, 36, 44, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-detail-tabs",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.68)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-detail-tabs",
+      "prop": "border",
+      "literal": "rgba(118, 118, 128, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-detail-tabs",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.68)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-drawer-head button:hover",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-drawer-head button:hover",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.28)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-drawer-head button.danger:hover",
+      "prop": "background",
+      "literal": "rgba(255, 59, 48, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-drawer-head button.danger:hover",
+      "prop": "border-color",
+      "literal": "rgba(255, 59, 48, 0.2)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-drawer-head button.danger:hover",
+      "prop": "color",
+      "literal": "#d70015",
+      "n": 0
+    },
+    {
+      "selector": ".agent-form-preview-avatar-action",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-form-preview-avatar-action",
+      "prop": "border",
+      "literal": "rgba(10, 132, 255, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-form-preview-avatar-action:hover, .agent-form-preview-avatar-action:focus-visible",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.13)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-form-preview, .owner-profile-preview",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".agent-form-preview, .owner-profile-preview",
+      "prop": "border",
+      "literal": "rgba(142, 142, 147, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row",
+      "prop": "border-color",
+      "literal": "rgba(118, 118, 128, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row-icon",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.09)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row-meta strong",
+      "prop": "color",
+      "literal": "#1d1c1d",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row-title h5",
+      "prop": "color",
+      "literal": "#1d1c1d",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row-title span",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.13)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row-title span",
+      "prop": "color",
+      "literal": "#5f6368",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row-title span[data-status=\"active\"]",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.11)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row-title span[data-status=\"active\"]",
+      "prop": "color",
+      "literal": "#0067c5",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row-title span[data-status=\"attention\"]",
+      "prop": "background",
+      "literal": "rgba(255, 59, 48, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row-title span[data-status=\"attention\"]",
+      "prop": "color",
+      "literal": "#c91810",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row-title span[data-status=\"done\"]",
+      "prop": "background",
+      "literal": "#f0f9f3",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row-title span[data-status=\"done\"]",
+      "prop": "color",
+      "literal": "#167a36",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row:hover",
+      "prop": "background",
+      "literal": "rgba(248, 250, 252, 0.92)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-inbox-row:hover",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminder-icon",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminder-row",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.72)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminder-row",
+      "prop": "border",
+      "literal": "rgba(118, 118, 128, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminder-row.status-fired",
+      "prop": "background",
+      "literal": "rgba(255, 69, 58, 0.06)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminder-row.status-fired",
+      "prop": "border-color",
+      "literal": "rgba(255, 69, 58, 0.24)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminder-row.status-fired .agent-reminder-icon",
+      "prop": "background",
+      "literal": "rgba(255, 69, 58, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminder-row.status-fired .agent-reminder-icon",
+      "prop": "color",
+      "literal": "#c91810",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminder-row.status-fired .agent-reminder-title span",
+      "prop": "background",
+      "literal": "rgba(255, 69, 58, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminder-row.status-fired .agent-reminder-title span",
+      "prop": "color",
+      "literal": "#c91810",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminder-title span",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminders-section",
+      "prop": "background",
+      "literal": "rgba(248, 249, 251, 0.76)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminders-section",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.82)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminders-section",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.9)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminders-section",
+      "prop": "border",
+      "literal": "rgba(118, 118, 128, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-reminders-section",
+      "prop": "box-shadow",
+      "literal": "rgba(32, 36, 44, 0.04)",
+      "n": 0
+    },
+    {
+      "selector": ".agent-select-control svg",
+      "prop": "color",
+      "literal": "rgba(20, 23, 31, 0.48)",
+      "n": 0
+    },
+    {
+      "selector": ".app",
+      "prop": "background",
+      "literal": "#edf2fa",
+      "n": 0
+    },
+    {
+      "selector": ".app",
+      "prop": "background",
+      "literal": "#eef1f5",
+      "n": 0
+    },
+    {
+      "selector": ".app",
+      "prop": "background",
+      "literal": "#fbfbfd",
+      "n": 0
+    },
+    {
+      "selector": ".app",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".app",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.92)",
+      "n": 0
+    },
+    {
+      "selector": ".app-toast",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.96)",
+      "n": 0
+    },
+    {
+      "selector": ".app-toast",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".app-toast",
+      "prop": "box-shadow",
+      "literal": "rgba(15, 23, 42, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".app-toast",
+      "prop": "color",
+      "literal": "#2c3038",
+      "n": 0
+    },
+    {
+      "selector": ".app-toast button",
+      "prop": "background",
+      "literal": "rgba(20, 23, 31, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".app-toast button",
+      "prop": "color",
+      "literal": "#4f5560",
+      "n": 0
+    },
+    {
+      "selector": ".artifact-icon",
+      "prop": "background",
+      "literal": "rgba(16, 185, 129, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".artifact-icon",
+      "prop": "color",
+      "literal": "#047857",
+      "n": 0
+    },
+    {
+      "selector": ".artifact-render-error",
+      "prop": "background",
+      "literal": "rgba(254, 242, 242, 0.82)",
+      "n": 0
+    },
+    {
+      "selector": ".artifact-render-error",
+      "prop": "border",
+      "literal": "rgba(185, 28, 28, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".artifact-render-error",
+      "prop": "color",
+      "literal": "#991b1b",
+      "n": 0
+    },
+    {
+      "selector": ".attach-button",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.04)",
+      "n": 0
+    },
+    {
+      "selector": ".attach-button",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.8)",
+      "n": 0
+    },
+    {
+      "selector": ".attachment-icon",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".attachment-lightbox-backdrop",
+      "prop": "background",
+      "literal": "rgba(12, 16, 24, 0.76)",
+      "n": 0
+    },
+    {
+      "selector": ".attachment-lightbox-close",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.92)",
+      "n": 0
+    },
+    {
+      "selector": ".attachment-lightbox-close",
+      "prop": "box-shadow",
+      "literal": "rgba(0, 0, 0, 0.2)",
+      "n": 0
+    },
+    {
+      "selector": ".attachment-lightbox-close",
+      "prop": "color",
+      "literal": "#111827",
+      "n": 0
+    },
+    {
+      "selector": ".attachment-lightbox-content img",
+      "prop": "box-shadow",
+      "literal": "rgba(0, 0, 0, 0.34)",
+      "n": 0
+    },
+    {
+      "selector": ".avatar",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.7)",
+      "n": 0
+    },
+    {
+      "selector": ".avatar",
+      "prop": "box-shadow",
+      "literal": "rgba(0, 0, 0, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".avatar",
+      "prop": "color",
+      "literal": "#171717",
+      "n": 0
+    },
+    {
+      "selector": ".avatar.human",
+      "prop": "background",
+      "literal": "#b9a7ff",
+      "n": 0
+    },
+    {
+      "selector": ".beginning",
+      "prop": "color",
+      "literal": "#8f8f95",
+      "n": 0
+    },
+    {
+      "selector": ".boot",
+      "prop": "color",
+      "literal": "#777",
+      "n": 0
+    },
+    {
+      "selector": ".boot-panel button",
+      "prop": "background",
+      "literal": "#1d4ed8",
+      "n": 0
+    },
+    {
+      "selector": ".boot-panel button",
+      "prop": "color",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".boot-panel p",
+      "prop": "color",
+      "literal": "#b42318",
+      "n": 0
+    },
+    {
+      "selector": ".boot-panel strong",
+      "prop": "color",
+      "literal": "#23252b",
+      "n": 0
+    },
+    {
+      "selector": ".channel-actions-menu",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 22, 28, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-actions-menu button:hover",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-actions-menu button.danger",
+      "prop": "color",
+      "literal": "#d92d20",
+      "n": 0
+    },
+    {
+      "selector": ".channel-actions-menu button.danger:hover",
+      "prop": "background",
+      "literal": "rgba(217, 45, 32, 0.09)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-count-trigger:hover, .channel-action-trigger:hover, .channel-action-trigger.active",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-count-trigger:hover, .channel-action-trigger:hover, .channel-action-trigger.active",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.28)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-empty-cta",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-empty-cta",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.07)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-empty-cta button",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-empty-cta button",
+      "prop": "border",
+      "literal": "rgba(10, 132, 255, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-empty-cta button",
+      "prop": "color",
+      "literal": "#1262b3",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-empty-cta button:hover, .channel-agent-empty-cta button:focus-visible",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.15)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-empty-cta button:hover, .channel-agent-empty-cta button:focus-visible",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.34)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-empty-cta button:hover, .channel-agent-empty-cta button:focus-visible",
+      "prop": "color",
+      "literal": "#075aa5",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-modal-icon",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-modal-icon",
+      "prop": "border",
+      "literal": "rgba(10, 132, 255, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-modal-icon",
+      "prop": "color",
+      "literal": "#1262b3",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-modal-intro",
+      "prop": "background",
+      "literal": "#f7f8fa",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-modal-intro",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-modal-intro",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.07)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-option-state",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-option-state",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-option-state",
+      "prop": "color",
+      "literal": "#535967",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-option-state.selected",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-option-state.selected",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-option-state.selected",
+      "prop": "color",
+      "literal": "#1262b3",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-picker .channel-agent-option.selected",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-picker .channel-agent-option.selected",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": ".channel-agent-preview .agent-avatar",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".channel.selected",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.05)",
+      "n": 0
+    },
+    {
+      "selector": ".channel.selected",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.82)",
+      "n": 0
+    },
+    {
+      "selector": ".code-block-shell button",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".code-block-shell button",
+      "prop": "border",
+      "literal": "rgba(255, 255, 255, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".code-block-shell button",
+      "prop": "color",
+      "literal": "#f7f7f8",
+      "n": 0
+    },
+    {
+      "selector": ".code-block-shell button:hover",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": ".composer textarea:focus, .reply-composer textarea:focus",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.42)",
+      "n": 0
+    },
+    {
+      "selector": ".composer textarea:focus, .reply-composer textarea:focus",
+      "prop": "box-shadow",
+      "literal": "rgba(10, 132, 255, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".composer.drag-over textarea, .reply-composer.drag-over textarea",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.5)",
+      "n": 0
+    },
+    {
+      "selector": ".composer.drag-over, .reply-composer.drag-over",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".composer.drag-over, .reply-composer.drag-over",
+      "prop": "box-shadow",
+      "literal": "rgba(10, 132, 255, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".desktop-history-button:hover:not(:disabled), .desktop-history-button:focus-visible:not(:disabled)",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.09)",
+      "n": 0
+    },
+    {
+      "selector": ".desktop-history-button:hover:not(:disabled), .desktop-history-button:focus-visible:not(:disabled)",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.24)",
+      "n": 0
+    },
+    {
+      "selector": ".detail-grid > div",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.78)",
+      "n": 0
+    },
+    {
+      "selector": ".detail-grid > div",
+      "prop": "border",
+      "literal": "rgba(118, 118, 128, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".detail-grid > div",
+      "prop": "box-shadow",
+      "literal": "rgba(32, 36, 44, 0.04)",
+      "n": 0
+    },
+    {
+      "selector": ".detail-work",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".detail-work-actions button",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".detail-work-actions button.danger",
+      "prop": "background",
+      "literal": "rgba(255, 59, 48, 0.11)",
+      "n": 0
+    },
+    {
+      "selector": ".detail-work-actions button.danger",
+      "prop": "color",
+      "literal": "#c91810",
+      "n": 0
+    },
+    {
+      "selector": ".dm-row:hover",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.055)",
+      "n": 0
+    },
+    {
+      "selector": ".dm-row:hover .dm-detail-trigger, .dm-row:focus-within .dm-detail-trigger, .dm-detail-trigger:hover, .dm-detail-trigger:focus-visible",
+      "prop": "background",
+      "literal": "rgba(246, 247, 249, 0.9)",
+      "n": 0
+    },
+    {
+      "selector": ".dm-row:hover .dm-detail-trigger, .dm-row:focus-within .dm-detail-trigger, .dm-detail-trigger:hover, .dm-detail-trigger:focus-visible",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.94)",
+      "n": 0
+    },
+    {
+      "selector": ".dm-row:hover .dm-detail-trigger, .dm-row:focus-within .dm-detail-trigger, .dm-detail-trigger:hover, .dm-detail-trigger:focus-visible",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".dm-row:hover .dm-detail-trigger, .dm-row:focus-within .dm-detail-trigger, .dm-detail-trigger:hover, .dm-detail-trigger:focus-visible",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".dm-row:hover .dm-detail-trigger, .dm-row:focus-within .dm-detail-trigger, .dm-detail-trigger:hover, .dm-detail-trigger:focus-visible",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.76)",
+      "n": 0
+    },
+    {
+      "selector": ".dm.selected .dm-badge, .dm-row.selected .dm .dm-badge",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".dm.selected .dm-badge, .dm-row.selected .dm .dm-badge",
+      "prop": "color",
+      "literal": "#0a84ff",
+      "n": 0
+    },
+    {
+      "selector": ".dot",
+      "prop": "color",
+      "literal": "#8e8e93",
+      "n": 0
+    },
+    {
+      "selector": ".dot.error",
+      "prop": "color",
+      "literal": "#ff3b30",
+      "n": 0
+    },
+    {
+      "selector": ".dot.idle",
+      "prop": "color",
+      "literal": "#34c759",
+      "n": 0
+    },
+    {
+      "selector": ".dot.starting, .dot.queued, .dot.running",
+      "prop": "color",
+      "literal": "#ffb020",
+      "n": 0
+    },
+    {
+      "selector": ".dot.stopping",
+      "prop": "color",
+      "literal": "#ffb020",
+      "n": 0
+    },
+    {
+      "selector": ".draft-attachment-remove",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".draft-attachment.image",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".draft-attachment.image .draft-attachment-remove",
+      "prop": "background",
+      "literal": "rgba(17, 24, 39, 0.86)",
+      "n": 0
+    },
+    {
+      "selector": ".draft-attachment.image .draft-attachment-remove",
+      "prop": "color",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".empty-state-action",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".empty-state-action",
+      "prop": "border",
+      "literal": "rgba(10, 132, 255, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".empty-state-action",
+      "prop": "color",
+      "literal": "#1262b3",
+      "n": 0
+    },
+    {
+      "selector": ".empty-state-action:hover",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.13)",
+      "n": 0
+    },
+    {
+      "selector": ".empty-state-action:hover",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.34)",
+      "n": 0
+    },
+    {
+      "selector": ".fatal-actions button",
+      "prop": "color",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".fatal-card",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.92)",
+      "n": 0
+    },
+    {
+      "selector": ".fatal-card",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".fatal-card",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".fatal-card p",
+      "prop": "color",
+      "literal": "#4d515b",
+      "n": 0
+    },
+    {
+      "selector": ".fatal-card pre",
+      "prop": "background",
+      "literal": "#101216",
+      "n": 0
+    },
+    {
+      "selector": ".fatal-card pre",
+      "prop": "color",
+      "literal": "#f6f8ff",
+      "n": 0
+    },
+    {
+      "selector": ".fatal-shell",
+      "prop": "background",
+      "literal": "#eef1f5",
+      "n": 0
+    },
+    {
+      "selector": ".fatal-shell",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".fatal-shell",
+      "prop": "background",
+      "literal": "rgba(255, 111, 174, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".fatal-shell",
+      "prop": "color",
+      "literal": "#16181d",
+      "n": 0
+    },
+    {
+      "selector": ".hash-card",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.04)",
+      "n": 0
+    },
+    {
+      "selector": ".hash-card",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.82)",
+      "n": 0
+    },
+    {
+      "selector": ".local-entity-link",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".local-entity-link:hover",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".markdown-body blockquote",
+      "prop": "border-left",
+      "literal": "rgba(10, 132, 255, 0.28)",
+      "n": 0
+    },
+    {
+      "selector": ".markdown-body code",
+      "prop": "background",
+      "literal": "rgba(20, 23, 31, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".markdown-body pre",
+      "prop": "background",
+      "literal": "#101318",
+      "n": 0
+    },
+    {
+      "selector": ".markdown-body pre",
+      "prop": "color",
+      "literal": "#f7f7f8",
+      "n": 0
+    },
+    {
+      "selector": ".member-editor",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.3)",
+      "n": 0
+    },
+    {
+      "selector": ".member-editor",
+      "prop": "border",
+      "literal": "rgba(0, 0, 0, 0.06)",
+      "n": 0
+    },
+    {
+      "selector": ".member-editor label",
+      "prop": "color",
+      "literal": "#24262b",
+      "n": 0
+    },
+    {
+      "selector": ".mention-picker",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.96)",
+      "n": 0
+    },
+    {
+      "selector": ".mention-picker",
+      "prop": "border",
+      "literal": "rgba(10, 132, 255, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".mention-picker",
+      "prop": "box-shadow",
+      "literal": "rgba(15, 23, 42, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".mention-picker button.active, .mention-picker button:hover",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".mention-picker-channel-icon",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".mention-picker-channel-icon",
+      "prop": "color",
+      "literal": "#0a84ff",
+      "n": 0
+    },
+    {
+      "selector": ".mention-picker-copy em",
+      "prop": "color",
+      "literal": "#667085",
+      "n": 0
+    },
+    {
+      "selector": ".message-action-menu",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.96)",
+      "n": 0
+    },
+    {
+      "selector": ".message-action-menu",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".message-action-menu",
+      "prop": "box-shadow",
+      "literal": "rgba(15, 23, 42, 0.2)",
+      "n": 0
+    },
+    {
+      "selector": ".message-action-menu button",
+      "prop": "border-bottom",
+      "literal": "rgba(142, 142, 147, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".message-action-menu button:hover",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".message-agent-avatar-trigger:hover",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".message-artifact pre",
+      "prop": "background",
+      "literal": "#10141d",
+      "n": 0
+    },
+    {
+      "selector": ".message-artifact pre",
+      "prop": "color",
+      "literal": "#eef3ff",
+      "n": 0
+    },
+    {
+      "selector": ".message-attachment",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.72)",
+      "n": 0
+    },
+    {
+      "selector": ".message-attachment:hover",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.92)",
+      "n": 0
+    },
+    {
+      "selector": ".message-attachment:hover",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.24)",
+      "n": 0
+    },
+    {
+      "selector": ".message-attachment.image",
+      "prop": "background",
+      "literal": "#eef0f4",
+      "n": 0
+    },
+    {
+      "selector": ".message-attachment.image img",
+      "prop": "background",
+      "literal": "#eef0f4",
+      "n": 0
+    },
+    {
+      "selector": ".message-card:hover .message-long-preview.collapsed::after, .message-card.focused .message-long-preview.collapsed::after, .message-card.tap-focused .message-long-preview.collapsed::after, .message-card[data-jump-focused=\"true\"] .message-long-preview.collapsed::after",
+      "prop": "background",
+      "literal": "rgba(248, 248, 248, 0.98)",
+      "n": 0
+    },
+    {
+      "selector": ".message-card:hover .message-long-preview.collapsed::after, .message-card.focused .message-long-preview.collapsed::after, .message-card.tap-focused .message-long-preview.collapsed::after, .message-card[data-jump-focused=\"true\"] .message-long-preview.collapsed::after",
+      "prop": "background",
+      "literal": "rgba(248, 248, 248, 0)",
+      "n": 0
+    },
+    {
+      "selector": ".message-card.focused, .message-card.tap-focused",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.28)",
+      "n": 0
+    },
+    {
+      "selector": ".message-card.focused, .message-card.tap-focused",
+      "prop": "box-shadow",
+      "literal": "rgba(10, 132, 255, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".message-card[data-jump-focused=\"true\"], .thread-root[data-jump-focused=\"true\"], .reply-list article[data-jump-focused=\"true\"]",
+      "prop": "background",
+      "literal": "rgba(255, 204, 0, 0.15)",
+      "n": 0
+    },
+    {
+      "selector": ".message-card[data-jump-focused=\"true\"], .thread-root[data-jump-focused=\"true\"], .reply-list article[data-jump-focused=\"true\"]",
+      "prop": "box-shadow",
+      "literal": "#ffcc00",
+      "n": 0
+    },
+    {
+      "selector": ".message-compact-time",
+      "prop": "color",
+      "literal": "rgba(123, 125, 132, 0.82)",
+      "n": 0
+    },
+    {
+      "selector": ".message-date-divider",
+      "prop": "color",
+      "literal": "#8f8f95",
+      "n": 0
+    },
+    {
+      "selector": ".message-expand-button:focus-visible",
+      "prop": "outline",
+      "literal": "rgba(10, 132, 255, 0.3)",
+      "n": 0
+    },
+    {
+      "selector": ".message-hover-actions",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".message-hover-actions",
+      "prop": "border",
+      "literal": "rgba(29, 28, 29, 0.13)",
+      "n": 0
+    },
+    {
+      "selector": ".message-hover-actions",
+      "prop": "box-shadow",
+      "literal": "rgba(29, 28, 29, 0.04)",
+      "n": 0
+    },
+    {
+      "selector": ".message-hover-actions",
+      "prop": "box-shadow",
+      "literal": "rgba(29, 28, 29, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".message-hover-actions button",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".message-hover-actions button",
+      "prop": "color",
+      "literal": "#5e5d60",
+      "n": 0
+    },
+    {
+      "selector": ".message-hover-actions button:hover",
+      "prop": "background",
+      "literal": "rgba(29, 28, 29, 0.06)",
+      "n": 0
+    },
+    {
+      "selector": ".message-hover-actions button:hover",
+      "prop": "color",
+      "literal": "#1d1c1d",
+      "n": 0
+    },
+    {
+      "selector": ".message-hover-actions button.saved:last-child",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".message-hover-actions button.saved:last-child",
+      "prop": "color",
+      "literal": "#8a5b00",
+      "n": 0
+    },
+    {
+      "selector": ".message-hover-actions button.saved:last-child:hover",
+      "prop": "background",
+      "literal": "rgba(29, 28, 29, 0.06)",
+      "n": 0
+    },
+    {
+      "selector": ".message-hover-actions button[data-tooltip]::after",
+      "prop": "background",
+      "literal": "rgba(29, 28, 29, 0.94)",
+      "n": 0
+    },
+    {
+      "selector": ".message-hover-actions button[data-tooltip]::after",
+      "prop": "color",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".message-hover-actions button[data-tooltip]::before",
+      "prop": "background",
+      "literal": "rgba(29, 28, 29, 0.94)",
+      "n": 0
+    },
+    {
+      "selector": ".message-long-preview.collapsed::after",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.96)",
+      "n": 0
+    },
+    {
+      "selector": ".message-long-preview.collapsed::after",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0)",
+      "n": 0
+    },
+    {
+      "selector": ".message-save-button",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".message-save-button:hover, .message-save-button.saved",
+      "prop": "background",
+      "literal": "rgba(255, 204, 0, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".message-save-button:hover, .message-save-button.saved",
+      "prop": "color",
+      "literal": "#8a5b00",
+      "n": 0
+    },
+    {
+      "selector": ".message-stream-state",
+      "prop": "color",
+      "literal": "#5f6b7a",
+      "n": 0
+    },
+    {
+      "selector": ".message-stream-state::before",
+      "prop": "background",
+      "literal": "#2f80ed",
+      "n": 0
+    },
+    {
+      "selector": ".message-stream-state::before",
+      "prop": "box-shadow",
+      "literal": "rgba(47, 128, 237, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".message-stream-state.error",
+      "prop": "color",
+      "literal": "#a34828",
+      "n": 0
+    },
+    {
+      "selector": ".message-stream-state.error::before",
+      "prop": "background",
+      "literal": "#e1583f",
+      "n": 0
+    },
+    {
+      "selector": ".message-stream-state.error::before",
+      "prop": "box-shadow",
+      "literal": "rgba(225, 88, 63, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".message-stream-state.sending",
+      "prop": "color",
+      "literal": "#6a5a20",
+      "n": 0
+    },
+    {
+      "selector": ".message-stream-state.sending::before",
+      "prop": "background",
+      "literal": "#d99a17",
+      "n": 0
+    },
+    {
+      "selector": ".message-stream-state.sending::before",
+      "prop": "box-shadow",
+      "literal": "rgba(217, 154, 23, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-actions button",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-actions button.danger",
+      "prop": "background",
+      "literal": "rgba(255, 59, 48, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-actions button.danger",
+      "prop": "color",
+      "literal": "#d70015",
+      "n": 0
+    },
+    {
+      "selector": ".modal-actions button.primary",
+      "prop": "color",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".modal-backdrop",
+      "prop": "background",
+      "literal": "rgba(17, 24, 39, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-card",
+      "prop": "background",
+      "literal": "rgba(250, 251, 253, 0.98)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-card",
+      "prop": "border",
+      "literal": "rgba(255, 255, 255, 0.72)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-card",
+      "prop": "box-shadow",
+      "literal": "rgba(15, 23, 42, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-close",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-field-error",
+      "prop": "color",
+      "literal": "#c91810",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form .agent-select-control select",
+      "prop": "background",
+      "literal": "#f6f7f9",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form .agent-select-control select",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form .agent-select-control select",
+      "prop": "border-color",
+      "literal": "rgba(20, 23, 31, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form .agent-select-control select",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.05)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form .agent-select-control select",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.82)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form .agent-select-control select",
+      "prop": "color",
+      "literal": "#20242b",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form .agent-select-control select:focus",
+      "prop": "border-color",
+      "literal": "rgba(20, 23, 31, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form .agent-select-control select:focus",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form .agent-select-control select:focus",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.82)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form .agent-select-control select:hover",
+      "prop": "background",
+      "literal": "#f6f7f9",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form .agent-select-control select:hover",
+      "prop": "background",
+      "literal": "#ffffff",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form .agent-select-control select:hover",
+      "prop": "border-color",
+      "literal": "rgba(20, 23, 31, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form .modal-member-editor label:hover",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.07)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form input[aria-invalid=\"true\"], .modal-form textarea[aria-invalid=\"true\"]",
+      "prop": "border-color",
+      "literal": "rgba(255, 59, 48, 0.72)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-form input[aria-invalid=\"true\"], .modal-form textarea[aria-invalid=\"true\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 59, 48, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-head",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.72)",
+      "n": 0
+    },
+    {
+      "selector": ".modal-member-editor",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".performance-card",
+      "prop": "background",
+      "literal": "rgba(248, 249, 251, 0.74)",
+      "n": 0
+    },
+    {
+      "selector": ".performance-card",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.92)",
+      "n": 0
+    },
+    {
+      "selector": ".performance-card",
+      "prop": "border",
+      "literal": "rgba(118, 118, 128, 0.13)",
+      "n": 0
+    },
+    {
+      "selector": ".performance-card small",
+      "prop": "color",
+      "literal": "#6b7280",
+      "n": 0
+    },
+    {
+      "selector": ".performance-card span",
+      "prop": "color",
+      "literal": "#8e8e93",
+      "n": 0
+    },
+    {
+      "selector": ".performance-card strong",
+      "prop": "color",
+      "literal": "#111827",
+      "n": 0
+    },
+    {
+      "selector": ".phase-badge",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".phase-badge.phase-acting, .phase-badge.phase-event, .phase-badge.phase-message, .phase-badge.phase-task",
+      "prop": "background",
+      "literal": "rgba(52, 199, 89, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".phase-badge.phase-acting, .phase-badge.phase-event, .phase-badge.phase-message, .phase-badge.phase-task",
+      "prop": "color",
+      "literal": "#167d32",
+      "n": 0
+    },
+    {
+      "selector": ".phase-badge.phase-command",
+      "prop": "background",
+      "literal": "rgba(255, 159, 10, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": ".phase-badge.phase-command",
+      "prop": "color",
+      "literal": "#9a5a00",
+      "n": 0
+    },
+    {
+      "selector": ".phase-badge.phase-error, .phase-badge.phase-event_error, .phase-badge.phase-run_error",
+      "prop": "background",
+      "literal": "rgba(255, 69, 58, 0.15)",
+      "n": 0
+    },
+    {
+      "selector": ".phase-badge.phase-error, .phase-badge.phase-event_error, .phase-badge.phase-run_error",
+      "prop": "color",
+      "literal": "#c91810",
+      "n": 0
+    },
+    {
+      "selector": ".phase-badge.phase-file_edit",
+      "prop": "background",
+      "literal": "rgba(191, 90, 242, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".phase-badge.phase-file_edit",
+      "prop": "color",
+      "literal": "#7b2cbf",
+      "n": 0
+    },
+    {
+      "selector": ".phase-badge.phase-thinking",
+      "prop": "background",
+      "literal": "rgba(90, 200, 250, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".phase-badge.phase-thinking",
+      "prop": "color",
+      "literal": "#0071a8",
+      "n": 0
+    },
+    {
+      "selector": ".phase-badge.phase-tools",
+      "prop": "background",
+      "literal": "rgba(255, 159, 10, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": ".phase-badge.phase-tools",
+      "prop": "color",
+      "literal": "#9a5a00",
+      "n": 0
+    },
+    {
+      "selector": ".profile-main:hover, .profile-main:focus-visible, .profile-settings:hover, .profile-settings:focus-visible",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.06)",
+      "n": 0
+    },
+    {
+      "selector": ".profile-settings",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.44)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-create",
+      "prop": "background",
+      "literal": "rgba(0, 122, 255, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-create",
+      "prop": "background",
+      "literal": "rgba(244, 247, 251, 0.88)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-create",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.95)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-create",
+      "prop": "border",
+      "literal": "rgba(255, 255, 255, 0.76)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-create",
+      "prop": "box-shadow",
+      "literal": "rgba(15, 23, 42, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-create",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.74)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-create input, .reminder-create textarea, .reminder-create select",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.92)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-create input, .reminder-create textarea, .reminder-create select",
+      "prop": "border",
+      "literal": "rgba(142, 142, 147, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-create input:focus, .reminder-create textarea:focus, .reminder-create select:focus",
+      "prop": "border-color",
+      "literal": "rgba(0, 122, 255, 0.42)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-create input:focus, .reminder-create textarea:focus, .reminder-create select:focus",
+      "prop": "box-shadow",
+      "literal": "rgba(0, 122, 255, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-icon, .reminder-row-icon",
+      "prop": "background",
+      "literal": "rgba(0, 122, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-icon, .reminder-row-icon",
+      "prop": "color",
+      "literal": "#006edb",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-quick-grid button",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.72)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-quick-grid button",
+      "prop": "border",
+      "literal": "rgba(142, 142, 147, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-row",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.9)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-row",
+      "prop": "box-shadow",
+      "literal": "rgba(15, 23, 42, 0.04)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-row p",
+      "prop": "color",
+      "literal": "#4b4d55",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-row-icon",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.11)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-row.fired",
+      "prop": "background",
+      "literal": "rgba(255, 249, 237, 0.96)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-row.fired",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.92)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-row.fired",
+      "prop": "border-color",
+      "literal": "rgba(255, 149, 0, 0.26)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-status",
+      "prop": "background",
+      "literal": "rgba(0, 122, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-status",
+      "prop": "color",
+      "literal": "#006edb",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-status.due",
+      "prop": "background",
+      "literal": "rgba(255, 149, 0, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-status.due",
+      "prop": "color",
+      "literal": "#b75d00",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-summary div",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.76)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-thread-toggle",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.58)",
+      "n": 0
+    },
+    {
+      "selector": ".reminder-thread-toggle",
+      "prop": "border",
+      "literal": "rgba(142, 142, 147, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".reply-composer",
+      "prop": "box-shadow",
+      "literal": "rgba(0, 0, 0, 0.035)",
+      "n": 0
+    },
+    {
+      "selector": ".reply-composer .reply-send",
+      "prop": "background",
+      "literal": "#20242b",
+      "n": 0
+    },
+    {
+      "selector": ".reply-composer .reply-send",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.2)",
+      "n": 0
+    },
+    {
+      "selector": ".reply-composer .reply-send",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".reply-composer .reply-send",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".reply-composer .reply-send",
+      "prop": "color",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".reply-list article:hover",
+      "prop": "background",
+      "literal": "rgba(246, 247, 249, 0.92)",
+      "n": 0
+    },
+    {
+      "selector": ".runtime-preflight",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".runtime-preflight",
+      "prop": "border",
+      "literal": "rgba(142, 142, 147, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".runtime-preflight.missing",
+      "prop": "background",
+      "literal": "rgba(255, 149, 0, 0.09)",
+      "n": 0
+    },
+    {
+      "selector": ".runtime-preflight.missing",
+      "prop": "border-color",
+      "literal": "rgba(255, 149, 0, 0.28)",
+      "n": 0
+    },
+    {
+      "selector": ".runtime-preflight.missing strong",
+      "prop": "color",
+      "literal": "#9a5a00",
+      "n": 0
+    },
+    {
+      "selector": ".runtime-preflight.ok",
+      "prop": "background",
+      "literal": "rgba(52, 199, 89, 0.09)",
+      "n": 0
+    },
+    {
+      "selector": ".runtime-preflight.ok",
+      "prop": "border-color",
+      "literal": "rgba(52, 199, 89, 0.24)",
+      "n": 0
+    },
+    {
+      "selector": ".search-backdrop",
+      "prop": "background",
+      "literal": "rgba(246, 247, 249, 0.7)",
+      "n": 0
+    },
+    {
+      "selector": ".search-clear",
+      "prop": "background",
+      "literal": "#f6f7f9",
+      "n": 0
+    },
+    {
+      "selector": ".search-clear",
+      "prop": "background",
+      "literal": "#ffffff",
+      "n": 0
+    },
+    {
+      "selector": ".search-clear",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".search-clear",
+      "prop": "color",
+      "literal": "#656c78",
+      "n": 0
+    },
+    {
+      "selector": ".search-clear:hover",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".search-clear:hover",
+      "prop": "color",
+      "literal": "#20242b",
+      "n": 0
+    },
+    {
+      "selector": ".search-filter-group button, .search-time-filter",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".search-filter-group button, .search-time-filter",
+      "prop": "border",
+      "literal": "rgba(142, 142, 147, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".search-filter-group button.active",
+      "prop": "background",
+      "literal": "#eef0f4",
+      "n": 0
+    },
+    {
+      "selector": ".search-filter-group button.active",
+      "prop": "border-color",
+      "literal": "rgba(20, 23, 31, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".search-filter-group button.active",
+      "prop": "color",
+      "literal": "#20242b",
+      "n": 0
+    },
+    {
+      "selector": ".search-filters",
+      "prop": "background",
+      "literal": "rgba(248, 249, 251, 0.86)",
+      "n": 0
+    },
+    {
+      "selector": ".search-input-icon",
+      "prop": "background",
+      "literal": "#f6f7f9",
+      "n": 0
+    },
+    {
+      "selector": ".search-input-icon",
+      "prop": "background",
+      "literal": "#ffffff",
+      "n": 0
+    },
+    {
+      "selector": ".search-input-icon",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.04)",
+      "n": 0
+    },
+    {
+      "selector": ".search-input-icon",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".search-input-icon",
+      "prop": "color",
+      "literal": "#5f6672",
+      "n": 0
+    },
+    {
+      "selector": ".search-panel",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.96)",
+      "n": 0
+    },
+    {
+      "selector": ".search-result-fallback-avatar",
+      "prop": "background",
+      "literal": "#eef0f4",
+      "n": 0
+    },
+    {
+      "selector": ".search-result-fallback-avatar",
+      "prop": "color",
+      "literal": "#555a66",
+      "n": 0
+    },
+    {
+      "selector": ".search-result-list button:hover",
+      "prop": "background",
+      "literal": "rgba(248, 248, 248, 0.72)",
+      "n": 0
+    },
+    {
+      "selector": ".search-result-list mark",
+      "prop": "background",
+      "literal": "rgba(255, 214, 10, 0.45)",
+      "n": 0
+    },
+    {
+      "selector": ".search-result-list p",
+      "prop": "color",
+      "literal": "#1d1c1d",
+      "n": 0
+    },
+    {
+      "selector": ".search-result-list strong",
+      "prop": "color",
+      "literal": "#1d1c1d",
+      "n": 0
+    },
+    {
+      "selector": ".search-time-chevron",
+      "prop": "color",
+      "literal": "rgba(20, 23, 31, 0.48)",
+      "n": 0
+    },
+    {
+      "selector": ".send",
+      "prop": "background",
+      "literal": "#20242b",
+      "n": 0
+    },
+    {
+      "selector": ".send",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.2)",
+      "n": 0
+    },
+    {
+      "selector": ".send",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".send",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".send",
+      "prop": "color",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".send:hover:not(:disabled), .reply-composer .reply-send:hover:not(:disabled)",
+      "prop": "background",
+      "literal": "#111318",
+      "n": 0
+    },
+    {
+      "selector": ".sidebar-empty-cta button",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".sidebar-empty-cta button",
+      "prop": "border",
+      "literal": "rgba(10, 132, 255, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".sidebar-empty-cta button",
+      "prop": "color",
+      "literal": "#1262b3",
+      "n": 0
+    },
+    {
+      "selector": ".sidebar-empty-cta button:hover, .sidebar-empty-cta button:focus-visible",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.15)",
+      "n": 0
+    },
+    {
+      "selector": ".sidebar-empty-cta button:hover, .sidebar-empty-cta button:focus-visible",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.34)",
+      "n": 0
+    },
+    {
+      "selector": ".sidebar-empty-cta button:hover, .sidebar-empty-cta button:focus-visible",
+      "prop": "color",
+      "literal": "#075aa5",
+      "n": 0
+    },
+    {
+      "selector": ".sidebar-nav-trigger.active",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".sidebar-nav-trigger.active",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.24)",
+      "n": 0
+    },
+    {
+      "selector": ".sidebar-resize-handle::after",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0)",
+      "n": 0
+    },
+    {
+      "selector": ".sidebar-resize-handle:hover::after, .sidebar-resize-handle:focus-visible::after",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.48)",
+      "n": 0
+    },
+    {
+      "selector": ".sidebar-section-resize-handle::after",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0)",
+      "n": 0
+    },
+    {
+      "selector": ".sidebar-section-resize-handle::before",
+      "prop": "background",
+      "literal": "rgba(20, 23, 31, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".sidebar-section-resize-handle:hover::after, .sidebar-section-resize-handle:focus-visible::after",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.5)",
+      "n": 0
+    },
+    {
+      "selector": ".status-row",
+      "prop": "background",
+      "literal": "rgba(20, 23, 31, 0.04)",
+      "n": 0
+    },
+    {
+      "selector": ".status-row button.active",
+      "prop": "box-shadow",
+      "literal": "rgba(10, 132, 255, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".status-row button.active",
+      "prop": "color",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".system-message-line",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".system-message-line",
+      "prop": "border",
+      "literal": "rgba(142, 142, 147, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".system-message-line",
+      "prop": "color",
+      "literal": "#6b7280",
+      "n": 0
+    },
+    {
+      "selector": ".system-message-line time",
+      "prop": "color",
+      "literal": "#9ca3af",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-menu",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-option-copy span b",
+      "prop": "color",
+      "literal": "rgba(20, 23, 31, 0.28)",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-option:hover, .task-assignee-option[aria-selected=\"true\"]",
+      "prop": "background",
+      "literal": "#f6f7f9",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-option:hover, .task-assignee-option[aria-selected=\"true\"]",
+      "prop": "background",
+      "literal": "#ffffff",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-option:hover, .task-assignee-option[aria-selected=\"true\"]",
+      "prop": "border-color",
+      "literal": "rgba(20, 23, 31, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-option:hover, .task-assignee-option[aria-selected=\"true\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.05)",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-option:hover, .task-assignee-option[aria-selected=\"true\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.82)",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-option[aria-selected=\"true\"]",
+      "prop": "color",
+      "literal": "#20242b",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-trigger:focus-visible",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.34)",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-trigger:focus-visible",
+      "prop": "box-shadow",
+      "literal": "rgba(10, 132, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-trigger:hover, .task-assignee-trigger[aria-expanded=\"true\"]",
+      "prop": "background",
+      "literal": "#f6f7f9",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-trigger:hover, .task-assignee-trigger[aria-expanded=\"true\"]",
+      "prop": "background",
+      "literal": "#ffffff",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-trigger:hover, .task-assignee-trigger[aria-expanded=\"true\"]",
+      "prop": "border-color",
+      "literal": "rgba(20, 23, 31, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-trigger:hover, .task-assignee-trigger[aria-expanded=\"true\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.05)",
+      "n": 0
+    },
+    {
+      "selector": ".task-assignee-trigger:hover, .task-assignee-trigger[aria-expanded=\"true\"]",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.82)",
+      "n": 0
+    },
+    {
+      "selector": ".task-board",
+      "prop": "background",
+      "literal": "#f7f8fa",
+      "n": 0
+    },
+    {
+      "selector": ".task-board-summary > div",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".task-card",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".task-card input, .thread-task-card input, .thread-task-card select",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.78)",
+      "n": 0
+    },
+    {
+      "selector": ".task-card-head strong",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.09)",
+      "n": 0
+    },
+    {
+      "selector": ".task-card.unassigned",
+      "prop": "border-color",
+      "literal": "rgba(255, 149, 0, 0.32)",
+      "n": 0
+    },
+    {
+      "selector": ".task-execution-head strong",
+      "prop": "color",
+      "literal": "#172033",
+      "n": 0
+    },
+    {
+      "selector": ".task-execution-panel",
+      "prop": "border-top",
+      "literal": "rgba(10, 132, 255, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".task-execution-row p, .task-execution-empty",
+      "prop": "color",
+      "literal": "#7b7b81",
+      "n": 0
+    },
+    {
+      "selector": ".task-execution-row small",
+      "prop": "color",
+      "literal": "#7b7b81",
+      "n": 0
+    },
+    {
+      "selector": ".task-execution-row strong",
+      "prop": "color",
+      "literal": "#172033",
+      "n": 0
+    },
+    {
+      "selector": ".task-execution-row time",
+      "prop": "color",
+      "literal": "#8e8e93",
+      "n": 0
+    },
+    {
+      "selector": ".task-open-thread",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".task-queue-heading mark",
+      "prop": "background",
+      "literal": "rgba(20, 23, 31, 0.07)",
+      "n": 0
+    },
+    {
+      "selector": ".task-queue-section.unassigned",
+      "prop": "background",
+      "literal": "rgba(255, 250, 242, 0.78)",
+      "n": 0
+    },
+    {
+      "selector": ".task-queue-section.unassigned",
+      "prop": "border",
+      "literal": "rgba(255, 149, 0, 0.3)",
+      "n": 0
+    },
+    {
+      "selector": ".task-queue-section.unassigned .task-queue-heading mark",
+      "prop": "background",
+      "literal": "rgba(255, 149, 0, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".task-queue-section.unassigned .task-queue-heading mark",
+      "prop": "color",
+      "literal": "#a35b00",
+      "n": 0
+    },
+    {
+      "selector": ".task-review-actions button",
+      "prop": "border",
+      "literal": "rgba(10, 132, 255, 0.2)",
+      "n": 0
+    },
+    {
+      "selector": ".task-review-actions button:first-child",
+      "prop": "border-color",
+      "literal": "rgba(52, 199, 89, 0.24)",
+      "n": 0
+    },
+    {
+      "selector": ".task-review-actions button:first-child",
+      "prop": "color",
+      "literal": "#167a36",
+      "n": 0
+    },
+    {
+      "selector": ".task-toggle",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.04)",
+      "n": 0
+    },
+    {
+      "selector": ".task-toggle",
+      "prop": "box-shadow",
+      "literal": "rgba(255, 255, 255, 0.78)",
+      "n": 0
+    },
+    {
+      "selector": ".task-toggle.active",
+      "prop": "background",
+      "literal": "#d6f3e0",
+      "n": 0
+    },
+    {
+      "selector": ".task-toggle.active",
+      "prop": "border-color",
+      "literal": "rgba(21, 128, 61, 0.55)",
+      "n": 0
+    },
+    {
+      "selector": ".task-toggle.active",
+      "prop": "box-shadow",
+      "literal": "rgba(21, 128, 61, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".task-toggle.active",
+      "prop": "box-shadow",
+      "literal": "rgba(21, 128, 61, 0.22)",
+      "n": 0
+    },
+    {
+      "selector": ".task-toggle.active",
+      "prop": "color",
+      "literal": "#0f5f2c",
+      "n": 0
+    },
+    {
+      "selector": ".task-toggle.active:hover:not(:disabled)",
+      "prop": "background",
+      "literal": "#c6ecd3",
+      "n": 0
+    },
+    {
+      "selector": ".task-toggle.active:hover:not(:disabled)",
+      "prop": "border-color",
+      "literal": "rgba(21, 128, 61, 0.7)",
+      "n": 0
+    },
+    {
+      "selector": ".task-toggle.active:hover:not(:disabled)",
+      "prop": "color",
+      "literal": "#0c5026",
+      "n": 0
+    },
+    {
+      "selector": ".task-unassigned-avatar",
+      "prop": "background",
+      "literal": "rgba(20, 23, 31, 0.02)",
+      "n": 0
+    },
+    {
+      "selector": ".task-unassigned-avatar",
+      "prop": "background",
+      "literal": "rgba(20, 23, 31, 0.07)",
+      "n": 0
+    },
+    {
+      "selector": ".task-unassigned-avatar",
+      "prop": "border",
+      "literal": "rgba(20, 23, 31, 0.2)",
+      "n": 0
+    },
+    {
+      "selector": ".theme-choice-grid button.selected",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".theme-choice-grid button.selected",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": ".theme-choice-grid button.selected",
+      "prop": "box-shadow",
+      "literal": "rgba(10, 132, 255, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-back-to-bottom",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.94)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-back-to-bottom",
+      "prop": "border",
+      "literal": "rgba(10, 132, 255, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-back-to-bottom",
+      "prop": "box-shadow",
+      "literal": "rgba(15, 23, 42, 0.13)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-back-to-bottom:hover",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".thread-browser-follow",
+      "prop": "background",
+      "literal": "rgba(52, 199, 89, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-browser-follow",
+      "prop": "color",
+      "literal": "#168a36",
+      "n": 0
+    },
+    {
+      "selector": ".thread-browser-follow:hover",
+      "prop": "background",
+      "literal": "rgba(255, 59, 48, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-browser-follow:hover",
+      "prop": "color",
+      "literal": "#d70015",
+      "n": 0
+    },
+    {
+      "selector": ".thread-browser-panel",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.96)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-browser-row",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": ".thread-browser-row",
+      "prop": "border",
+      "literal": "rgba(142, 142, 147, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-browser-row:hover, .thread-browser-row.selected",
+      "prop": "background",
+      "literal": "rgba(248, 249, 251, 0.94)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-browser-row:hover, .thread-browser-row.selected",
+      "prop": "border-color",
+      "literal": "rgba(20, 23, 31, 0.16)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-browser-row:hover, .thread-browser-row.selected",
+      "prop": "box-shadow",
+      "literal": "rgba(15, 23, 42, 0.06)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-browser-row.has-unread",
+      "prop": "border-color",
+      "literal": "rgba(20, 23, 31, 0.2)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-replies-divider > span",
+      "prop": "background",
+      "literal": "rgba(20, 23, 31, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-replies-divider small",
+      "prop": "color",
+      "literal": "rgba(102, 112, 133, 0.82)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-avatars .agent-avatar, .thread-reply-fallback-avatar",
+      "prop": "border",
+      "literal": "#fbfbfc",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-avatars .agent-avatar, .thread-reply-fallback-avatar",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-fallback-avatar",
+      "prop": "background",
+      "literal": "#eef0f4",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-fallback-avatar",
+      "prop": "color",
+      "literal": "#555a66",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-summary .thread-reply-avatars .agent-avatar, .thread-reply-summary .thread-reply-fallback-avatar",
+      "prop": "border-color",
+      "literal": "#ffffff",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-summary-action time",
+      "prop": "color",
+      "literal": "#8f8f95",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-summary-icon",
+      "prop": "color",
+      "literal": "#8e939b",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-summary-open",
+      "prop": "color",
+      "literal": "#686d76",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-summary-status",
+      "prop": "color",
+      "literal": "#4f5560",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-summary:focus-visible",
+      "prop": "border-color",
+      "literal": "rgba(30, 111, 201, 0.36)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-summary:focus-visible",
+      "prop": "box-shadow",
+      "literal": "rgba(30, 111, 201, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-summary:hover",
+      "prop": "border-color",
+      "literal": "rgba(30, 111, 201, 0.28)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-summary:hover",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-summary.active-reply",
+      "prop": "color",
+      "literal": "#4f5560",
+      "n": 0
+    },
+    {
+      "selector": ".thread-reply-summary.active-reply strong",
+      "prop": "color",
+      "literal": "#1f7a4d",
+      "n": 0
+    },
+    {
+      "selector": ".thread-resize-handle::after",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-resize-handle:hover::after, .thread-resize-handle:focus-visible::after",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.48)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-root.tap-focused, .reply-list article.tap-focused",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.07)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-root.tap-focused, .reply-list article.tap-focused",
+      "prop": "border-color",
+      "literal": "rgba(10, 132, 255, 0.34)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-root.tap-focused, .reply-list article.tap-focused",
+      "prop": "box-shadow",
+      "literal": "rgba(10, 132, 255, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-task-card",
+      "prop": "background",
+      "literal": "rgba(228, 241, 255, 0.62)",
+      "n": 0
+    },
+    {
+      "selector": ".thread-task-card",
+      "prop": "border",
+      "literal": "rgba(10, 132, 255, 0.2)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-entry-kind",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-entry-kind.kind-dir",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-error",
+      "prop": "background",
+      "literal": "rgba(255, 69, 58, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-error",
+      "prop": "color",
+      "literal": "#c91810",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-path-card, .workspace-memory-card",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.74)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-path-card, .workspace-memory-card",
+      "prop": "border",
+      "literal": "rgba(118, 118, 128, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-preview",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.82)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-preview",
+      "prop": "border",
+      "literal": "rgba(10, 132, 255, 0.14)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-preview-head button",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-preview-raw",
+      "prop": "background",
+      "literal": "#111827",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-preview-raw",
+      "prop": "color",
+      "literal": "#f9fafb",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-row-action",
+      "prop": "background",
+      "literal": "rgba(142, 142, 147, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-section",
+      "prop": "background",
+      "literal": "rgba(248, 249, 251, 0.76)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-section",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.8)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-section",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.9)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-section",
+      "prop": "border",
+      "literal": "rgba(118, 118, 128, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-section",
+      "prop": "box-shadow",
+      "literal": "rgba(32, 36, 44, 0.04)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-switch",
+      "prop": "box-shadow",
+      "literal": "rgba(15, 23, 42, 0.06)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-tree",
+      "prop": "background",
+      "literal": "rgba(255, 255, 255, 0.58)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-tree",
+      "prop": "border",
+      "literal": "rgba(118, 118, 128, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-tree-children",
+      "prop": "border-bottom",
+      "literal": "rgba(118, 118, 128, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-tree-row",
+      "prop": "border-bottom",
+      "literal": "rgba(118, 118, 128, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-tree-row:hover, .workspace-tree-row.selected",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.07)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-tree-row.is-dir .workspace-row-action",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-tree-row.is-dir:hover .workspace-disclosure",
+      "prop": "background",
+      "literal": "rgba(10, 132, 255, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-tree-row.is-file .workspace-entry-kind",
+      "prop": "background",
+      "literal": "rgba(52, 199, 89, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-tree-row.is-file .workspace-entry-kind",
+      "prop": "color",
+      "literal": "#167d32",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-tree-row.is-file:hover .workspace-row-action, .workspace-tree-row.selected .workspace-row-action",
+      "prop": "background",
+      "literal": "rgba(52, 199, 89, 0.13)",
+      "n": 0
+    },
+    {
+      "selector": ".workspace-tree-row.is-file:hover .workspace-row-action, .workspace-tree-row.selected .workspace-row-action",
+      "prop": "color",
+      "literal": "#167d32",
+      "n": 0
+    },
+    {
+      "selector": "@container conversation (max-width: 420px) >> .message-card .message-hover-actions",
+      "prop": "border-color",
+      "literal": "rgba(20, 23, 31, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": "@container thread (max-width: 420px) >> .thread .message-hover-actions",
+      "prop": "border-color",
+      "literal": "rgba(20, 23, 31, 0.1)",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .activity-feed-body",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .activity-feed-row",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .activity-feed-row-shell",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .activity-feed-row-shell.swiping",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .activity-feed-swipe-action",
+      "prop": "background",
+      "literal": "#ff3b30",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .activity-feed-swipe-action",
+      "prop": "color",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .mobile-bottom-nav",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.08)",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .mobile-bottom-nav",
+      "prop": "box-shadow",
+      "literal": "rgba(20, 23, 31, 0.18)",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .mobile-bottom-nav strong",
+      "prop": "background",
+      "literal": "#ff3b30",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .mobile-bottom-nav strong",
+      "prop": "color",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .mobile-message-save-tag",
+      "prop": "border",
+      "literal": "rgba(138, 91, 0, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .search-backdrop",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .search-filters",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .search-panel",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .search-panel-body",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .search-panel-head",
+      "prop": "background",
+      "literal": "#fff",
+      "n": 0
+    },
+    {
+      "selector": "@media (max-width: 760px) >> .search-panel-head input",
+      "prop": "background",
+      "literal": "#f6f7f9",
+      "n": 0
+    },
+    {
+      "selector": "@media (min-width: 761px) and (max-width: 1100px) >> .thread, .agent-drawer",
+      "prop": "border-left",
+      "literal": "rgba(20, 23, 31, 0.12)",
+      "n": 0
+    },
+    {
+      "selector": "mark",
+      "prop": "background",
+      "literal": "#dfff9a",
+      "n": 0
+    },
+    {
+      "selector": "mark",
+      "prop": "color",
+      "literal": "#2e5200",
+      "n": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Mechanical CI gate that prevents new raw color literals (`#fff`, `rgba(255,255,255,…)`, named colors, etc.) from landing in `src/styles.css`. Every recent dark-theme bug — artifact card, agent profile drawer — followed the same pattern: a new component shipped with a hardcoded light color, then got patched via `:root[data-theme="dark"]` overrides. This PR makes that pattern fail CI instead of slip through.

PR-B in the plan agreed earlier in #lantor (PR-A is #36 — agent profile token migration, owned by @Dylan; this PR is independent and does not stack).

## How it works

- **`scripts/check-raw-colors.mjs`** walks `src/styles.css`, parses every rule body (handles nested at-rules), and extracts every color literal from declarations whose property is color-bearing (`color`, `background`, `background-color`, `border-color`, `box-shadow`, `text-shadow`, etc.).
- Detects: `#hex` (3/4/6/8), `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()`, `lab()`, `lch()`, `oklab()`, `oklch()`, `color()`, and the full CSS named color set.
- Excludes: `currentColor`, `transparent`, `inherit`, `initial`, `unset`, `revert`, `none`. `var(--…)` references are inherently safe and never matched.
- **`scripts/styles-raw-color-baseline.json`** captures the **738 raw color fingerprints that exist today**, so this PR itself is non-breaking: existing literals are grandfathered.
- **Fingerprint = `(selector, property, literal, occurrence_index)`**, intentionally NOT line-number-based — formatting changes or unrelated inserts won't churn the baseline. Line numbers are only surfaced in error output for human debugging.

## CI wiring

A new step `Style token gate (no new raw color literals)` runs before `Build frontend` in `.github/workflows/ci.yml`. Also exposed locally as `npm run lint:css-tokens`.

## Failure mode

When a new literal is added (e.g. `.lint-test-block { background: #abcdef; }`):

```
✗ style token gate: new raw color literal(s) detected in src/styles.css.

  Raw color literals should be replaced with semantic CSS tokens
  (e.g. var(--bg-panel), var(--ink-primary), var(--border-subtle)) so
  light and dark themes resolve from a single source of truth.

  src/styles.css:9086
    selector : .lint-test-block
    property : background
    literal  : #abcdef

  If this literal is truly unavoidable, add it explicitly by running:
    npm run lint:css-tokens -- --update-baseline
  and including the resulting baseline diff in your PR with justification.
```

Escape hatch (`--update-baseline`) is intentional but loud: a reviewer sees the baseline diff and asks "why is this needed instead of a token?".

## Migration path

Each future PR that migrates a component to tokens (agent profile, sidebar, thread, modal, …) should:

1. Replace the literal in `src/styles.css` with `var(--…)`.
2. Pop the matching entries from `scripts/styles-raw-color-baseline.json` (the script also flags stale entries automatically).

**Shrinking the baseline is the progress metric** toward full color-token unification. When the baseline file is empty, the codebase no longer needs `:root[data-theme="dark"]` overrides for color — light and dark are decided entirely by token aliasing in `:root` / `:root[data-theme="dark"]` variable declarations.

## Verification

- `npm run lint:css-tokens` → `✓ style token gate: 738 known raw color literal(s); none new.`
- Injected a synthetic violation `.lint-test-block { background: #abcdef; }` → fails with selector / property / literal / line surfaced. Reverted → passes.
- `npm run build` ✅
- `git diff --check` ✅

## Note unrelated to this PR

While building this, I noticed **PR #33 (`Add theme token contract`) is not in `main`**:

- `gh pr view 33` reports `state: MERGED` and `mergedAt: 2026-05-21T10:24:19Z`.
- But its **base was `ui-theme-preview-polish`, not `main`**.
- `#32` was squash-merged into `main` at `10:24:00Z` (commit `507e2d3`); `#33` was then squash-merged into `ui-theme-preview-polish` 19s later, producing `562561e` on a branch that no longer feeds main.
- Result: `docs/theme-tokens.md` and the new `--surface-*` / `--ink-on-*` / `--border-*` / `--state-*` / `--status-*` / `--badge-*` token contract from #33 **never reached `main`**. The `theme-token-contract` branch still exists on origin (`3980e17`).

Flagging here so it can be re-opened as a follow-up PR off `main`. This gate works without #33 (it points users to the older `--bg-*` / `--ink-*` / `--border-*` tokens that DO live in main from #32), but the full token contract from #33 needs to land before broader migration PRs can reference its richer vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)