### PR TITLE
Tokenize DM row selected and hover colors

### DIFF
--- a/scripts/styles-raw-color-baseline.json
+++ b/scripts/styles-raw-color-baseline.json
@@ -1305,78 +1305,6 @@
       "n": 1
     },
     {
-      "selector": ".agent-detail-hero",
-      "prop": "background",
-      "literal": "rgba(10, 132, 255, 0.17)",
-      "n": 0
-    },
-    {
-      "selector": ".agent-detail-hero",
-      "prop": "background",
-      "literal": "rgba(248, 249, 251, 0.82)",
-      "n": 0
-    },
-    {
-      "selector": ".agent-detail-hero",
-      "prop": "background",
-      "literal": "rgba(255, 255, 255, 0.96)",
-      "n": 0
-    },
-    {
-      "selector": ".agent-detail-hero",
-      "prop": "background",
-      "literal": "rgba(52, 199, 89, 0.13)",
-      "n": 0
-    },
-    {
-      "selector": ".agent-detail-hero",
-      "prop": "border",
-      "literal": "rgba(118, 118, 128, 0.14)",
-      "n": 0
-    },
-    {
-      "selector": ".agent-detail-hero",
-      "prop": "box-shadow",
-      "literal": "rgba(32, 36, 44, 0.08)",
-      "n": 0
-    },
-    {
-      "selector": ".agent-detail-tab:hover",
-      "prop": "background",
-      "literal": "rgba(255, 255, 255, 0.78)",
-      "n": 0
-    },
-    {
-      "selector": ".agent-detail-tab.active",
-      "prop": "background",
-      "literal": "#fff",
-      "n": 0
-    },
-    {
-      "selector": ".agent-detail-tab.active",
-      "prop": "box-shadow",
-      "literal": "rgba(32, 36, 44, 0.08)",
-      "n": 0
-    },
-    {
-      "selector": ".agent-detail-tabs",
-      "prop": "background",
-      "literal": "rgba(255, 255, 255, 0.68)",
-      "n": 0
-    },
-    {
-      "selector": ".agent-detail-tabs",
-      "prop": "border",
-      "literal": "rgba(118, 118, 128, 0.12)",
-      "n": 0
-    },
-    {
-      "selector": ".agent-detail-tabs",
-      "prop": "box-shadow",
-      "literal": "rgba(255, 255, 255, 0.68)",
-      "n": 0
-    },
-    {
       "selector": ".agent-drawer-head button:hover",
       "prop": "background",
       "literal": "rgba(10, 132, 255, 0.1)",
@@ -2001,18 +1929,6 @@
       "n": 0
     },
     {
-      "selector": ".channel.selected",
-      "prop": "box-shadow",
-      "literal": "rgba(20, 23, 31, 0.05)",
-      "n": 0
-    },
-    {
-      "selector": ".channel.selected",
-      "prop": "box-shadow",
-      "literal": "rgba(255, 255, 255, 0.82)",
-      "n": 0
-    },
-    {
       "selector": ".code-block-shell button",
       "prop": "background",
       "literal": "rgba(255, 255, 255, 0.1)",
@@ -2118,54 +2034,6 @@
       "selector": ".detail-work-actions button.danger",
       "prop": "color",
       "literal": "#c91810",
-      "n": 0
-    },
-    {
-      "selector": ".dm-row:hover",
-      "prop": "background",
-      "literal": "rgba(10, 132, 255, 0.055)",
-      "n": 0
-    },
-    {
-      "selector": ".dm-row:hover .dm-detail-trigger, .dm-row:focus-within .dm-detail-trigger, .dm-detail-trigger:hover, .dm-detail-trigger:focus-visible",
-      "prop": "background",
-      "literal": "rgba(246, 247, 249, 0.9)",
-      "n": 0
-    },
-    {
-      "selector": ".dm-row:hover .dm-detail-trigger, .dm-row:focus-within .dm-detail-trigger, .dm-detail-trigger:hover, .dm-detail-trigger:focus-visible",
-      "prop": "background",
-      "literal": "rgba(255, 255, 255, 0.94)",
-      "n": 0
-    },
-    {
-      "selector": ".dm-row:hover .dm-detail-trigger, .dm-row:focus-within .dm-detail-trigger, .dm-detail-trigger:hover, .dm-detail-trigger:focus-visible",
-      "prop": "border-color",
-      "literal": "rgba(10, 132, 255, 0.22)",
-      "n": 0
-    },
-    {
-      "selector": ".dm-row:hover .dm-detail-trigger, .dm-row:focus-within .dm-detail-trigger, .dm-detail-trigger:hover, .dm-detail-trigger:focus-visible",
-      "prop": "box-shadow",
-      "literal": "rgba(20, 23, 31, 0.08)",
-      "n": 0
-    },
-    {
-      "selector": ".dm-row:hover .dm-detail-trigger, .dm-row:focus-within .dm-detail-trigger, .dm-detail-trigger:hover, .dm-detail-trigger:focus-visible",
-      "prop": "box-shadow",
-      "literal": "rgba(255, 255, 255, 0.76)",
-      "n": 0
-    },
-    {
-      "selector": ".dm.selected .dm-badge, .dm-row.selected .dm .dm-badge",
-      "prop": "background",
-      "literal": "rgba(10, 132, 255, 0.1)",
-      "n": 0
-    },
-    {
-      "selector": ".dm.selected .dm-badge, .dm-row.selected .dm .dm-badge",
-      "prop": "color",
-      "literal": "#0a84ff",
       "n": 0
     },
     {
@@ -2922,84 +2790,6 @@
       "selector": ".performance-card strong",
       "prop": "color",
       "literal": "#111827",
-      "n": 0
-    },
-    {
-      "selector": ".phase-badge",
-      "prop": "background",
-      "literal": "rgba(142, 142, 147, 0.12)",
-      "n": 0
-    },
-    {
-      "selector": ".phase-badge.phase-acting, .phase-badge.phase-event, .phase-badge.phase-message, .phase-badge.phase-task",
-      "prop": "background",
-      "literal": "rgba(52, 199, 89, 0.16)",
-      "n": 0
-    },
-    {
-      "selector": ".phase-badge.phase-acting, .phase-badge.phase-event, .phase-badge.phase-message, .phase-badge.phase-task",
-      "prop": "color",
-      "literal": "#167d32",
-      "n": 0
-    },
-    {
-      "selector": ".phase-badge.phase-command",
-      "prop": "background",
-      "literal": "rgba(255, 159, 10, 0.18)",
-      "n": 0
-    },
-    {
-      "selector": ".phase-badge.phase-command",
-      "prop": "color",
-      "literal": "#9a5a00",
-      "n": 0
-    },
-    {
-      "selector": ".phase-badge.phase-error, .phase-badge.phase-event_error, .phase-badge.phase-run_error",
-      "prop": "background",
-      "literal": "rgba(255, 69, 58, 0.15)",
-      "n": 0
-    },
-    {
-      "selector": ".phase-badge.phase-error, .phase-badge.phase-event_error, .phase-badge.phase-run_error",
-      "prop": "color",
-      "literal": "#c91810",
-      "n": 0
-    },
-    {
-      "selector": ".phase-badge.phase-file_edit",
-      "prop": "background",
-      "literal": "rgba(191, 90, 242, 0.14)",
-      "n": 0
-    },
-    {
-      "selector": ".phase-badge.phase-file_edit",
-      "prop": "color",
-      "literal": "#7b2cbf",
-      "n": 0
-    },
-    {
-      "selector": ".phase-badge.phase-thinking",
-      "prop": "background",
-      "literal": "rgba(90, 200, 250, 0.16)",
-      "n": 0
-    },
-    {
-      "selector": ".phase-badge.phase-thinking",
-      "prop": "color",
-      "literal": "#0071a8",
-      "n": 0
-    },
-    {
-      "selector": ".phase-badge.phase-tools",
-      "prop": "background",
-      "literal": "rgba(255, 159, 10, 0.18)",
-      "n": 0
-    },
-    {
-      "selector": ".phase-badge.phase-tools",
-      "prop": "color",
-      "literal": "#9a5a00",
       "n": 0
     },
     {

--- a/src/styles.css
+++ b/src/styles.css
@@ -184,6 +184,9 @@ button,
   --state-hover: var(--bg-hover);
   --state-selected: var(--bg-selected-soft);
   --state-active: var(--bg-selected-soft);
+  --state-selected-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.82),
+    0 1px 2px rgba(20, 23, 31, 0.05);
   --state-focus-ring: rgba(10, 132, 255, 0.16);
   --state-danger: var(--status-danger-soft);
   --state-warning: var(--status-warning-soft);
@@ -324,6 +327,9 @@ button,
   --state-hover: var(--bg-hover);
   --state-selected: var(--bg-selected-soft);
   --state-active: var(--bg-selected-soft);
+  --state-selected-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 1px 2px rgba(0, 0, 0, 0.18);
   --state-focus-ring: rgba(105, 170, 252, 0.2);
   --state-danger: var(--status-danger-soft);
   --state-warning: var(--status-warning-soft);
@@ -566,8 +572,7 @@ button,
 }
 
 .quick-actions button:hover,
-.channel:hover,
-.dm:hover {
+.channel:hover {
   background: var(--bg-control-flat);
 }
 
@@ -789,9 +794,7 @@ button,
   border-color: var(--control-border);
   background: var(--bg-control-selected);
   color: var(--ink-control);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.82),
-    0 1px 2px rgba(20, 23, 31, 0.05);
+  box-shadow: var(--state-selected-shadow);
 }
 
 .channel.selected strong {
@@ -824,11 +827,17 @@ button,
   align-items: center;
   column-gap: 8px;
   padding-right: 6px;
+  border: 1px solid transparent;
   border-radius: 15px;
+  background: transparent;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease;
 }
 
 .dm-row:hover {
-  background: rgba(10, 132, 255, 0.055);
+  background: var(--bg-hover);
 }
 
 .dm-row.has-unread:not(.selected) {
@@ -837,9 +846,10 @@ button,
 }
 
 .dm-row.selected {
-  background: transparent;
-  color: inherit;
-  box-shadow: none;
+  border-color: var(--control-border);
+  background: var(--bg-control-selected);
+  color: var(--ink-control);
+  box-shadow: var(--state-selected-shadow);
 }
 
 .dm {
@@ -849,7 +859,6 @@ button,
   align-items: center;
   gap: 8px;
   padding: 9px 4px 9px 0;
-  border-radius: 0 14px 14px 0;
   text-align: left;
 }
 
@@ -894,8 +903,8 @@ button,
 
 .dm.selected .dm-badge,
 .dm-row.selected .dm .dm-badge {
-  background: rgba(10, 132, 255, 0.1);
-  color: #0a84ff;
+  background: var(--badge-bg);
+  color: var(--badge-ink);
 }
 
 .dm-avatar-shell {
@@ -957,15 +966,12 @@ button,
 .dm-row:focus-within .dm-detail-trigger,
 .dm-detail-trigger:hover,
 .dm-detail-trigger:focus-visible {
-  border-color: rgba(10, 132, 255, 0.22);
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(246, 247, 249, 0.9));
+  border-color: var(--state-focus-ring);
+  background: var(--bg-control-selected);
   color: var(--accent);
   opacity: 1;
   transform: translateY(-1px);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.76),
-    0 8px 18px rgba(20, 23, 31, 0.08);
+  box-shadow: var(--state-selected-shadow);
 }
 
 .member-editor {


### PR DESCRIPTION
## Summary

- move agent/DM row hover and selected surfaces onto the parent `.dm-row`
- remove the middle `.dm:hover` background so the left/avatar, center/name, and right/actions areas share one row surface
- reuse semantic tokens for selected row shadow, selected badge color, and detail-button hover state
- refresh the raw color baseline after removing stale literals from #36 plus this row migration

## Verification

- `npm run lint:css-tokens`
- `npm run build`
- `git diff --check`

## Notes

This continues the color-token migration after #38/#36/#37. It targets the Agents/DM row surface Martin flagged: hover and selected states now render as one row-level shape instead of three independently colored segments.