### PR TITLE
Keep thread following when scrolled to bottom

### DIFF
--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -256,7 +256,8 @@ export function ThreadPanel({
       || threadScrollMetricsRef.current.clientHeight !== element.clientHeight;
     const userScrolling = isUserScrollingThread();
     let shouldShowBackToBottom = Boolean(activeRoot) && !atBottom && !shouldFollowThreadRef.current;
-    if (atBottom && !userScrolling) {
+    if (atBottom) {
+      userThreadScrollUntilRef.current = 0;
       shouldFollowThreadRef.current = true;
       shouldShowBackToBottom = false;
     } else if (!userScrolling && shouldFollowThreadRef.current && layoutChanged && wasThreadPreviouslyAtBottom()) {

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -255,8 +255,9 @@ export function ThreadPanel({
       threadScrollMetricsRef.current.scrollHeight !== element.scrollHeight
       || threadScrollMetricsRef.current.clientHeight !== element.clientHeight;
     const userScrolling = isUserScrollingThread();
+    const reachedScrollEnd = Math.abs(threadScrollDistanceFromBottom(element)) <= 1;
     let shouldShowBackToBottom = Boolean(activeRoot) && !atBottom && !shouldFollowThreadRef.current;
-    if (atBottom) {
+    if (atBottom && (!userScrolling || reachedScrollEnd)) {
       userThreadScrollUntilRef.current = 0;
       shouldFollowThreadRef.current = true;
       shouldShowBackToBottom = false;


### PR DESCRIPTION
## Summary
- keep the thread follow-bottom state from staying disabled after the user actually reaches the bottom
- preserve the user-scroll grace window while the user is only within the loose bottom threshold, so streaming/layout changes do not yank the view down mid-scroll
- sync the branch with current main

## Test
- npm run build
- git diff --check