### PR TITLE
Keep thread back-to-bottom button outside scroll

### DIFF
--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -862,13 +862,13 @@ export function ThreadPanel({
               onClose={() => setMessageMenu(null)}
             />
           )}
+          </div>
           {activeRoot && showBackToBottom && (
             <button type="button" className="thread-back-to-bottom" onClick={returnThreadToBottom}>
               <ArrowDown size={15} />
               Back to bottom
             </button>
           )}
-        </div>
         </div>
 
         <ThreadReplyComposer


### PR DESCRIPTION
## Summary
- move the ThreadPanel back-to-bottom overlay out of the `.thread-scroll` element
- keep it inside `.thread-scroll-shell`, where its absolute positioning is anchored
- prevent the button from being a descendant of the scroll container when it appears/disappears near the bottom

## Verification
- npm run build
- npm run lint:css-tokens
- git diff --check