### PR TITLE
Remove sidebar active border

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -713,7 +713,7 @@ button,
 }
 
 .sidebar-nav-trigger.active {
-  border-color: var(--accent-soft-border);
+  border-color: transparent;
   background: var(--accent-soft);
   color: var(--accent);
 }


### PR DESCRIPTION
## Summary
- remove the blue border from active left sidebar navigation items
- keep the active background/text styling intact in light and dark themes

## Verification
- npm run lint:css-tokens
- npm run build
- git diff --check