### PR TITLE
Remove channel focus ring

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -952,6 +952,11 @@ button,
   white-space: nowrap;
 }
 
+.channel:focus-visible {
+  outline: 1px solid var(--accent-soft-hover-border);
+  outline-offset: -3px;
+}
+
 .channel.selected {
   border-color: var(--control-border);
   background: var(--bg-control-selected);


### PR DESCRIPTION
## Summary
- remove the native focus outline from sidebar channel buttons
- prevents the blue ring from showing around selected channels in light or dark mode

## Verification
- npm run build
- npm run lint:css-tokens
- git diff --check