### PR TITLE
Pause dispatch to error agents

### DIFF
--- a/src-tauri/src/agent_inbox_wake.rs
+++ b/src-tauri/src/agent_inbox_wake.rs
@@ -671,6 +671,9 @@ pub(crate) async fn ensure_agent_inbox_wake_work_item(
     pool: &SqlitePool,
     agent_id: Uuid,
 ) -> CommandResult<Option<(Uuid, bool)>> {
+    if !agent_accepts_new_work(pool, agent_id).await? {
+        return Ok(None);
+    }
     let Some(primary) = next_unread_inbox_wake_item(pool, agent_id).await? else {
         return Ok(None);
     };
@@ -782,6 +785,20 @@ pub(crate) async fn agent_runtime(
         .map_err(to_string)
 }
 
+pub(crate) async fn agent_accepts_new_work(
+    pool: &SqlitePool,
+    agent_id: Uuid,
+) -> CommandResult<bool> {
+    let status: Option<String> = sqlx::query_scalar("select status from agents where id = $1")
+        .bind(agent_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(to_string)?;
+    Ok(status
+        .as_deref()
+        .is_some_and(|status| !status.eq_ignore_ascii_case("error")))
+}
+
 async fn agent_has_active_run(pool: &SqlitePool, agent_id: Uuid) -> CommandResult<bool> {
     let active_run: Option<Uuid> = sqlx::query_scalar(
         r#"
@@ -840,6 +857,9 @@ pub(crate) async fn enqueue_agent_work_if_available(
             .await
             .map_err(to_string)?;
     if status.as_deref() != Some("queued") {
+        return Ok(false);
+    }
+    if !agent_accepts_new_work(pool, agent_id).await? {
         return Ok(false);
     }
     let runtime = agent_runtime(pool, agent_id).await?;

--- a/src-tauri/src/agent_routing.rs
+++ b/src-tauri/src/agent_routing.rs
@@ -4,7 +4,8 @@ use sqlx::{Row, SqlitePool};
 use uuid::Uuid;
 
 use crate::agent_inbox_wake::{
-    create_agent_inbox_item, ensure_agent_inbox_wake_work_item, AgentInboxItemInput,
+    agent_accepts_new_work, create_agent_inbox_item, ensure_agent_inbox_wake_work_item,
+    AgentInboxItemInput,
 };
 use crate::events::activity::record_agent_activity;
 use crate::message_store::insert_agent_handoff_message;
@@ -150,7 +151,7 @@ pub(crate) async fn queue_mentions_as_work_items(
         }
         if let Some(agent_id) = dm_agent_id {
             let agent_handle: Option<String> =
-                sqlx::query_scalar("select handle from agents where id = $1")
+                sqlx::query_scalar("select handle from agents where id = $1 and status <> 'error'")
                     .bind(agent_id)
                     .fetch_optional(pool)
                     .await
@@ -162,7 +163,7 @@ pub(crate) async fn queue_mentions_as_work_items(
     } else {
         for handle in &mentions {
             let agent_id: Option<Uuid> =
-                sqlx::query_scalar("select id from agents where handle = $1")
+                sqlx::query_scalar("select id from agents where handle = $1 and status <> 'error'")
                     .bind(handle)
                     .fetch_optional(pool)
                     .await
@@ -431,6 +432,7 @@ async fn load_thread_followup_targets(
         ) candidates
         join agents a on a.id = candidates.agent_id
         join channel_members cm on cm.channel_id = $1 and cm.agent_id = a.id
+        where a.status <> 'error'
         order by candidates.last_at desc, lower(a.handle)
         limit 8
         "#,
@@ -457,6 +459,7 @@ async fn load_channel_root_delivery_targets(
         from channel_members cm
         join agents a on a.id = cm.agent_id
         where cm.channel_id = $1
+          and a.status <> 'error'
         order by lower(a.handle)
         "#,
     )
@@ -701,6 +704,11 @@ pub(crate) async fn create_agent_handoff(
     let target_agent_id = resolve_agent_by_handle(pool, target_agent).await?;
     if target_agent_id == source_agent_id {
         return Err("handoff_create target_agent must be a different agent".to_owned());
+    }
+    if !agent_accepts_new_work(pool, target_agent_id).await? {
+        return Err(format!(
+            "handoff_create target_agent @{target_agent} is in error state"
+        ));
     }
     let target_handle = resolve_agent_handle(pool, target_agent_id).await?;
     let source_handle = resolve_agent_handle(pool, source_agent_id).await?;

--- a/src-tauri/src/agent_work_dispatch.rs
+++ b/src-tauri/src/agent_work_dispatch.rs
@@ -4,8 +4,9 @@ use tauri::State;
 use uuid::Uuid;
 
 use crate::agent_inbox_wake::{
-    attach_work_item_to_inbox, create_agent_inbox_item, enqueue_agent_work_if_available,
-    ensure_agent_inbox_wake_work_item, prepend_inbox_context, AgentInboxItemInput,
+    agent_accepts_new_work, attach_work_item_to_inbox, create_agent_inbox_item,
+    enqueue_agent_work_if_available, ensure_agent_inbox_wake_work_item, prepend_inbox_context,
+    AgentInboxItemInput,
 };
 use crate::agent_routing::{resolve_agent_handle, upsert_agent_thread_subscription};
 use crate::events::activity::record_agent_activity;
@@ -33,6 +34,11 @@ pub(crate) async fn dispatch_agent_work(
     let Some(agent_handle) = agent_handle else {
         return Err("agent does not exist".to_owned());
     };
+    if !agent_accepts_new_work(&state.pool, agent_id).await? {
+        return Err(format!(
+            "agent @{agent_handle} is in error state and cannot accept new work"
+        ));
+    }
 
     let mut resolved_channel_id = channel_id;
     let mut resolved_thread_root_id = thread_root_id;
@@ -206,6 +212,9 @@ pub(crate) async fn dispatch_task_assignment_to_agent(
     let message_id: Uuid = row.get("message_id");
     let title: String = row.get("title");
     let body: String = row.get("body");
+    if !agent_accepts_new_work(pool, agent_id).await? {
+        return Ok(());
+    }
 
     sqlx::query(
         r#"
@@ -310,6 +319,7 @@ pub(crate) async fn dispatch_unassigned_task_availability(
         from channel_members cm
         join agents a on a.id = cm.agent_id
         where cm.channel_id = $1
+          and a.status <> 'error'
         order by cm.created_at, a.handle
         "#,
     )
@@ -389,8 +399,10 @@ pub(crate) async fn try_claim_unassigned_task(
           and exists (
               select 1
               from channel_members cm
+              join agents a on a.id = cm.agent_id
               where cm.channel_id = t.channel_id
                 and cm.agent_id = $2
+                and a.status <> 'error'
           )
           and not exists (
               select 1
@@ -485,6 +497,17 @@ pub(crate) async fn claim_task_in_pool(
         .await?
         .map(|_| ())
         .ok_or_else(|| "task was already claimed or is no longer available".to_owned());
+    }
+
+    if let Some(agent_id) = agent_id {
+        let agent_handle = resolve_agent_handle(pool, agent_id)
+            .await
+            .unwrap_or_else(|_| "unknown".to_owned());
+        if !agent_accepts_new_work(pool, agent_id).await? {
+            return Err(format!(
+                "agent @{agent_handle} is in error state and cannot accept new work"
+            ));
+        }
     }
 
     sqlx::query_scalar::<_, Uuid>(

--- a/src-tauri/src/events/control.rs
+++ b/src-tauri/src/events/control.rs
@@ -6,6 +6,7 @@ use sha2::{Digest, Sha256};
 use sqlx::SqlitePool;
 use uuid::Uuid;
 
+use crate::agent_inbox_wake::agent_accepts_new_work;
 use crate::agent_memory::{append_agent_memory, append_run_log, compact_agent_memory};
 use crate::agent_routing::{
     create_agent_handoff, ensure_agent_channel_member, queue_mentions_as_work_items,
@@ -756,6 +757,11 @@ pub(crate) async fn handle_agent_event(
                 return Err("task_handoff target_agent must be a different agent".to_owned());
             }
             let target_handle = resolve_agent_handle(pool, target_agent_id).await?;
+            if !agent_accepts_new_work(pool, target_agent_id).await? {
+                return Err(format!(
+                    "task_handoff target_agent @{target_handle} is in error state"
+                ));
+            }
             let source_handle = resolve_agent_handle(pool, agent_id).await?;
             let reason = reason.trim();
             if reason.is_empty() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5128,6 +5128,107 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn owner_channel_root_message_does_not_dispatch_error_agent() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let agent_id = insert_test_agent(&pool, "quota-paused").await?;
+            sqlx::query("update agents set status = 'error' where id = $1")
+                .bind(agent_id)
+                .execute(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+            let channel_id = insert_test_channel(&pool, "error-agent-channel").await?;
+            sqlx::query(
+                r#"
+                insert into channel_members (channel_id, agent_id)
+                values ($1, $2)
+                "#,
+            )
+            .bind(channel_id)
+            .bind(agent_id)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            send_owner_message_in_pool(
+                &pool,
+                channel_id,
+                None,
+                "This should not wake a quota-limited agent",
+                false,
+                vec![],
+            )
+            .await?;
+
+            let inbox_count: i64 =
+                sqlx::query_scalar("select count(*) from agent_inbox_items where agent_id = $1")
+                    .bind(agent_id)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|err| err.to_string())?;
+            let work_count: i64 =
+                sqlx::query_scalar("select count(*) from agent_work_items where agent_id = $1")
+                    .bind(agent_id)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|err| err.to_string())?;
+            assert_eq!(inbox_count, 0);
+            assert_eq!(work_count, 0);
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn owner_mention_does_not_dispatch_error_agent() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let agent_id = insert_test_agent(&pool, "quota-mentioned").await?;
+            sqlx::query("update agents set status = 'error' where id = $1")
+                .bind(agent_id)
+                .execute(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+            let channel_id = insert_test_channel(&pool, "error-agent-mention").await?;
+
+            send_owner_message_in_pool(
+                &pool,
+                channel_id,
+                None,
+                "@quota-mentioned please check this",
+                false,
+                vec![],
+            )
+            .await?;
+
+            let inbox_count: i64 =
+                sqlx::query_scalar("select count(*) from agent_inbox_items where agent_id = $1")
+                    .bind(agent_id)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|err| err.to_string())?;
+            let work_count: i64 =
+                sqlx::query_scalar("select count(*) from agent_work_items where agent_id = $1")
+                    .bind(agent_id)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|err| err.to_string())?;
+            assert_eq!(inbox_count, 0);
+            assert_eq!(work_count, 0);
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    #[tokio::test]
     async fn owner_thread_followup_dispatches_to_thread_agents_without_mentions() {
         let Some((pool, schema)) = test_pool().await else {
             return;


### PR DESCRIPTION
## Summary
- skip agents in error status when routing owner messages, mentions, DMs, thread follow-ups, task availability, and handoffs
- add wake/enqueue safeguards so existing unread inbox items do not restart error agents
- reject manual dispatch/task assignment to error agents instead of creating more work

## Verification
- cargo check
- cargo test error_agent
- git diff --check