### PR TITLE
Render alert badges as numeric counts

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -217,7 +217,7 @@ export function Sidebar({
           </div>
           <div className="sidebar-section-scroll">
             {!collapsedSections.channels && normalChannels.map((item) => {
-              const badge = item.unread_count > 0 ? String(item.unread_count) : channelAlertIds.has(item.id) ? "new" : "";
+              const badge = item.unread_count > 0 ? String(item.unread_count) : channelAlertIds.has(item.id) ? "1" : "";
               return (
                 <button
                   key={item.id}
@@ -283,7 +283,7 @@ export function Sidebar({
                 ? item.unread_count > 0
                   ? String(item.unread_count)
                   : channelAlertIds.has(item.id)
-                    ? "new"
+                    ? "1"
                     : ""
                 : "";
               return (


### PR DESCRIPTION
## Summary
- replace the transient channel/DM alert badge label from `new` to `1`
- keep persisted unread counts unchanged when `unread_count` is available

## Validation
- npm run lint:css-tokens
- git diff --check
- npm run build