### PR TITLE
Show numeric fallback unread badges

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -217,7 +217,7 @@ export function Sidebar({
           </div>
           <div className="sidebar-section-scroll">
             {!collapsedSections.channels && normalChannels.map((item) => {
-              const badge = item.unread_count > 0 ? String(item.unread_count) : channelAlertIds.has(item.id) ? "new" : "";
+              const badge = item.unread_count > 0 ? String(item.unread_count) : channelAlertIds.has(item.id) ? "1" : "";
               return (
                 <button
                   key={item.id}
@@ -283,7 +283,7 @@ export function Sidebar({
                 ? item.unread_count > 0
                   ? String(item.unread_count)
                   : channelAlertIds.has(item.id)
-                    ? "new"
+                    ? "1"
                     : ""
                 : "";
               return (


### PR DESCRIPTION
## Summary
- replace sidebar fallback unread badge text from `new` to `1` for channels
- apply the same numeric fallback to DM rows

## Test
- npm run build