### PR TITLE
Remove sidebar row edge accents

### DIFF
--- a/scripts/styles-raw-color-baseline.json
+++ b/scripts/styles-raw-color-baseline.json
@@ -1935,24 +1935,6 @@
       "n": 0
     },
     {
-      "selector": ".workspace-preview",
-      "prop": "background",
-      "literal": "rgba(255, 255, 255, 0.82)",
-      "n": 0
-    },
-    {
-      "selector": ".workspace-preview",
-      "prop": "border",
-      "literal": "rgba(10, 132, 255, 0.14)",
-      "n": 0
-    },
-    {
-      "selector": ".workspace-preview-head button",
-      "prop": "background",
-      "literal": "rgba(142, 142, 147, 0.12)",
-      "n": 0
-    },
-    {
       "selector": ".workspace-preview-raw",
       "prop": "background",
       "literal": "#111827",

--- a/src/styles.css
+++ b/src/styles.css
@@ -959,10 +959,10 @@ button,
 }
 
 .channel.selected {
-  border-color: var(--control-border);
+  border-color: transparent;
   background: var(--bg-control-selected);
   color: var(--ink-control);
-  box-shadow: var(--state-selected-shadow);
+  box-shadow: none;
 }
 
 .channel.selected strong {
@@ -1014,10 +1014,10 @@ button,
 }
 
 .dm-row.selected {
-  border-color: var(--control-border);
+  border-color: transparent;
   background: var(--bg-control-selected);
   color: var(--ink-control);
-  box-shadow: var(--state-selected-shadow);
+  box-shadow: none;
 }
 
 .dm {
@@ -1124,12 +1124,12 @@ button,
 .dm-row:focus-within .dm-detail-trigger,
 .dm-detail-trigger:hover,
 .dm-detail-trigger:focus-visible {
-  border-color: var(--state-focus-ring);
+  border-color: transparent;
   background: var(--bg-control-selected);
   color: var(--accent);
   opacity: 1;
   transform: translateY(-1px);
-  box-shadow: var(--state-selected-shadow);
+  box-shadow: none;
 }
 
 .member-editor {


### PR DESCRIPTION
## Summary
- remove remaining edge/border accents from selected channel rows and agent DM rows
- remove unread left accent bars now that unread badges carry the signal
- keep hover/focus/selected backgrounds without outline or shadow edges

## Validation
- npm run lint:css-tokens
- git diff --check
- npm run build