### PR TITLE
Stabilize thread bottom follow and back-to-bottom overlay

### DIFF
--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -152,6 +152,7 @@ export function ThreadPanel({
   const threadBottomAnchorRef = useRef<HTMLDivElement | null>(null);
   const threadScrollFrameRef = useRef<number | null>(null);
   const threadScrollTimeoutRef = useRef<number | null>(null);
+  const threadResumeFollowTimeoutRef = useRef<number | null>(null);
   const shouldFollowThreadRef = useRef(true);
   const userThreadScrollUntilRef = useRef(0);
   const threadScrollMetricsRef = useRef({ scrollHeight: 0, scrollTop: 0, clientHeight: 0 });
@@ -204,6 +205,13 @@ export function ThreadPanel({
     }
   }
 
+  function cancelPendingThreadFollowResume() {
+    if (threadResumeFollowTimeoutRef.current !== null) {
+      window.clearTimeout(threadResumeFollowTimeoutRef.current);
+      threadResumeFollowTimeoutRef.current = null;
+    }
+  }
+
   function isUserScrollingThread() {
     return Date.now() < userThreadScrollUntilRef.current;
   }
@@ -212,6 +220,7 @@ export function ThreadPanel({
     userThreadScrollUntilRef.current = Date.now() + 650;
     shouldFollowThreadRef.current = false;
     cancelPendingThreadBottomScroll();
+    cancelPendingThreadFollowResume();
     if (element) rememberThreadScrollMetrics(element);
   }
 
@@ -225,12 +234,25 @@ export function ThreadPanel({
   function scrollThreadToBottomNow(behavior: ScrollBehavior = "auto") {
     const element = threadScrollRef.current;
     if (!element) return;
+    cancelPendingThreadFollowResume();
     userThreadScrollUntilRef.current = 0;
     element.scrollTo({ top: element.scrollHeight, behavior });
     if (behavior === "auto") {
       shouldFollowThreadRef.current = true;
       rememberThreadScrollMetrics(element);
     }
+  }
+
+  function scheduleThreadFollowResume() {
+    cancelPendingThreadFollowResume();
+    // Give a manual scroll a beat to settle at the bottom before follow mode resumes.
+    threadResumeFollowTimeoutRef.current = window.setTimeout(() => {
+      threadResumeFollowTimeoutRef.current = null;
+      const element = threadScrollRef.current;
+      if (!element || !isThreadScrollAtBottom(element)) return;
+      scrollThreadToBottom();
+      setShowBackToBottom(false);
+    }, 120);
   }
 
   function scrollThreadToBottom(behavior: ScrollBehavior = "auto") {
@@ -250,18 +272,28 @@ export function ThreadPanel({
   function handleThreadScroll() {
     const element = threadScrollRef.current;
     if (!element) return;
+    const previousMetrics = threadScrollMetricsRef.current;
     const atBottom = isThreadScrollAtBottom(element);
     const layoutChanged =
-      threadScrollMetricsRef.current.scrollHeight !== element.scrollHeight
-      || threadScrollMetricsRef.current.clientHeight !== element.clientHeight;
+      previousMetrics.scrollHeight !== element.scrollHeight
+      || previousMetrics.clientHeight !== element.clientHeight;
     const userScrolling = isUserScrollingThread();
     let shouldShowBackToBottom = Boolean(activeRoot) && !atBottom && !shouldFollowThreadRef.current;
-    if (atBottom && !userScrolling) {
-      shouldFollowThreadRef.current = true;
+    if (atBottom) {
+      if (userScrolling) {
+        scheduleThreadFollowResume();
+      } else {
+        cancelPendingThreadFollowResume();
+        userThreadScrollUntilRef.current = 0;
+        shouldFollowThreadRef.current = true;
+      }
       shouldShowBackToBottom = false;
     } else if (!userScrolling && shouldFollowThreadRef.current && layoutChanged && wasThreadPreviouslyAtBottom()) {
+      cancelPendingThreadFollowResume();
       scrollThreadToBottom();
       shouldShowBackToBottom = false;
+    } else {
+      cancelPendingThreadFollowResume();
     }
     setShowBackToBottom((current) => current === shouldShowBackToBottom ? current : shouldShowBackToBottom);
     rememberThreadScrollMetrics(element);
@@ -306,6 +338,7 @@ export function ThreadPanel({
   useEffect(() => () => {
     if (threadScrollFrameRef.current !== null) window.cancelAnimationFrame(threadScrollFrameRef.current);
     if (threadScrollTimeoutRef.current !== null) window.clearTimeout(threadScrollTimeoutRef.current);
+    if (threadResumeFollowTimeoutRef.current !== null) window.clearTimeout(threadResumeFollowTimeoutRef.current);
   }, []);
 
   useEffect(() => {
@@ -862,13 +895,13 @@ export function ThreadPanel({
               onClose={() => setMessageMenu(null)}
             />
           )}
-          {activeRoot && showBackToBottom && (
-            <button type="button" className="thread-back-to-bottom" onClick={returnThreadToBottom}>
-              <ArrowDown size={15} />
-              Back to bottom
-            </button>
-          )}
         </div>
+        {activeRoot && showBackToBottom && (
+          <button type="button" className="thread-back-to-bottom" onClick={returnThreadToBottom}>
+            <ArrowDown size={15} />
+            Back to bottom
+          </button>
+        )}
         </div>
 
         <ThreadReplyComposer


### PR DESCRIPTION
## Summary

Replaces #48 and #49 with one combined, more conservative fix in `ThreadPanel.tsx`.

**Follow-bottom state machine (`handleThreadScroll`)**
- When the thread reaches `atBottom` while the post-gesture grace window is still active, the previous logic refused to restore follow until the grace expired (up to ~650ms), so streaming content arriving in that window stayed pinned to an old offset.
- #48's earlier proposal removed the grace guard outright, which would also fire mid-gesture for a brief bounce-through-bottom and could fight a user wheel-up.
- This change keeps the grace window meaningful: if `atBottom` is observed while the user is still actively scrolling, follow resume is scheduled for ~120ms after. If the user is still at the bottom by then, follow is restored and the back-to-bottom overlay is dismissed. A reversed wheel/touch gesture cancels the pending resume via `stopFollowingThread`, so a user who scrolls past the threshold and back up does not get yanked.

**Back-to-bottom overlay DOM position**
- Moves `.thread-back-to-bottom` out of `.thread-scroll` while keeping it inside `.thread-scroll-shell`, where its `position: absolute` is already anchored.
- `position: absolute` already removes it from flow, but an absolutely-positioned descendant of a scrolling container can still affect `scrollHeight` in some engines / edge cases. Making it a sibling of `.thread-scroll` resolves that ambiguity in the DOM itself.

## Relationship to existing PRs
- Supersedes #48 (more conservative version that does not clobber the in-flight user-scroll grace window).
- Supersedes #49 (same DOM move, no additional change).

## Verification
- git diff --check
- npm run build
- npm run lint:css-tokens

CI on this branch will exercise the same gates.