### PR TITLE
Center and share unread badges

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
 import { APP_DISPLAY_NAME } from "../branding";
 import { ownerAsAvatarAgent } from "../ui-utils";
 import { AgentAvatar } from "./AgentAvatar";
+import { UnreadBadge } from "./UnreadBadge";
 
 const SIDEBAR_CHANNELS_HEIGHT_STORAGE_KEY = "lantor.sidebarChannelsHeight";
 const DEFAULT_SIDEBAR_CHANNELS_HEIGHT = 260;
@@ -181,7 +182,7 @@ export function Sidebar({
         >
           <Inbox size={18} />
           <span>Activity</span>
-          {activityFeedUnreadCount > 0 && <strong>{activityFeedUnreadCount}</strong>}
+          {activityFeedUnreadCount > 0 && <UnreadBadge value={activityFeedUnreadCount} />}
         </button>
         <button
           className={`sidebar-nav-trigger ${savedUnreadCount ? "has-unread" : ""}`}
@@ -189,7 +190,7 @@ export function Sidebar({
         >
           <Bookmark size={18} />
           <span>Saved</span>
-          {savedUnreadCount > 0 && <strong>{savedUnreadCount}</strong>}
+          {savedUnreadCount > 0 && <UnreadBadge value={savedUnreadCount} />}
         </button>
       </section>
 
@@ -226,7 +227,7 @@ export function Sidebar({
                 >
                   <Hash size={17} />
                   <span className="channel-name">{item.name}</span>
-                  {badge && <strong>{badge}</strong>}
+                  {badge && <UnreadBadge value={badge} />}
                 </button>
               );
             })}
@@ -308,7 +309,7 @@ export function Sidebar({
                       <strong>{agent.display_name}</strong>
                       <span>@{agent.handle}</span>
                     </div>
-                    {badge && <strong className="dm-badge">{badge}</strong>}
+                    {badge && <UnreadBadge value={badge} />}
                   </button>
                   <div className="dm-row-actions">
                     <Circle className={`dot ${agent.status}`} size={10} />

--- a/src/components/UnreadBadge.tsx
+++ b/src/components/UnreadBadge.tsx
@@ -1,0 +1,12 @@
+type UnreadBadgeProps = {
+  value: number | string;
+  className?: string;
+};
+
+export function UnreadBadge({ value, className }: UnreadBadgeProps) {
+  return (
+    <span className={className ? `unread-badge ${className}` : "unread-badge"}>
+      {value}
+    </span>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -32,6 +32,7 @@ import { SearchModal } from "./components/SearchModal";
 import { SettingsModal, type ChatTextSize, type ThemePreference } from "./components/SettingsModal";
 import { Sidebar } from "./components/Sidebar";
 import { ThreadPanel } from "./components/ThreadPanel";
+import { UnreadBadge } from "./components/UnreadBadge";
 import { isProgressOnlyMessage } from "./message-grouping";
 import {
   ACTIVE_RUN_STATUSES,
@@ -3412,7 +3413,7 @@ function App() {
         >
           <span className="mobile-bottom-nav-icon">
             <Inbox size={20} />
-            {activityFeedUnreadCount > 0 && <strong>{activityFeedUnreadCount}</strong>}
+            {activityFeedUnreadCount > 0 && <UnreadBadge value={activityFeedUnreadCount} />}
           </span>
           <span>Activity</span>
         </button>
@@ -3423,7 +3424,7 @@ function App() {
         >
           <span className="mobile-bottom-nav-icon">
             <Bookmark size={20} />
-            {savedUnreadCount > 0 && <strong>{savedUnreadCount}</strong>}
+            {savedUnreadCount > 0 && <UnreadBadge value={savedUnreadCount} />}
           </span>
           <span>Saved</span>
         </button>

--- a/src/styles.css
+++ b/src/styles.css
@@ -747,7 +747,7 @@ button,
   background: var(--badge-bg);
   color: var(--badge-ink);
   font-size: var(--type-size-caption);
-  font-variant-numeric: tabular-nums;
+  font-variant-numeric: lining-nums;
   font-weight: var(--type-weight-semibold);
   line-height: 1;
   text-align: center;

--- a/src/styles.css
+++ b/src/styles.css
@@ -732,22 +732,21 @@ button,
   font-size: var(--type-size-body);
 }
 
-.sidebar-nav-trigger strong,
-.channel strong,
-.dm-badge,
-.mobile-bottom-nav strong {
+.unread-badge {
   display: inline-flex;
+  box-sizing: border-box;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
   justify-self: end;
   min-width: 18px;
-  min-height: 18px;
-  padding: 2px 7px;
+  height: 18px;
+  padding: 0 6px;
   border-radius: 999px;
   background: var(--badge-bg);
   color: var(--badge-ink);
   font-size: var(--type-size-caption);
-  font-variant-numeric: lining-nums;
+  font-variant-numeric: lining-nums tabular-nums;
   font-weight: var(--type-weight-semibold);
   line-height: 1;
   text-align: center;
@@ -965,7 +964,7 @@ button,
   box-shadow: none;
 }
 
-.channel.selected strong {
+.channel.selected .unread-badge {
   background: var(--bg-control-flat);
   color: var(--ink-muted);
 }
@@ -976,16 +975,16 @@ button,
   color: var(--unread-ink);
 }
 
-.sidebar-nav-trigger.has-unread strong,
-.channel.has-unread strong,
-.dm-row.has-unread .dm-badge,
-.mobile-bottom-nav button.has-unread strong {
+.sidebar-nav-trigger.has-unread .unread-badge,
+.channel.has-unread .unread-badge,
+.dm-row.has-unread .unread-badge,
+.mobile-bottom-nav button.has-unread .unread-badge {
   background: var(--accent);
   color: var(--accent-ink);
 }
 
-.channel.selected.has-unread strong,
-.dm-row.selected.has-unread .dm-badge {
+.channel.selected.has-unread .unread-badge,
+.dm-row.selected.has-unread .unread-badge {
   background: var(--accent);
   color: var(--accent-ink);
 }
@@ -1055,12 +1054,12 @@ button,
   opacity: 0.62;
 }
 
-.dm-badge {
+.dm .unread-badge {
   max-width: 34px;
 }
 
-.dm.selected .dm-badge,
-.dm-row.selected:not(.has-unread) .dm .dm-badge {
+.dm.selected .unread-badge,
+.dm-row.selected:not(.has-unread) .dm .unread-badge {
   background: var(--badge-bg);
   color: var(--badge-ink);
 }
@@ -8877,7 +8876,7 @@ body.resizing-row * {
     place-items: center;
   }
 
-  .mobile-bottom-nav strong {
+  .mobile-bottom-nav .unread-badge {
     position: absolute;
     top: -7px;
     right: -12px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1035,8 +1035,8 @@ button,
   color: inherit;
 }
 
-.dm strong,
-.dm span {
+.dm > div strong,
+.dm > div span {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
- center single-digit unread badges with stable shared badge sizing
- extract a shared `UnreadBadge` component for sidebar and mobile nav unread counts
- switch unread badge styling from structural selectors to the explicit `.unread-badge` class

## Testing
- npm run build
- npm run lint:css-tokens
- git diff --check