### PR TITLE
Keep DM unread badge centered

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1036,7 +1036,7 @@ button,
   color: inherit;
 }
 
-.dm strong,
+.dm > div strong,
 .dm span {
   display: block;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- keep DM unread badges on the shared sidebar badge inline-flex centering styles
- narrow the DM text selector so it no longer overrides .dm-badge with display: block

## Notes
- Activity/Saved, channel, DM, and mobile nav badges share the sidebar badge selector in styles.css.
- The Activity feed modal unread indicator is separate: it uses .activity-feed-unread-dot, not the numeric badge style.

## Test
- npm run build
- git diff --check