### PR TITLE
Show agent action tooltips immediately

### DIFF
--- a/src/components/AgentDetailDrawer.tsx
+++ b/src/components/AgentDetailDrawer.tsx
@@ -918,8 +918,8 @@ export function AgentDetailDrawer({
           <button
             type="button"
             className="agent-head-action"
-            title={`Edit @${agent.handle}`}
             aria-label={`Edit @${agent.handle}`}
+            data-tooltip={`Edit @${agent.handle}`}
             onClick={() => onEdit(agent)}
           >
             <Pencil size={16} />
@@ -929,7 +929,7 @@ export function AgentDetailDrawer({
             className="agent-head-action danger"
             disabled={deleteDisabled}
             aria-label={`Delete @${agent.handle}`}
-            title={deleteDisabled ? "Stop the active run before deleting this agent" : `Delete @${agent.handle}`}
+            data-tooltip={deleteDisabled ? "Stop the active run before deleting this agent" : `Delete @${agent.handle}`}
             onClick={() => onDelete(agent)}
           >
             <Trash2 size={16} />

--- a/src/styles.css
+++ b/src/styles.css
@@ -178,12 +178,14 @@ button,
   --surface-control-hover: var(--bg-control-hover);
   --surface-control-selected: var(--bg-control-selected);
   --surface-code: var(--bg-code);
+  --surface-tooltip: rgba(29, 28, 29, 0.94);
   --ink-on-surface: var(--ink-primary);
   --ink-on-surface-secondary: var(--ink-secondary);
   --ink-on-surface-muted: var(--ink-muted);
   --ink-on-control: var(--ink-control);
   --ink-on-accent: var(--accent-ink);
   --ink-on-code: #f7f7f8;
+  --ink-on-tooltip: #ffffff;
   --border-default: var(--border-subtle);
   --border-emphasis: var(--border-strong);
   --border-control: var(--control-border);
@@ -4899,39 +4901,39 @@ body.resizing-row * {
 
 .agent-drawer-head .agent-head-action[data-tooltip]::after {
   position: absolute;
-  right: 50%;
-  bottom: calc(100% + 10px);
+  top: calc(100% + 10px);
+  right: 0;
   z-index: 4;
   max-width: 220px;
   padding: 5px 8px;
   border-radius: 8px;
-  background: rgba(29, 28, 29, 0.94);
-  color: #fff;
+  background: var(--surface-tooltip);
+  color: var(--ink-on-tooltip);
   content: attr(data-tooltip);
   font-size: 11px;
   font-weight: var(--type-weight-medium);
   line-height: 1.35;
   opacity: 0;
   pointer-events: none;
-  transform: translate(50%, 2px);
+  overflow-wrap: anywhere;
+  transform: translateY(-2px);
   transition:
     opacity 90ms ease,
     transform 90ms ease;
-  white-space: nowrap;
 }
 
 .agent-drawer-head .agent-head-action[data-tooltip]::before {
   position: absolute;
-  right: 50%;
-  bottom: calc(100% + 6px);
+  top: calc(100% + 6px);
+  right: calc(50% - 4px);
   z-index: 4;
   width: 8px;
   height: 8px;
-  background: rgba(29, 28, 29, 0.94);
+  background: var(--surface-tooltip);
   content: "";
   opacity: 0;
   pointer-events: none;
-  transform: translate(50%, 2px) rotate(45deg);
+  transform: translateY(-2px) rotate(45deg);
   transition:
     opacity 90ms ease,
     transform 90ms ease;
@@ -4942,12 +4944,12 @@ body.resizing-row * {
 .agent-drawer-head .agent-head-action[data-tooltip]:hover::before,
 .agent-drawer-head .agent-head-action[data-tooltip]:focus-visible::before {
   opacity: 1;
-  transform: translate(50%, 0);
+  transform: translateY(0);
 }
 
 .agent-drawer-head .agent-head-action[data-tooltip]:hover::before,
 .agent-drawer-head .agent-head-action[data-tooltip]:focus-visible::before {
-  transform: translate(50%, 0) rotate(45deg);
+  transform: translateY(0) rotate(45deg);
 }
 
 .agent-drawer-head .agent-mobile-back {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4901,31 +4901,31 @@ body.resizing-row * {
 
 .agent-drawer-head .agent-head-action[data-tooltip]::after {
   position: absolute;
-  top: calc(100% + 10px);
-  right: 0;
+  top: calc(100% + 8px);
+  right: 50%;
   z-index: 4;
-  max-width: 220px;
+  max-width: 140px;
   padding: 5px 8px;
-  border-radius: 8px;
+  border-radius: 6px;
   background: var(--surface-tooltip);
   color: var(--ink-on-tooltip);
   content: attr(data-tooltip);
-  font-size: 11px;
-  font-weight: var(--type-weight-medium);
-  line-height: 1.35;
+  font-size: var(--type-size-caption);
+  font-weight: var(--type-weight-semibold);
+  line-height: 14px;
   opacity: 0;
   pointer-events: none;
-  overflow-wrap: anywhere;
-  transform: translateY(-2px);
+  transform: translate(50%, -2px);
   transition:
     opacity 90ms ease,
     transform 90ms ease;
+  white-space: nowrap;
 }
 
 .agent-drawer-head .agent-head-action[data-tooltip]::before {
   position: absolute;
-  top: calc(100% + 6px);
-  right: calc(50% - 4px);
+  top: calc(100% + 3px);
+  right: 50%;
   z-index: 4;
   width: 8px;
   height: 8px;
@@ -4933,7 +4933,7 @@ body.resizing-row * {
   content: "";
   opacity: 0;
   pointer-events: none;
-  transform: translateY(-2px) rotate(45deg);
+  transform: translate(50%, -2px) rotate(45deg);
   transition:
     opacity 90ms ease,
     transform 90ms ease;
@@ -4944,12 +4944,12 @@ body.resizing-row * {
 .agent-drawer-head .agent-head-action[data-tooltip]:hover::before,
 .agent-drawer-head .agent-head-action[data-tooltip]:focus-visible::before {
   opacity: 1;
-  transform: translateY(0);
+  transform: translate(50%, 0) rotate(45deg);
 }
 
-.agent-drawer-head .agent-head-action[data-tooltip]:hover::before,
-.agent-drawer-head .agent-head-action[data-tooltip]:focus-visible::before {
-  transform: translateY(0) rotate(45deg);
+.agent-drawer-head .agent-head-action[data-tooltip]:hover::after,
+.agent-drawer-head .agent-head-action[data-tooltip]:focus-visible::after {
+  transform: translate(50%, 0);
 }
 
 .agent-drawer-head .agent-mobile-back {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4893,6 +4893,63 @@ body.resizing-row * {
   opacity: 0.45;
 }
 
+.agent-drawer-head .agent-head-action[data-tooltip] {
+  position: relative;
+}
+
+.agent-drawer-head .agent-head-action[data-tooltip]::after {
+  position: absolute;
+  right: 50%;
+  bottom: calc(100% + 10px);
+  z-index: 4;
+  max-width: 220px;
+  padding: 5px 8px;
+  border-radius: 8px;
+  background: rgba(29, 28, 29, 0.94);
+  color: #fff;
+  content: attr(data-tooltip);
+  font-size: 11px;
+  font-weight: var(--type-weight-medium);
+  line-height: 1.35;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(50%, 2px);
+  transition:
+    opacity 90ms ease,
+    transform 90ms ease;
+  white-space: nowrap;
+}
+
+.agent-drawer-head .agent-head-action[data-tooltip]::before {
+  position: absolute;
+  right: 50%;
+  bottom: calc(100% + 6px);
+  z-index: 4;
+  width: 8px;
+  height: 8px;
+  background: rgba(29, 28, 29, 0.94);
+  content: "";
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(50%, 2px) rotate(45deg);
+  transition:
+    opacity 90ms ease,
+    transform 90ms ease;
+}
+
+.agent-drawer-head .agent-head-action[data-tooltip]:hover::after,
+.agent-drawer-head .agent-head-action[data-tooltip]:focus-visible::after,
+.agent-drawer-head .agent-head-action[data-tooltip]:hover::before,
+.agent-drawer-head .agent-head-action[data-tooltip]:focus-visible::before {
+  opacity: 1;
+  transform: translate(50%, 0);
+}
+
+.agent-drawer-head .agent-head-action[data-tooltip]:hover::before,
+.agent-drawer-head .agent-head-action[data-tooltip]:focus-visible::before {
+  transform: translate(50%, 0) rotate(45deg);
+}
+
 .agent-drawer-head .agent-mobile-back {
   display: none;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -4892,11 +4892,22 @@ body.resizing-row * {
 .agent-drawer-head button:disabled,
 .agent-head-action:disabled {
   cursor: not-allowed;
-  opacity: 0.45;
+  color: var(--ink-on-surface-muted);
 }
 
 .agent-drawer-head .agent-head-action[data-tooltip] {
   position: relative;
+}
+
+.agent-drawer-head button:disabled:hover,
+.agent-drawer-head button.danger:disabled:hover {
+  border-color: var(--line);
+  background: var(--panel-strong);
+  color: var(--ink-on-surface-muted);
+}
+
+.agent-drawer-head button:disabled svg {
+  opacity: 0.45;
 }
 
 .agent-drawer-head .agent-head-action[data-tooltip]::after {


### PR DESCRIPTION
## Summary
- replace native delayed `title` tooltips on agent drawer action buttons with immediate `data-tooltip` UI
- position the tooltip below the header action buttons so it is not clipped by the drawer top
- use tooltip theme tokens so the CSS token gate stays clean

## Verification
- npm run lint:css-tokens
- npm run build
- git diff --check