### PR TITLE
Solid hover card backgrounds, token cleanup, and activity thread sort

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1791,6 +1791,7 @@ function App() {
       const currentMessage = unreadCount > 0
         ? replies[unreadStartIndex] ?? latestReply ?? root
         : latestReply ?? root;
+      const latestActivity = latestReply ?? root;
       const unread = unreadCount > 0;
       items.push({
         id: `thread:${root.id}`,
@@ -1800,7 +1801,7 @@ function App() {
         excerpt: currentMessage.body,
         surface: channelLabel(root.channel_id),
         actor: currentMessage.sender_name,
-        timestamp: timestamp(currentMessage.created_at),
+        timestamp: timestamp(latestActivity.created_at),
         unread,
         actorAgentId: currentMessage.sender_agent_id,
         actorRole: currentMessage.sender_role,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1386,12 +1386,12 @@ button,
 }
 
 .agent-avatar-profile-card {
-  --agent-avatar-profile-bg: var(--bg-panel, #ffffff);
-  --agent-avatar-profile-border: var(--border-subtle, rgba(20, 23, 31, 0.1));
-  --agent-avatar-profile-shadow: var(--surface-shadow, 0 24px 64px rgba(15, 23, 42, 0.18));
-  --agent-avatar-profile-ink-primary: var(--ink-primary, #121316);
-  --agent-avatar-profile-ink-secondary: var(--ink-secondary, #24262b);
-  --agent-avatar-profile-ink-muted: var(--ink-muted, #7b7d84);
+  --agent-avatar-profile-bg: var(--bg-panel);
+  --agent-avatar-profile-border: var(--border-subtle);
+  --agent-avatar-profile-shadow: var(--surface-shadow);
+  --agent-avatar-profile-ink-primary: var(--ink-primary);
+  --agent-avatar-profile-ink-secondary: var(--ink-secondary);
+  --agent-avatar-profile-ink-muted: var(--ink-muted);
   position: fixed;
   z-index: 1400;
   display: grid;
@@ -1418,12 +1418,7 @@ button,
 }
 
 :root[data-theme="dark"] .agent-avatar-profile-card {
-  --agent-avatar-profile-bg: #202631;
-  --agent-avatar-profile-border: rgba(226, 232, 240, 0.14);
-  --agent-avatar-profile-shadow: 0 24px 64px rgba(0, 0, 0, 0.38);
-  --agent-avatar-profile-ink-primary: #e6e8ee;
-  --agent-avatar-profile-ink-secondary: #cfd4de;
-  --agent-avatar-profile-ink-muted: #8f98a8;
+  --agent-avatar-profile-bg: var(--bg-panel-strong);
 }
 
 .agent-avatar-profile-image {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1386,7 +1386,7 @@ button,
 }
 
 .agent-avatar-profile-card {
-  --agent-avatar-profile-bg: var(--bg-panel-strong, #ffffff);
+  --agent-avatar-profile-bg: var(--bg-panel, #ffffff);
   --agent-avatar-profile-border: var(--border-subtle, rgba(20, 23, 31, 0.1));
   --agent-avatar-profile-shadow: var(--surface-shadow, 0 24px 64px rgba(15, 23, 42, 0.18));
   --agent-avatar-profile-ink-primary: var(--ink-primary, #121316);


### PR DESCRIPTION
## Summary

This PR now bundles three small follow-ups in the same area:

### 1. Solid background for the agent profile hover card

Originally the popup used \`--bg-panel-strong\`, which in light mode is \`rgba(255, 255, 255, 0.98)\`. The 2% transparency made the card look like it had no fill against the similarly light app background, including in the **DM header avatar** and the **thread reply avatars** (both render \`AgentAvatarWithProfile\` and produce the same \`.agent-avatar-profile-card\` popup).

Light mode now uses \`--bg-panel\` (\`#ffffff\`), matching \`.owner-profile-preview\`. Dark mode keeps \`--bg-panel-strong\` (\`#202631\`), matching the existing \`mention-picker\` / \`agent-form-preview\` / \`owner-profile-preview\` dark group rule.

### 2. Tokenize the dark-mode override (no more raw color literals)

The recently-landed \`4049c64 fix hover\` inlined six raw color literals into the dark override of the hover card (and four fallback literals in the light defaults). All of them already exist as design tokens:

| Hardcoded | Token equivalent |
|---|---|
| \`#202631\` | \`var(--bg-panel-strong)\` |
| \`#e6e8ee\` | \`var(--ink-primary)\` |
| \`#cfd4de\` | \`var(--ink-secondary)\` |
| \`#8f98a8\` | \`var(--ink-muted)\` |
| \`0 24px 64px rgba(0, 0, 0, 0.38)\` | \`var(--surface-shadow)\` |
| \`rgba(226, 232, 240, 0.14)\` | \`var(--border-subtle)\` (0.1) |

Replace the literals with token references. The \`var(--foo, fallback)\` defaults in light are dead weight (tokens are always defined), so the fallback literals are dropped too. The card now follows future theme changes automatically and matches the surface family without a separate per-component palette.

### 3. Activity-feed thread items sort by latest reply, not first unread

The thread items in \`activityFeedItems\` (\`src/main.tsx\`) used \`currentMessage.created_at\` for the \`timestamp\` field, where \`currentMessage\` is the first **unread** reply for an unread thread. That meant an unread thread with older unread messages would sort **below** a fully-read thread that had been touched more recently — directly opposite to the standard chat convention where new activity bubbles up.

Now the \`timestamp\` (used by both sort and read-tracking) uses the latest reply (or the root, if no replies). The preview title / excerpt / actor still anchor on \`currentMessage\` so opening the thread lands at the first unread message.

## Verification

- \`npm run build\` ✓
- \`npm run lint:css-tokens\` ✓ (\`350 known raw color literal(s); none new\`)
- \`git diff --check\` ✓

Scope: \`src/styles.css\` (token cleanup + light fix) + \`src/main.tsx\` (one-line sort field switch).