### PR TITLE
Sort thread feed items by latest reply

### DIFF
--- a/src/components/ActivityFeedModal.tsx
+++ b/src/components/ActivityFeedModal.tsx
@@ -1,4 +1,4 @@
-import { Bell, Check, Hash, Inbox, MessageSquare, UserRound, X } from "lucide-react";
+import { ArrowUp, Bell, Check, Hash, Inbox, MessageSquare, UserRound, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, PointerEvent } from "react";
 import type { Agent, ActivityFeedItem, ActivityFeedKind, OwnerProfile } from "../types";
@@ -52,6 +52,11 @@ function actorAvatarAgent(item: ActivityFeedItem, agents: Agent[], ownerProfile:
   return null;
 }
 
+function activityTimestampValue(item: ActivityFeedItem) {
+  const value = new Date(item.timestamp).getTime();
+  return Number.isFinite(value) ? value : 0;
+}
+
 export function ActivityFeedModal({
   open,
   items,
@@ -66,6 +71,7 @@ export function ActivityFeedModal({
 }: ActivityFeedModalProps) {
   const [filter, setFilter] = useState<ActivityFeedFilter>("all");
   const [visibleCount, setVisibleCount] = useState(ACTIVITY_FEED_INITIAL_VISIBLE);
+  const [displayItems, setDisplayItems] = useState<ActivityFeedItem[]>(items);
   const [swipeState, setSwipeState] = useState<{
     itemId: string;
     startX: number;
@@ -73,13 +79,22 @@ export function ActivityFeedModal({
     offsetX: number;
     tracking: boolean;
   } | null>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
   const suppressNextClickRef = useRef(false);
-  const unreadCount = items.filter((item) => item.unread).length;
+  const unreadCount = displayItems.filter((item) => item.unread).length;
+  const pendingItems = useMemo(() => {
+    const displayedById = new Map(displayItems.map((item) => [item.id, item]));
+    return items.filter((item) => {
+      const displayed = displayedById.get(item.id);
+      if (!displayed) return true;
+      return activityTimestampValue(item) > activityTimestampValue(displayed);
+    });
+  }, [displayItems, items]);
   const filteredItems = useMemo(() => {
-    if (filter === "all") return items;
-    if (filter === "unread") return items.filter((item) => item.unread);
-    return items.filter((item) => item.kind === filter);
-  }, [filter, items]);
+    if (filter === "all") return displayItems;
+    if (filter === "unread") return displayItems.filter((item) => item.unread);
+    return displayItems.filter((item) => item.kind === filter);
+  }, [displayItems, filter]);
   const filteredUnreadCount = filteredItems.filter((item) => item.unread).length;
   const visibleItems = useMemo(
     () => filteredItems.slice(0, visibleCount),
@@ -89,7 +104,42 @@ export function ActivityFeedModal({
 
   useEffect(() => {
     setVisibleCount(ACTIVITY_FEED_INITIAL_VISIBLE);
-  }, [filter, items.length]);
+  }, [displayItems.length, filter]);
+
+  useEffect(() => {
+    if (!open) return;
+    setVisibleCount(ACTIVITY_FEED_INITIAL_VISIBLE);
+  }, [open]);
+
+  useEffect(() => {
+    if (open) return;
+    setDisplayItems(items);
+  }, [items, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    setDisplayItems((current) => {
+      const latestById = new Map(items.map((item) => [item.id, item]));
+      let changed = false;
+      const next: ActivityFeedItem[] = [];
+
+      for (const displayed of current) {
+        const latest = latestById.get(displayed.id);
+        if (!latest) {
+          changed = true;
+          continue;
+        }
+        if (activityTimestampValue(latest) <= activityTimestampValue(displayed)) {
+          if (latest !== displayed) changed = true;
+          next.push(latest);
+        } else {
+          next.push(displayed);
+        }
+      }
+
+      return changed ? next : current;
+    });
+  }, [items, open]);
 
   useEffect(() => {
     if (!open) return;
@@ -152,6 +202,14 @@ export function ActivityFeedModal({
     onOpenItem(item);
   }
 
+  function showPendingItems() {
+    setDisplayItems(items);
+    setVisibleCount(ACTIVITY_FEED_INITIAL_VISIBLE);
+    window.requestAnimationFrame(() => {
+      bodyRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+    });
+  }
+
   return (
     <div className="search-backdrop" onClick={onClose}>
       <section className="activity-feed-panel activity-panel" onClick={(event) => event.stopPropagation()}>
@@ -161,7 +219,7 @@ export function ActivityFeedModal({
           </button>
           <div>
             <h2>Activity</h2>
-            <p>{items.length} active · {unreadCount} unread</p>
+            <p>{displayItems.length} active · {unreadCount} unread</p>
           </div>
           <div className="activity-feed-head-actions">
             <button
@@ -193,7 +251,18 @@ export function ActivityFeedModal({
           ))}
         </div>
 
-        <div className="activity-feed-body">
+        <div className="activity-feed-body" ref={bodyRef}>
+          {pendingItems.length > 0 && (
+            <div className="activity-feed-new-activity">
+              <button type="button" onClick={showPendingItems}>
+                <ArrowUp size={16} />
+                <span>
+                  {pendingItems.length === 1 ? "1 new activity" : `${pendingItems.length} new activities`}
+                </span>
+              </button>
+            </div>
+          )}
+
           {filteredItems.length === 0 && (
             <div className="search-empty">
               <Inbox size={34} />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1786,28 +1786,23 @@ function App() {
     for (const root of allThreadRootMessages) {
       const replies = repliesByRoot.get(root.id) ?? [];
       const unreadCount = threadUnreadCounts[root.id] ?? 0;
-      const unreadStartIndex = Math.max(0, replies.length - unreadCount);
-      const latestReply = replies.length > 0 ? replies[replies.length - 1] : null;
-      const currentMessage = unreadCount > 0
-        ? replies[unreadStartIndex] ?? latestReply ?? root
-        : latestReply ?? root;
-      const latestActivity = latestReply ?? root;
+      const latestActivity = replies.length > 0 ? replies[replies.length - 1] : root;
       const unread = unreadCount > 0;
       items.push({
         id: `thread:${root.id}`,
         dismissId: `thread:${root.id}`,
         kind: "thread",
-        title: firstLines(currentMessage.body, 1),
-        excerpt: currentMessage.body,
+        title: firstLines(latestActivity.body, 1),
+        excerpt: latestActivity.body,
         surface: channelLabel(root.channel_id),
-        actor: currentMessage.sender_name,
+        actor: latestActivity.sender_name,
         timestamp: timestamp(latestActivity.created_at),
         unread,
-        actorAgentId: currentMessage.sender_agent_id,
-        actorRole: currentMessage.sender_role,
+        actorAgentId: latestActivity.sender_agent_id,
+        actorRole: latestActivity.sender_role,
         channelId: root.channel_id,
         threadId: root.id,
-        messageId: currentMessage.id,
+        messageId: latestActivity.id,
         taskId: null,
         reminderId: null,
         replyCount: threadReplyCounts[root.id] ?? 0,

--- a/src/styles.css
+++ b/src/styles.css
@@ -7993,6 +7993,37 @@ body.resizing-row * {
   scrollbar-gutter: stable;
 }
 
+.activity-feed-new-activity {
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  display: flex;
+  justify-content: center;
+  padding: 10px 22px 8px;
+  pointer-events: none;
+}
+
+.activity-feed-new-activity button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 7px 14px;
+  border: 1px solid var(--activity-feed-filter-active-border);
+  border-radius: 999px;
+  background: var(--activity-feed-control-bg);
+  color: var(--activity-feed-filter-active-ink);
+  font-size: var(--type-size-body);
+  font-weight: var(--type-weight-bold);
+  box-shadow: var(--activity-feed-control-shadow);
+  pointer-events: auto;
+}
+
+.activity-feed-new-activity button:hover {
+  background: var(--activity-feed-control-hover-bg);
+  color: var(--activity-feed-control-hover-ink);
+}
+
 .activity-feed-row-shell {
   position: relative;
   min-height: max-content;
@@ -9217,6 +9248,15 @@ body.resizing-row * {
     gap: 10px;
     padding: 12px 12px 118px;
     background: var(--activity-feed-mobile-bg);
+  }
+
+  .activity-feed-new-activity {
+    padding: 0 0 2px;
+  }
+
+  .activity-feed-new-activity button {
+    min-height: 36px;
+    padding: 8px 14px;
   }
 
   .saved-panel {


### PR DESCRIPTION
## Summary
- sort thread activity feed items by the latest reply in the thread
- keep the row preview, sender, and timestamp aligned to that same latest activity
- avoid stale ordering caused by using the first unread reply as the sort timestamp

## Testing
- npm run build
- git diff --check