### PR TITLE
Keep sidebar unread badges visually consistent

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -171,7 +171,7 @@ export function Sidebar({
       <section className="quick-actions">
         <button className="search-trigger" onClick={openSearch}>
           <Search size={18} />
-          <span>Search</span>
+          <span className="search-trigger-label">Search</span>
           <kbd>⌘K</kbd>
         </button>
         <button
@@ -179,7 +179,7 @@ export function Sidebar({
           onClick={openActivityFeed}
         >
           <Inbox size={18} />
-          <span>Activity</span>
+          <span className="sidebar-nav-trigger-label">Activity</span>
           {activityFeedUnreadCount > 0 && <UnreadBadge value={activityFeedUnreadCount} />}
         </button>
         <button
@@ -187,7 +187,7 @@ export function Sidebar({
           onClick={openSaved}
         >
           <Bookmark size={18} />
-          <span>Saved</span>
+          <span className="sidebar-nav-trigger-label">Saved</span>
           {savedUnreadCount > 0 && <UnreadBadge value={savedUnreadCount} />}
         </button>
       </section>

--- a/src/styles.css
+++ b/src/styles.css
@@ -706,8 +706,8 @@ button,
   color: var(--muted);
 }
 
-.search-trigger span,
-.sidebar-nav-trigger span {
+.search-trigger-label,
+.sidebar-nav-trigger-label {
   color: var(--ink);
   font-size: var(--type-size-message);
   font-weight: var(--type-weight-semibold);
@@ -720,7 +720,7 @@ button,
   color: var(--accent);
 }
 
-.sidebar-nav-trigger.active span {
+.sidebar-nav-trigger.active .sidebar-nav-trigger-label {
   color: var(--accent);
 }
 


### PR DESCRIPTION
## Summary
- scope the quick-action text selector to the actual labels instead of every nested `span`
- let the Activity and Saved unread badges keep using the shared `UnreadBadge` styling unchanged

## Testing
- git diff --check
- npm run build