### PR TITLE
Harden streaming control event parsing

### DIFF
--- a/src-tauri/src/events/control.rs
+++ b/src-tauri/src/events/control.rs
@@ -34,7 +34,7 @@ use crate::{
     try_claim_unassigned_task,
 };
 
-const AGENT_EVENT_PREFIX: &str = "LANTOR_EVENT ";
+const AGENT_EVENT_MARKER: &str = "LANTOR_EVENT";
 const SILENT_REPLY_PREFIX: &str = "LANTOR_SILENT_REPLY";
 
 #[derive(Debug, Deserialize)]
@@ -300,23 +300,51 @@ fn extract_agent_event_json_with_remainder(line: &str) -> Option<(&str, &str)> {
             break;
         }
     }
-    let payload = trimmed.strip_prefix(AGENT_EVENT_PREFIX)?.trim_start();
+    let (marker_index, payload_start) = find_agent_event_marker(trimmed)?;
+    if marker_index != 0 {
+        return None;
+    }
+    let payload = &trimmed[payload_start..];
     match complete_json_object_end(payload) {
         Some(end) => Some((&payload[..end], &payload[end..])),
         None => Some((payload.trim(), "")),
     }
 }
 
-pub(crate) fn split_agent_event_jsons_from_text(text: &str) -> (String, Vec<String>) {
+fn find_agent_event_marker(text: &str) -> Option<(usize, usize)> {
+    let mut search_start = 0;
+    while search_start < text.len() {
+        let relative_index = text[search_start..].find(AGENT_EVENT_MARKER)?;
+        let marker_index = search_start + relative_index;
+        let after_marker_index = marker_index + AGENT_EVENT_MARKER.len();
+        let after_marker = &text[after_marker_index..];
+        let payload_offset = after_marker
+            .char_indices()
+            .find_map(|(index, ch)| (!ch.is_whitespace()).then_some(index));
+        let Some(payload_offset) = payload_offset else {
+            return Some((marker_index, text.len()));
+        };
+        let payload_start = after_marker_index + payload_offset;
+        if text[payload_start..].starts_with('{') {
+            return Some((marker_index, payload_start));
+        }
+        search_start = after_marker_index;
+    }
+    None
+}
+
+fn split_agent_event_jsons_from_text(text: &str, drop_incomplete: bool) -> (String, Vec<String>) {
     let mut visible = String::new();
     let mut events = Vec::new();
     let mut rest = text;
 
-    while let Some(marker_index) = rest.find(AGENT_EVENT_PREFIX) {
+    while let Some((marker_index, payload_start)) = find_agent_event_marker(rest) {
         visible.push_str(&rest[..marker_index]);
-        let payload = rest[marker_index + AGENT_EVENT_PREFIX.len()..].trim_start();
+        let payload = &rest[payload_start..];
         let Some(end) = complete_json_object_end(payload) else {
-            visible.push_str(&rest[marker_index..]);
+            if !drop_incomplete {
+                visible.push_str(&rest[marker_index..]);
+            }
             return (visible.trim().to_owned(), events);
         };
         events.push(payload[..end].to_owned());
@@ -381,28 +409,11 @@ pub(crate) fn silent_reply_reason(body: &str) -> Option<String> {
 }
 
 pub(crate) fn split_streaming_agent_event_lines(body: &str) -> (String, Vec<String>) {
-    split_agent_event_jsons_from_text(body)
+    split_agent_event_jsons_from_text(body, true)
 }
 
 pub(crate) fn split_complete_streaming_agent_event_lines(body: &str) -> (String, Vec<String>) {
-    let mut visible = String::new();
-    let mut events = Vec::new();
-    for segment in body.split_inclusive('\n') {
-        if !segment.ends_with('\n') {
-            visible.push_str(segment);
-            continue;
-        }
-        let line = segment.trim_end_matches(['\r', '\n']);
-        let (line_visible, line_events) = split_agent_event_jsons_from_text(line);
-        if line_events.is_empty() {
-            visible.push_str(segment);
-        } else if !line_visible.is_empty() {
-            visible.push_str(&line_visible);
-            visible.push('\n');
-        }
-        events.extend(line_events);
-    }
-    (visible.trim().to_owned(), events)
+    split_agent_event_jsons_from_text(body, false)
 }
 
 fn control_event_creates_visible_chat_message(json: &str) -> bool {
@@ -1281,19 +1292,69 @@ mod tests {
     }
 
     #[test]
-    fn complete_split_consumes_inline_control_events_only_after_newline() {
+    fn complete_split_consumes_complete_inline_control_events() {
         let (visible, events) = split_complete_streaming_agent_event_lines(
             "Working patch.LANTOR_EVENT {\"type\":\"activity\",\"title\":\"Step\",\"detail\":\"one\"}\npartial LANTOR_EVENT {\"type\":\"activity\",\"title\":\"Later\",\"detail\":\"two\"}",
         );
 
         assert_eq!(
             events,
-            vec![r#"{"type":"activity","title":"Step","detail":"one"}"#]
+            vec![
+                r#"{"type":"activity","title":"Step","detail":"one"}"#,
+                r#"{"type":"activity","title":"Later","detail":"two"}"#,
+            ]
         );
+        assert_eq!(visible, "Working patch.\npartial");
+    }
+
+    #[test]
+    fn strips_control_event_split_between_marker_and_json() {
+        let (visible, events) = split_streaming_agent_event_lines(
+            "LANTOR_EVENT\n{\"type\":\"activity\",\"title\":\"x\",\"detail\":\"ok\"}",
+        );
+
+        assert_eq!(visible, "");
         assert_eq!(
-            visible,
-            "Working patch.\npartial LANTOR_EVENT {\"type\":\"activity\",\"title\":\"Later\",\"detail\":\"two\"}"
+            events,
+            vec![r#"{"type":"activity","title":"x","detail":"ok"}"#]
         );
+    }
+
+    #[test]
+    fn strips_control_event_with_multiple_whitespace_chars() {
+        let (visible, events) = split_streaming_agent_event_lines(
+            "LANTOR_EVENT  \t\r\n {\"type\":\"activity\",\"title\":\"x\"}",
+        );
+
+        assert_eq!(visible, "");
+        assert_eq!(events, vec![r#"{"type":"activity","title":"x"}"#]);
+    }
+
+    #[test]
+    fn drops_unclosed_control_event_at_terminal_split() {
+        let (visible, events) =
+            split_streaming_agent_event_lines("Hello there.\nLANTOR_EVENT {\"type\":\"activity\"");
+
+        assert_eq!(visible, "Hello there.");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn keeps_unclosed_control_event_during_incremental_split() {
+        let body = "Hello there.\nLANTOR_EVENT {\"type\":\"activity\"";
+        let (visible, events) = split_complete_streaming_agent_event_lines(body);
+
+        assert_eq!(visible, body);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn preserves_text_when_event_marker_appears_in_prose() {
+        let body = "我刚提到 LANTOR_EVENT 是系统级控制行，看附录。";
+        let (visible, events) = split_streaming_agent_event_lines(body);
+
+        assert_eq!(visible, body);
+        assert!(events.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/events/control.rs
+++ b/src-tauri/src/events/control.rs
@@ -34,7 +34,7 @@ use crate::{
     try_claim_unassigned_task,
 };
 
-const AGENT_EVENT_MARKER: &str = "LANTOR_EVENT";
+const AGENT_EVENT_PREFIX: &str = "LANTOR_EVENT";
 const SILENT_REPLY_PREFIX: &str = "LANTOR_SILENT_REPLY";
 
 #[derive(Debug, Deserialize)]
@@ -300,49 +300,50 @@ fn extract_agent_event_json_with_remainder(line: &str) -> Option<(&str, &str)> {
             break;
         }
     }
-    let (marker_index, payload_start) = find_agent_event_marker(trimmed)?;
-    if marker_index != 0 {
+    let payload = strip_agent_event_prefix(trimmed)?;
+    if payload.is_empty() {
         return None;
     }
-    let payload = &trimmed[payload_start..];
     match complete_json_object_end(payload) {
         Some(end) => Some((&payload[..end], &payload[end..])),
         None => Some((payload.trim(), "")),
     }
 }
 
-fn find_agent_event_marker(text: &str) -> Option<(usize, usize)> {
-    let mut search_start = 0;
-    while search_start < text.len() {
-        let relative_index = text[search_start..].find(AGENT_EVENT_MARKER)?;
-        let marker_index = search_start + relative_index;
-        let after_marker_index = marker_index + AGENT_EVENT_MARKER.len();
-        let after_marker = &text[after_marker_index..];
-        let payload_offset = after_marker
-            .char_indices()
-            .find_map(|(index, ch)| (!ch.is_whitespace()).then_some(index));
-        let Some(payload_offset) = payload_offset else {
-            return Some((marker_index, text.len()));
-        };
-        let payload_start = after_marker_index + payload_offset;
-        if text[payload_start..].starts_with('{') {
-            return Some((marker_index, payload_start));
+fn strip_agent_event_prefix(text: &str) -> Option<&str> {
+    let rest = text.strip_prefix(AGENT_EVENT_PREFIX)?;
+    match rest.chars().next() {
+        None => Some(""),
+        Some(ch) if ch.is_whitespace() => Some(rest.trim_start()),
+        _ => None,
+    }
+}
+
+fn find_agent_event_prefix(text: &str) -> Option<(usize, &str)> {
+    let mut offset = 0usize;
+    while let Some(found) = text[offset..].find(AGENT_EVENT_PREFIX) {
+        let marker_index = offset + found;
+        let candidate = &text[marker_index..];
+        if let Some(payload) = strip_agent_event_prefix(candidate) {
+            return Some((marker_index, payload));
         }
-        search_start = after_marker_index;
+        offset = marker_index + AGENT_EVENT_PREFIX.len();
     }
     None
 }
 
-fn split_agent_event_jsons_from_text(text: &str, drop_incomplete: bool) -> (String, Vec<String>) {
+fn split_agent_event_jsons_from_text(
+    text: &str,
+    strip_incomplete_tail: bool,
+) -> (String, Vec<String>) {
     let mut visible = String::new();
     let mut events = Vec::new();
     let mut rest = text;
 
-    while let Some((marker_index, payload_start)) = find_agent_event_marker(rest) {
+    while let Some((marker_index, payload)) = find_agent_event_prefix(rest) {
         visible.push_str(&rest[..marker_index]);
-        let payload = &rest[payload_start..];
         let Some(end) = complete_json_object_end(payload) else {
-            if !drop_incomplete {
+            if !strip_incomplete_tail {
                 visible.push_str(&rest[marker_index..]);
             }
             return (visible.trim().to_owned(), events);
@@ -409,11 +410,15 @@ pub(crate) fn silent_reply_reason(body: &str) -> Option<String> {
 }
 
 pub(crate) fn split_streaming_agent_event_lines(body: &str) -> (String, Vec<String>) {
-    split_agent_event_jsons_from_text(body, true)
+    split_agent_event_jsons_from_text(body, false)
 }
 
 pub(crate) fn split_complete_streaming_agent_event_lines(body: &str) -> (String, Vec<String>) {
-    split_agent_event_jsons_from_text(body, false)
+    split_streaming_agent_event_lines(body)
+}
+
+pub(crate) fn split_terminal_streaming_agent_event_lines(body: &str) -> (String, Vec<String>) {
+    split_agent_event_jsons_from_text(body, true)
 }
 
 fn control_event_creates_visible_chat_message(json: &str) -> bool {
@@ -1259,7 +1264,7 @@ pub(crate) async fn handle_agent_event(
 mod tests {
     use super::{
         silent_reply_reason, split_complete_streaming_agent_event_lines,
-        split_streaming_agent_event_lines,
+        split_streaming_agent_event_lines, split_terminal_streaming_agent_event_lines,
     };
 
     #[test]
@@ -1292,7 +1297,7 @@ mod tests {
     }
 
     #[test]
-    fn complete_split_consumes_complete_inline_control_events() {
+    fn complete_split_consumes_inline_control_events_only_after_newline() {
         let (visible, events) = split_complete_streaming_agent_event_lines(
             "Working patch.LANTOR_EVENT {\"type\":\"activity\",\"title\":\"Step\",\"detail\":\"one\"}\npartial LANTOR_EVENT {\"type\":\"activity\",\"title\":\"Later\",\"detail\":\"two\"}",
         );
@@ -1308,53 +1313,26 @@ mod tests {
     }
 
     #[test]
-    fn strips_control_event_split_between_marker_and_json() {
+    fn consumes_control_events_when_json_starts_on_next_line() {
         let (visible, events) = split_streaming_agent_event_lines(
-            "LANTOR_EVENT\n{\"type\":\"activity\",\"title\":\"x\",\"detail\":\"ok\"}",
+            "Status update\nLANTOR_EVENT\n{\"type\":\"activity\",\"title\":\"Step\",\"detail\":\"one\"}\nDone",
         );
 
-        assert_eq!(visible, "");
         assert_eq!(
             events,
-            vec![r#"{"type":"activity","title":"x","detail":"ok"}"#]
+            vec![r#"{"type":"activity","title":"Step","detail":"one"}"#]
         );
+        assert_eq!(visible, "Status update\n\nDone");
     }
 
     #[test]
-    fn strips_control_event_with_multiple_whitespace_chars() {
-        let (visible, events) = split_streaming_agent_event_lines(
-            "LANTOR_EVENT  \t\r\n {\"type\":\"activity\",\"title\":\"x\"}",
+    fn terminal_split_strips_incomplete_control_tail() {
+        let (visible, events) = split_terminal_streaming_agent_event_lines(
+            "Working patch.\nLANTOR_EVENT\n{\"type\":\"activity\",\"title\":\"Step\"",
         );
 
-        assert_eq!(visible, "");
-        assert_eq!(events, vec![r#"{"type":"activity","title":"x"}"#]);
-    }
-
-    #[test]
-    fn drops_unclosed_control_event_at_terminal_split() {
-        let (visible, events) =
-            split_streaming_agent_event_lines("Hello there.\nLANTOR_EVENT {\"type\":\"activity\"");
-
-        assert_eq!(visible, "Hello there.");
         assert!(events.is_empty());
-    }
-
-    #[test]
-    fn keeps_unclosed_control_event_during_incremental_split() {
-        let body = "Hello there.\nLANTOR_EVENT {\"type\":\"activity\"";
-        let (visible, events) = split_complete_streaming_agent_event_lines(body);
-
-        assert_eq!(visible, body);
-        assert!(events.is_empty());
-    }
-
-    #[test]
-    fn preserves_text_when_event_marker_appears_in_prose() {
-        let body = "我刚提到 LANTOR_EVENT 是系统级控制行，看附录。";
-        let (visible, events) = split_streaming_agent_event_lines(body);
-
-        assert_eq!(visible, body);
-        assert!(events.is_empty());
+        assert_eq!(visible, "Working patch.");
     }
 
     #[test]

--- a/src-tauri/src/events/control.rs
+++ b/src-tauri/src/events/control.rs
@@ -34,7 +34,7 @@ use crate::{
     try_claim_unassigned_task,
 };
 
-const AGENT_EVENT_PREFIX: &str = "LANTOR_EVENT ";
+const AGENT_EVENT_PREFIX: &str = "LANTOR_EVENT";
 const SILENT_REPLY_PREFIX: &str = "LANTOR_SILENT_REPLY";
 
 #[derive(Debug, Deserialize)]
@@ -300,23 +300,52 @@ fn extract_agent_event_json_with_remainder(line: &str) -> Option<(&str, &str)> {
             break;
         }
     }
-    let payload = trimmed.strip_prefix(AGENT_EVENT_PREFIX)?.trim_start();
+    let payload = strip_agent_event_prefix(trimmed)?;
+    if payload.is_empty() {
+        return None;
+    }
     match complete_json_object_end(payload) {
         Some(end) => Some((&payload[..end], &payload[end..])),
         None => Some((payload.trim(), "")),
     }
 }
 
-pub(crate) fn split_agent_event_jsons_from_text(text: &str) -> (String, Vec<String>) {
+fn strip_agent_event_prefix(text: &str) -> Option<&str> {
+    let rest = text.strip_prefix(AGENT_EVENT_PREFIX)?;
+    match rest.chars().next() {
+        None => Some(""),
+        Some(ch) if ch.is_whitespace() => Some(rest.trim_start()),
+        _ => None,
+    }
+}
+
+fn find_agent_event_prefix(text: &str) -> Option<(usize, &str)> {
+    let mut offset = 0usize;
+    while let Some(found) = text[offset..].find(AGENT_EVENT_PREFIX) {
+        let marker_index = offset + found;
+        let candidate = &text[marker_index..];
+        if let Some(payload) = strip_agent_event_prefix(candidate) {
+            return Some((marker_index, payload));
+        }
+        offset = marker_index + AGENT_EVENT_PREFIX.len();
+    }
+    None
+}
+
+fn split_agent_event_jsons_from_text(
+    text: &str,
+    strip_incomplete_tail: bool,
+) -> (String, Vec<String>) {
     let mut visible = String::new();
     let mut events = Vec::new();
     let mut rest = text;
 
-    while let Some(marker_index) = rest.find(AGENT_EVENT_PREFIX) {
+    while let Some((marker_index, payload)) = find_agent_event_prefix(rest) {
         visible.push_str(&rest[..marker_index]);
-        let payload = rest[marker_index + AGENT_EVENT_PREFIX.len()..].trim_start();
         let Some(end) = complete_json_object_end(payload) else {
-            visible.push_str(&rest[marker_index..]);
+            if !strip_incomplete_tail {
+                visible.push_str(&rest[marker_index..]);
+            }
             return (visible.trim().to_owned(), events);
         };
         events.push(payload[..end].to_owned());
@@ -381,28 +410,15 @@ pub(crate) fn silent_reply_reason(body: &str) -> Option<String> {
 }
 
 pub(crate) fn split_streaming_agent_event_lines(body: &str) -> (String, Vec<String>) {
-    split_agent_event_jsons_from_text(body)
+    split_agent_event_jsons_from_text(body, false)
 }
 
 pub(crate) fn split_complete_streaming_agent_event_lines(body: &str) -> (String, Vec<String>) {
-    let mut visible = String::new();
-    let mut events = Vec::new();
-    for segment in body.split_inclusive('\n') {
-        if !segment.ends_with('\n') {
-            visible.push_str(segment);
-            continue;
-        }
-        let line = segment.trim_end_matches(['\r', '\n']);
-        let (line_visible, line_events) = split_agent_event_jsons_from_text(line);
-        if line_events.is_empty() {
-            visible.push_str(segment);
-        } else if !line_visible.is_empty() {
-            visible.push_str(&line_visible);
-            visible.push('\n');
-        }
-        events.extend(line_events);
-    }
-    (visible.trim().to_owned(), events)
+    split_streaming_agent_event_lines(body)
+}
+
+pub(crate) fn split_terminal_streaming_agent_event_lines(body: &str) -> (String, Vec<String>) {
+    split_agent_event_jsons_from_text(body, true)
 }
 
 fn control_event_creates_visible_chat_message(json: &str) -> bool {
@@ -1248,7 +1264,7 @@ pub(crate) async fn handle_agent_event(
 mod tests {
     use super::{
         silent_reply_reason, split_complete_streaming_agent_event_lines,
-        split_streaming_agent_event_lines,
+        split_streaming_agent_event_lines, split_terminal_streaming_agent_event_lines,
     };
 
     #[test]
@@ -1288,12 +1304,35 @@ mod tests {
 
         assert_eq!(
             events,
+            vec![
+                r#"{"type":"activity","title":"Step","detail":"one"}"#,
+                r#"{"type":"activity","title":"Later","detail":"two"}"#,
+            ]
+        );
+        assert_eq!(visible, "Working patch.\npartial");
+    }
+
+    #[test]
+    fn consumes_control_events_when_json_starts_on_next_line() {
+        let (visible, events) = split_streaming_agent_event_lines(
+            "Status update\nLANTOR_EVENT\n{\"type\":\"activity\",\"title\":\"Step\",\"detail\":\"one\"}\nDone",
+        );
+
+        assert_eq!(
+            events,
             vec![r#"{"type":"activity","title":"Step","detail":"one"}"#]
         );
-        assert_eq!(
-            visible,
-            "Working patch.\npartial LANTOR_EVENT {\"type\":\"activity\",\"title\":\"Later\",\"detail\":\"two\"}"
+        assert_eq!(visible, "Status update\n\nDone");
+    }
+
+    #[test]
+    fn terminal_split_strips_incomplete_control_tail() {
+        let (visible, events) = split_terminal_streaming_agent_event_lines(
+            "Working patch.\nLANTOR_EVENT\n{\"type\":\"activity\",\"title\":\"Step\"",
         );
+
+        assert!(events.is_empty());
+        assert_eq!(visible, "Working patch.");
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2827,6 +2827,137 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn streaming_control_event_split_after_marker_is_consumed() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let agent_id = insert_test_agent(&pool, "split-control-agent").await?;
+            let channel_id = insert_test_channel(&pool, "split-control-channel").await?;
+            let run_id: Uuid = sqlx::query_scalar(
+                r#"
+                insert into agent_runs (agent_id, command, status)
+                values ($1, 'codex app-server', 'running')
+                returning id
+                "#,
+            )
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            let stream_key = format!("{run_id}:split-control");
+            let event = json!({
+                "type": "activity",
+                "kind": "thinking",
+                "title": "Split marker",
+                "detail": "The marker and JSON arrived separately"
+            });
+
+            append_streaming_agent_message(
+                &pool,
+                agent_id,
+                channel_id,
+                None,
+                &stream_key,
+                "LANTOR_EVENT\n",
+            )
+            .await?;
+            let message_id = append_streaming_agent_message(
+                &pool,
+                agent_id,
+                channel_id,
+                None,
+                &stream_key,
+                &event.to_string(),
+            )
+            .await?;
+            finish_streaming_agent_message(&pool, &stream_key, "complete").await?;
+
+            let body: String = sqlx::query_scalar("select body from messages where id = $1")
+                .bind(message_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+            assert_eq!(body, "");
+
+            let activity_count: i64 = sqlx::query_scalar(
+                "select count(*) from agent_activities where run_id = $1 and title = 'Split marker'",
+            )
+            .bind(run_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            assert_eq!(activity_count, 1);
+
+            let leaked_messages: i64 = sqlx::query_scalar(
+                "select count(*) from messages where body like '%LANTOR_EVENT%'",
+            )
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            assert_eq!(leaked_messages, 0);
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn streaming_error_finish_drops_incomplete_control_fragment() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let agent_id = insert_test_agent(&pool, "partial-control-agent").await?;
+            let channel_id = insert_test_channel(&pool, "partial-control-channel").await?;
+            let run_id: Uuid = sqlx::query_scalar(
+                r#"
+                insert into agent_runs (agent_id, command, status)
+                values ($1, 'codex app-server', 'running')
+                returning id
+                "#,
+            )
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            let stream_key = format!("{run_id}:partial-control");
+            let message_id = append_streaming_agent_message(
+                &pool,
+                agent_id,
+                channel_id,
+                None,
+                &stream_key,
+                "Visible update\nLANTOR_EVENT {\"type\":\"activity\"",
+            )
+            .await?;
+
+            finish_streaming_agent_message(&pool, &stream_key, "error").await?;
+
+            let row = sqlx::query("select body, delivery_state from messages where id = $1")
+                .bind(message_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+            assert_eq!(row.get::<String, _>("body"), "Visible update");
+            assert_eq!(row.get::<String, _>("delivery_state"), "error");
+
+            let leaked_messages: i64 = sqlx::query_scalar(
+                "select count(*) from messages where body like '%LANTOR_EVENT%'",
+            )
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            assert_eq!(leaked_messages, 0);
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    #[tokio::test]
     async fn visible_reply_replaces_prior_activity_only_status_message() {
         let Some((pool, schema)) = test_pool().await else {
             return;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2062,6 +2062,16 @@ mod tests {
     }
 
     #[test]
+    fn extracts_agent_event_json_when_json_starts_on_next_line() {
+        assert_eq!(
+            extract_agent_event_json(
+                "LANTOR_EVENT\n{\"type\":\"message\",\"body\":\"from next line\"}"
+            ),
+            Some(r#"{"type":"message","body":"from next line"}"#)
+        );
+    }
+
+    #[test]
     fn extracts_agent_event_json_before_trailing_text() {
         assert_eq!(
             extract_agent_event_json(
@@ -3036,6 +3046,119 @@ mod tests {
         .await;
         drop_test_schema(pool, schema).await;
         result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn multiline_control_event_is_consumed_during_streaming() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let agent_id = insert_test_agent(&pool, "multiline-stream-control").await?;
+            let channel_id = insert_test_channel(&pool, "multiline-stream-channel").await?;
+            let run_id: Uuid = sqlx::query_scalar(
+                r#"
+                insert into agent_runs (agent_id, command, status)
+                values ($1, 'codex app-server', 'running')
+                returning id
+                "#,
+            )
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            let stream_key = format!("{run_id}:item-multiline");
+            let event = json!({
+                "type": "activity",
+                "kind": "thinking",
+                "title": "Streaming control",
+                "detail": "json starts on the next line"
+            });
+
+            let message_id = append_streaming_agent_message(
+                &pool,
+                agent_id,
+                channel_id,
+                None,
+                &stream_key,
+                &format!("LANTOR_EVENT\n{event}\n"),
+            )
+            .await?;
+
+            let body: String = sqlx::query_scalar("select body from messages where id = $1")
+                .bind(message_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+            assert_eq!(body, "");
+
+            let activity_count: i64 = sqlx::query_scalar(
+                "select count(*) from agent_activities where run_id = $1 and title = 'Streaming control'",
+            )
+            .bind(run_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            assert_eq!(activity_count, 1);
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn failed_streaming_message_strips_incomplete_control_tail() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let agent_id = insert_test_agent(&pool, "failed-stream-control").await?;
+            let channel_id = insert_test_channel(&pool, "failed-stream-channel").await?;
+            let run_id: Uuid = sqlx::query_scalar(
+                r#"
+                insert into agent_runs (agent_id, command, status)
+                values ($1, 'codex app-server', 'running')
+                returning id
+                "#,
+            )
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            let stream_key = format!("{run_id}:item-error");
+
+            let message_id = append_streaming_agent_message(
+                &pool,
+                agent_id,
+                channel_id,
+                None,
+                &stream_key,
+                "Working patch.\nLANTOR_EVENT\n{\"type\":\"activity\",\"title\":\"Step\"",
+            )
+            .await?;
+            finish_streaming_agent_message(&pool, &stream_key, "error").await?;
+
+            let row = sqlx::query("select body, delivery_state from messages where id = $1")
+                .bind(message_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+            assert_eq!(row.get::<String, _>("body"), "Working patch.");
+            assert_eq!(row.get::<String, _>("delivery_state"), "error");
+
+            let leaked_messages: i64 = sqlx::query_scalar(
+                "select count(*) from messages where body like '%LANTOR_EVENT%'",
+            )
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            assert_eq!(leaked_messages, 0);
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        assert!(result.is_ok(), "{:?}", result.err());
     }
 
     #[tokio::test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2062,6 +2062,16 @@ mod tests {
     }
 
     #[test]
+    fn extracts_agent_event_json_when_json_starts_on_next_line() {
+        assert_eq!(
+            extract_agent_event_json(
+                "LANTOR_EVENT\n{\"type\":\"message\",\"body\":\"from next line\"}"
+            ),
+            Some(r#"{"type":"message","body":"from next line"}"#)
+        );
+    }
+
+    #[test]
     fn extracts_agent_event_json_before_trailing_text() {
         assert_eq!(
             extract_agent_event_json(
@@ -2905,6 +2915,119 @@ mod tests {
         .await;
         drop_test_schema(pool, schema).await;
         result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn multiline_control_event_is_consumed_during_streaming() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let agent_id = insert_test_agent(&pool, "multiline-stream-control").await?;
+            let channel_id = insert_test_channel(&pool, "multiline-stream-channel").await?;
+            let run_id: Uuid = sqlx::query_scalar(
+                r#"
+                insert into agent_runs (agent_id, command, status)
+                values ($1, 'codex app-server', 'running')
+                returning id
+                "#,
+            )
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            let stream_key = format!("{run_id}:item-multiline");
+            let event = json!({
+                "type": "activity",
+                "kind": "thinking",
+                "title": "Streaming control",
+                "detail": "json starts on the next line"
+            });
+
+            let message_id = append_streaming_agent_message(
+                &pool,
+                agent_id,
+                channel_id,
+                None,
+                &stream_key,
+                &format!("LANTOR_EVENT\n{event}\n"),
+            )
+            .await?;
+
+            let body: String = sqlx::query_scalar("select body from messages where id = $1")
+                .bind(message_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+            assert_eq!(body, "");
+
+            let activity_count: i64 = sqlx::query_scalar(
+                "select count(*) from agent_activities where run_id = $1 and title = 'Streaming control'",
+            )
+            .bind(run_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            assert_eq!(activity_count, 1);
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn failed_streaming_message_strips_incomplete_control_tail() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let agent_id = insert_test_agent(&pool, "failed-stream-control").await?;
+            let channel_id = insert_test_channel(&pool, "failed-stream-channel").await?;
+            let run_id: Uuid = sqlx::query_scalar(
+                r#"
+                insert into agent_runs (agent_id, command, status)
+                values ($1, 'codex app-server', 'running')
+                returning id
+                "#,
+            )
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            let stream_key = format!("{run_id}:item-error");
+
+            let message_id = append_streaming_agent_message(
+                &pool,
+                agent_id,
+                channel_id,
+                None,
+                &stream_key,
+                "Working patch.\nLANTOR_EVENT\n{\"type\":\"activity\",\"title\":\"Step\"",
+            )
+            .await?;
+            finish_streaming_agent_message(&pool, &stream_key, "error").await?;
+
+            let row = sqlx::query("select body, delivery_state from messages where id = $1")
+                .bind(message_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+            assert_eq!(row.get::<String, _>("body"), "Working patch.");
+            assert_eq!(row.get::<String, _>("delivery_state"), "error");
+
+            let leaked_messages: i64 = sqlx::query_scalar(
+                "select count(*) from messages where body like '%LANTOR_EVENT%'",
+            )
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            assert_eq!(leaked_messages, 0);
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        assert!(result.is_ok(), "{:?}", result.err());
     }
 
     #[tokio::test]

--- a/src-tauri/src/runtime/streaming.rs
+++ b/src-tauri/src/runtime/streaming.rs
@@ -9,7 +9,7 @@ use crate::events::{
     control::{
         control_event_hides_empty_streaming_reply, handle_streaming_agent_event_json,
         silent_reply_reason, split_complete_streaming_agent_event_lines,
-        split_streaming_agent_event_lines,
+        split_terminal_streaming_agent_event_lines,
     },
 };
 use crate::message_store::load_message;
@@ -362,13 +362,21 @@ pub(crate) async fn finish_streaming_agent_message(
     stream_key: &str,
     delivery_state: &str,
 ) -> CommandResult<()> {
-    if let Some((agent_id, run_id, work_item_id)) =
-        load_streaming_control_context(pool, stream_key).await?
-    {
-        if consume_streaming_agent_control_lines(pool, agent_id, run_id, work_item_id, stream_key)
-            .await?
+    if delivery_state != "streaming" {
+        if let Some((agent_id, run_id, work_item_id)) =
+            load_streaming_control_context(pool, stream_key).await?
         {
-            return Ok(());
+            if consume_streaming_agent_control_lines(
+                pool,
+                agent_id,
+                run_id,
+                work_item_id,
+                stream_key,
+            )
+            .await?
+            {
+                return Ok(());
+            }
         }
     }
 
@@ -561,7 +569,7 @@ async fn consume_complete_streaming_agent_control_lines(
     let message_id: Uuid = row.get("id");
     let body: String = row.get("body");
     let (visible_body, event_jsons) = split_complete_streaming_agent_event_lines(&body);
-    if event_jsons.is_empty() && visible_body == body.trim() {
+    if event_jsons.is_empty() {
         return Ok(false);
     }
 
@@ -613,8 +621,9 @@ pub(crate) async fn consume_streaming_agent_control_lines(
     };
     let message_id: Uuid = row.get("id");
     let body: String = row.get("body");
-    let (visible_body, event_jsons) = split_streaming_agent_event_lines(&body);
-    if event_jsons.is_empty() && visible_body == body.trim() {
+    let (visible_body, event_jsons) = split_terminal_streaming_agent_event_lines(&body);
+    let body_changed = visible_body != body;
+    if event_jsons.is_empty() && !body_changed {
         return Ok(false);
     }
 
@@ -623,9 +632,10 @@ pub(crate) async fn consume_streaming_agent_control_lines(
     }
 
     if visible_body.is_empty()
-        && event_jsons
-            .iter()
-            .any(|json| control_event_hides_empty_streaming_reply(json))
+        && (body_changed
+            || event_jsons
+                .iter()
+                .any(|json| control_event_hides_empty_streaming_reply(json)))
     {
         delete_streaming_agent_message(pool, message_id, "stream_event_consumed").await?;
         return Ok(true);

--- a/src-tauri/src/runtime/streaming.rs
+++ b/src-tauri/src/runtime/streaming.rs
@@ -362,21 +362,13 @@ pub(crate) async fn finish_streaming_agent_message(
     stream_key: &str,
     delivery_state: &str,
 ) -> CommandResult<()> {
-    if delivery_state == "complete" {
-        if let Some((agent_id, run_id, work_item_id)) =
-            load_streaming_control_context(pool, stream_key).await?
-        {
-            if consume_streaming_agent_control_lines(
-                pool,
-                agent_id,
-                run_id,
-                work_item_id,
-                stream_key,
-            )
+    if let Some((agent_id, run_id, work_item_id)) =
+        load_streaming_control_context(pool, stream_key).await?
+    {
+        if consume_streaming_agent_control_lines(pool, agent_id, run_id, work_item_id, stream_key)
             .await?
-            {
-                return Ok(());
-            }
+        {
+            return Ok(());
         }
     }
 
@@ -569,7 +561,7 @@ async fn consume_complete_streaming_agent_control_lines(
     let message_id: Uuid = row.get("id");
     let body: String = row.get("body");
     let (visible_body, event_jsons) = split_complete_streaming_agent_event_lines(&body);
-    if event_jsons.is_empty() {
+    if event_jsons.is_empty() && visible_body == body.trim() {
         return Ok(false);
     }
 
@@ -622,7 +614,7 @@ pub(crate) async fn consume_streaming_agent_control_lines(
     let message_id: Uuid = row.get("id");
     let body: String = row.get("body");
     let (visible_body, event_jsons) = split_streaming_agent_event_lines(&body);
-    if event_jsons.is_empty() {
+    if event_jsons.is_empty() && visible_body == body.trim() {
         return Ok(false);
     }
 

--- a/src-tauri/src/runtime/streaming.rs
+++ b/src-tauri/src/runtime/streaming.rs
@@ -9,7 +9,7 @@ use crate::events::{
     control::{
         control_event_hides_empty_streaming_reply, handle_streaming_agent_event_json,
         silent_reply_reason, split_complete_streaming_agent_event_lines,
-        split_streaming_agent_event_lines,
+        split_terminal_streaming_agent_event_lines,
     },
 };
 use crate::message_store::load_message;
@@ -362,7 +362,7 @@ pub(crate) async fn finish_streaming_agent_message(
     stream_key: &str,
     delivery_state: &str,
 ) -> CommandResult<()> {
-    if delivery_state == "complete" {
+    if delivery_state != "streaming" {
         if let Some((agent_id, run_id, work_item_id)) =
             load_streaming_control_context(pool, stream_key).await?
         {
@@ -621,8 +621,9 @@ pub(crate) async fn consume_streaming_agent_control_lines(
     };
     let message_id: Uuid = row.get("id");
     let body: String = row.get("body");
-    let (visible_body, event_jsons) = split_streaming_agent_event_lines(&body);
-    if event_jsons.is_empty() {
+    let (visible_body, event_jsons) = split_terminal_streaming_agent_event_lines(&body);
+    let body_changed = visible_body != body;
+    if event_jsons.is_empty() && !body_changed {
         return Ok(false);
     }
 
@@ -631,9 +632,10 @@ pub(crate) async fn consume_streaming_agent_control_lines(
     }
 
     if visible_body.is_empty()
-        && event_jsons
-            .iter()
-            .any(|json| control_event_hides_empty_streaming_reply(json))
+        && (body_changed
+            || event_jsons
+                .iter()
+                .any(|json| control_event_hides_empty_streaming_reply(json)))
     {
         delete_streaming_agent_message(pool, message_id, "stream_event_consumed").await?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- parse `LANTOR_EVENT` when the marker and JSON are separated by arbitrary whitespace, including newlines
- keep incomplete control fragments during incremental streaming, but drop them during terminal cleanup so error/abort finishes do not leave raw control text visible
- run streaming control cleanup for all terminal delivery states, not only `complete`
- add parser and integration regressions for split marker/JSON events and incomplete error-finalized fragments

## Verification
- cargo test
- npm run build
- git diff --check