### PR TITLE
Strengthen agent profile popover border

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1395,7 +1395,7 @@ button,
 
 .agent-avatar-profile-card {
   --agent-avatar-profile-bg: var(--bg-panel);
-  --agent-avatar-profile-border: var(--border-subtle);
+  --agent-avatar-profile-border: var(--border-strong);
   --agent-avatar-profile-shadow: var(--surface-shadow);
   --agent-avatar-profile-ink-primary: var(--ink-primary);
   --agent-avatar-profile-ink-secondary: var(--ink-secondary);


### PR DESCRIPTION
## Summary
- raise the shared agent profile popover border from `--border-subtle` to `--border-strong`
- keeps the #69 portal/theme-token fix intact while making the verified hover card surface easier to distinguish

## Verification
- `git diff --check`
- `npm run lint:css-tokens`
- `npm run build`

Note: the clean worktree initially had no `node_modules`, so the first build failed on missing React/Tauri dependencies; after linking to the existing local dependencies, the build passed.