### PR TITLE
Strengthen agent hover card contrast

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1395,7 +1395,7 @@ button,
 
 .agent-avatar-profile-card {
   --agent-avatar-profile-bg: var(--bg-panel);
-  --agent-avatar-profile-border: var(--border-subtle);
+  --agent-avatar-profile-border: var(--border-strong);
   --agent-avatar-profile-shadow: var(--surface-shadow);
   --agent-avatar-profile-ink-primary: var(--ink-primary);
   --agent-avatar-profile-ink-secondary: var(--ink-secondary);


### PR DESCRIPTION
## Summary
- raise the shared agent hover card border from `--border-subtle` to `--border-strong`
- keep the portal hover card and activity progress surfaces from `#69` unchanged while making the card edge more legible

## Testing
- git diff --check
- npm run build