### PR TITLE
Polish mobile channel layout and image previews

### DIFF
--- a/src/components/MessageAttachments.tsx
+++ b/src/components/MessageAttachments.tsx
@@ -37,8 +37,15 @@ export function MessageAttachments({ attachments }: MessageAttachmentsProps) {
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") setImagePreview(null);
     }
+    function handleHistoryNavigation() {
+      setImagePreview(null);
+    }
     window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    window.addEventListener("popstate", handleHistoryNavigation);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("popstate", handleHistoryNavigation);
+    };
   }, [imagePreview]);
 
   if (attachments.length === 0) return null;
@@ -56,7 +63,11 @@ export function MessageAttachments({ attachments }: MessageAttachmentsProps) {
                 type="button"
                 className={`message-attachment image ${attachment.local_url ? "pending" : ""}`}
                 aria-label={`Preview ${attachment.original_name}`}
-                onClick={() => setImagePreview({ src, alt: attachment.original_name })}
+                onPointerDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setImagePreview({ src, alt: attachment.original_name });
+                }}
               >
                 <img src={src} alt="" loading="lazy" />
               </button>
@@ -70,7 +81,11 @@ export function MessageAttachments({ attachments }: MessageAttachmentsProps) {
               target="_blank"
               rel="noreferrer"
               title={attachment.original_name}
-              onClick={(event) => void openStoredAttachment(event, attachment)}
+              onPointerDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                void openStoredAttachment(event, attachment);
+              }}
             >
               <span className="attachment-icon"><FileText size={18} /></span>
               <span className="attachment-meta">
@@ -82,22 +97,29 @@ export function MessageAttachments({ attachments }: MessageAttachmentsProps) {
         })}
       </div>
       {imagePreview && (
-        <div className="attachment-lightbox" role="dialog" aria-modal="true" aria-label="Image preview">
+        <div
+          className="attachment-lightbox"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Image preview"
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => event.stopPropagation()}
+        >
           <button
             type="button"
             className="attachment-lightbox-backdrop"
             aria-label="Close image preview"
             onClick={() => setImagePreview(null)}
           />
+          <button
+            type="button"
+            className="attachment-lightbox-close"
+            aria-label="Close image preview"
+            onClick={() => setImagePreview(null)}
+          >
+            <X size={18} />
+          </button>
           <div className="attachment-lightbox-content">
-            <button
-              type="button"
-              className="attachment-lightbox-close"
-              aria-label="Close image preview"
-              onClick={() => setImagePreview(null)}
-            >
-              <X size={18} />
-            </button>
             <img src={imagePreview.src} alt={imagePreview.alt} />
           </div>
         </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -2801,7 +2801,7 @@ mark {
   z-index: 1200;
   display: grid;
   place-items: center;
-  padding: 24px;
+  padding: calc(60px + env(safe-area-inset-top)) 16px calc(24px + env(safe-area-inset-bottom));
 }
 
 .attachment-lightbox-backdrop {
@@ -2818,14 +2818,14 @@ mark {
   z-index: 1;
   display: grid;
   max-width: min(92vw, 1120px);
-  max-height: 88vh;
+  max-height: calc(100dvh - 104px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
   place-items: center;
 }
 
 .attachment-lightbox-content img {
   display: block;
   max-width: 100%;
-  max-height: 88vh;
+  max-height: calc(100dvh - 104px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
   border-radius: 18px;
   box-shadow: 0 28px 80px rgba(0, 0, 0, 0.34);
   object-fit: contain;
@@ -2833,8 +2833,8 @@ mark {
 
 .attachment-lightbox-close {
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: calc(14px + env(safe-area-inset-top));
+  right: 14px;
   z-index: 2;
   display: inline-grid;
   width: 34px;
@@ -8608,22 +8608,27 @@ body.resizing-row * {
 
   .topbar {
     overflow: visible;
-    min-height: 58px;
+    min-height: 48px;
     justify-content: flex-start;
-    gap: 10px;
-    padding: calc(10px + env(safe-area-inset-top)) 12px 10px;
+    gap: 8px;
+    padding: calc(5px + env(safe-area-inset-top)) 10px 5px;
   }
 
   .mobile-nav-button {
     display: grid;
-    width: 40px;
-    height: 40px;
+    width: 30px;
+    height: 30px;
     flex: 0 0 auto;
     place-items: center;
-    border-radius: 13px;
+    border-radius: 8px;
     background: var(--panel-strong);
     color: var(--ink);
     box-shadow: inset 0 0 0 1px var(--line);
+  }
+
+  .mobile-nav-button svg {
+    width: 16px;
+    height: 16px;
   }
 
   .desktop-history-controls {
@@ -8631,25 +8636,25 @@ body.resizing-row * {
   }
 
   .hash-card {
-    width: 36px;
-    height: 36px;
-    border-radius: 12px;
+    width: 30px;
+    height: 30px;
+    border-radius: 10px;
   }
 
   .hash-card.dm-card {
-    width: 38px;
-    height: 38px;
+    width: 30px;
+    height: 30px;
   }
 
   .hash-card.dm-card .agent-avatar {
-    width: 38px;
-    height: 38px;
-    border-radius: 13px;
+    width: 30px;
+    height: 30px;
+    border-radius: 10px;
   }
 
   .channel-title {
     flex: 1 1 0;
-    max-width: calc(100vw - 162px);
+    max-width: calc(100vw - 118px);
     min-width: 0;
     overflow: hidden;
     gap: 10px;
@@ -8671,11 +8676,7 @@ body.resizing-row * {
   }
 
   .channel-title p {
-    overflow: hidden;
-    max-width: 100%;
-    line-height: 14px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    display: none;
   }
 
   .channel-title .hash-card {
@@ -8684,20 +8685,20 @@ body.resizing-row * {
 
   .channel-header-actions {
     flex: 0 0 auto;
-    max-width: 92px;
+    max-width: 66px;
     min-width: 0;
-    gap: 6px;
+    gap: 4px;
   }
 
   .channel-agent-count-trigger {
-    min-width: 44px;
-    height: 44px;
-    padding: 0 8px;
+    min-width: 30px;
+    height: 30px;
+    padding: 0 5px;
   }
 
   .channel-action-trigger {
-    width: 44px;
-    height: 44px;
+    width: 30px;
+    height: 30px;
   }
 
   .channel-agent-preview {
@@ -8795,11 +8796,12 @@ body.resizing-row * {
   }
 
   .message-attachments {
-    grid-template-columns: minmax(0, 1fr);
+    grid-template-columns: minmax(0, min(58vw, 220px));
+    justify-content: start;
   }
 
   .message-attachment.image img {
-    height: 180px;
+    height: 124px;
   }
 
   .task-board {
@@ -8850,8 +8852,8 @@ body.resizing-row * {
   .reply-composer {
     align-items: end;
     gap: 6px 8px;
-    margin-bottom: calc(88px + env(safe-area-inset-bottom));
-    padding: 8px 12px 8px;
+    margin-bottom: calc(68px + env(safe-area-inset-bottom));
+    padding: 4px 12px;
   }
 
   .composer {
@@ -8886,17 +8888,17 @@ body.resizing-row * {
   .reply-composer:focus-within,
   .app.mobile-composer-focused .composer,
   .app.mobile-composer-focused .reply-composer {
-    margin-bottom: 0;
-    padding-bottom: calc(12px + env(safe-area-inset-bottom));
+    margin-bottom: calc(68px + env(safe-area-inset-bottom));
+    padding-bottom: calc(6px + env(safe-area-inset-bottom));
   }
 
   .composer textarea,
   .reply-composer textarea {
     grid-area: input;
-    min-height: 46px;
+    min-height: 38px;
     max-height: 112px;
-    padding: 12px 13px;
-    border-radius: 16px;
+    padding: 7px 13px;
+    border-radius: 14px;
     font-size: var(--type-size-control);
     line-height: 20px;
     overflow-y: auto;
@@ -8944,12 +8946,6 @@ body.resizing-row * {
     display: none;
   }
 
-  .app.mobile-composer-focused .mobile-bottom-nav,
-  .app:has(.composer textarea:focus) .mobile-bottom-nav,
-  .app:has(.reply-composer textarea:focus) .mobile-bottom-nav {
-    display: none;
-  }
-
   .thread,
   .agent-drawer {
     position: fixed;
@@ -8970,16 +8966,16 @@ body.resizing-row * {
 
   .mobile-bottom-nav {
     position: fixed;
-    right: 12px;
-    bottom: calc(14px + env(safe-area-inset-bottom));
-    left: 12px;
+    right: 10px;
+    bottom: calc(8px + env(safe-area-inset-bottom));
+    left: 10px;
     z-index: 80;
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 4px;
-    padding: 6px 8px;
+    gap: 3px;
+    padding: 4px 6px;
     border: 1px solid var(--border-subtle);
-    border-radius: 24px;
+    border-radius: 21px;
     background: var(--bg-panel-strong);
     box-shadow:
       0 16px 40px rgba(20, 23, 31, 0.18),
@@ -8991,15 +8987,16 @@ body.resizing-row * {
     position: relative;
     display: grid;
     min-width: 0;
-    min-height: 52px;
+    min-height: 42px;
     place-items: center;
     align-content: center;
-    gap: 3px;
-    border-radius: 18px;
+    gap: 2px;
+    border-radius: 16px;
     background: transparent;
     color: var(--ink-muted);
-    font-size: var(--type-size-caption);
+    font-size: 10px;
     font-weight: var(--type-weight-semibold);
+    line-height: 1;
   }
 
   .mobile-bottom-nav button.active {
@@ -9013,10 +9010,15 @@ body.resizing-row * {
     place-items: center;
   }
 
+  .mobile-bottom-nav svg {
+    width: 17px;
+    height: 17px;
+  }
+
   .mobile-bottom-nav .unread-badge {
     position: absolute;
-    top: -7px;
-    right: -12px;
+    top: -6px;
+    right: -11px;
   }
 
   .thread header,
@@ -9026,9 +9028,9 @@ body.resizing-row * {
     width: 100%;
     max-width: 100%;
     min-width: 0;
-    min-height: 58px;
-    gap: 10px;
-    padding: calc(10px + env(safe-area-inset-top)) 12px 10px;
+    min-height: 44px;
+    gap: 6px;
+    padding: calc(4px + env(safe-area-inset-top)) 10px 4px;
   }
 
   .thread header > div,
@@ -9039,22 +9041,22 @@ body.resizing-row * {
   }
 
   .thread-title {
-    max-width: calc(100vw - 124px);
+    max-width: calc(100vw - 88px);
     overflow: hidden;
   }
 
   .thread-title-card {
-    flex: 0 0 auto;
+    display: none;
   }
 
   .thread header .thread-mobile-back,
   .agent-drawer-head .agent-mobile-back {
     display: grid;
-    width: 44px;
-    height: 44px;
+    width: 30px;
+    height: 30px;
     flex: 0 0 auto;
     place-items: center;
-    border-radius: 13px;
+    border-radius: 10px;
     background: var(--panel-strong);
     color: var(--ink);
     box-shadow: inset 0 0 0 1px var(--line);
@@ -9062,13 +9064,13 @@ body.resizing-row * {
 
   .thread header .thread-close {
     display: grid;
-    width: 44px;
-    height: 44px;
+    width: 30px;
+    height: 30px;
     flex: 0 0 auto;
     margin-left: auto;
     padding: 0;
     place-items: center;
-    border-radius: 13px;
+    border-radius: 10px;
     background: var(--panel-strong);
     color: var(--ink);
     box-shadow: inset 0 0 0 1px var(--line);
@@ -9087,8 +9089,8 @@ body.resizing-row * {
   }
 
   .agent-drawer-head .agent-head-action {
-    width: 44px;
-    height: 44px;
+    width: 30px;
+    height: 30px;
   }
 
   .thread h2,
@@ -9097,17 +9099,13 @@ body.resizing-row * {
     min-width: 0;
     overflow: hidden;
     font-size: var(--type-size-title);
-    line-height: 22px;
+    line-height: 18px;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   .thread header p {
-    overflow: hidden;
-    font-size: var(--type-size-caption);
-    line-height: 14px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    display: none;
   }
 
   .thread-focus,


### PR DESCRIPTION
## Summary
- Tighten the mobile channel header, thread header, bottom navigation, composer, and message image attachment sizing so the phone web layout uses less vertical space while keeping controls readable and tappable.
- Include the final extra composer whitespace reduction: lower bottom clearance, smaller composer padding, and a slightly shorter input minimum height for the mobile/narrow viewport.
- Keep the mobile bottom navigation visible while composing and preserve bottom clearance so it does not overlap the input.
- Make channel image attachments behave like thread images: tapping an image opens the existing preview lightbox instead of opening the message thread, and clicking outside the image or pressing Escape closes the preview.
- Move the image preview close button outside the image area so it does not obscure image content.
- Prevent attachment taps from bubbling into the message card, and clear image preview state on browser history navigation so Back does not return into an image preview.

## Purpose
These changes refine the mobile web experience after testing on a phone-sized viewport. The goal is to reclaim screen space in high-frequency surfaces, make channel image previews more compact, and ensure attachment interactions are predictable without changing the desktop wide-screen layout.

## Verification
- `git diff --check`
- `npm run lint:css-tokens`
- `npm run build`

## Notes
Most layout changes live under `@media (max-width: 760px)`, so they apply to mobile/narrow viewports. The attachment event handling is shared by desktop and mobile because it fixes interaction behavior in the common `MessageAttachments` component.