### PR TITLE
Fix stale warm Codex start state

### DIFF
--- a/src-tauri/src/runtime/codex.rs
+++ b/src-tauri/src/runtime/codex.rs
@@ -121,6 +121,99 @@ async fn codex_context_rotation_candidate(
     }))
 }
 
+pub(crate) async fn cleanup_failed_warm_codex_start(
+    pool: &SqlitePool,
+    agent_id: Uuid,
+    run_id: Uuid,
+    work_item_id: Option<Uuid>,
+    error: &str,
+    requeue_work_item: bool,
+) -> CommandResult<()> {
+    let error_log = format!("codex warm turn failed before start: {error}\n");
+    sqlx::query(
+        r#"
+        update agent_runs
+        set status = 'failed',
+            exit_code = null,
+            log = substr(log || $2, -20000),
+            stopped_at = strftime('%Y-%m-%dT%H:%M:%f+00:00','now')
+        where id = $1
+        "#,
+    )
+    .bind(run_id)
+    .bind(&error_log)
+    .execute(pool)
+    .await
+    .map_err(to_string)?;
+    notify_ui_agent_run_changed(pool, run_id, "run_failed").await;
+
+    sqlx::query("update agents set status = $2 where id = $1")
+        .bind(agent_id)
+        .bind(if requeue_work_item {
+            "running"
+        } else {
+            "error"
+        })
+        .execute(pool)
+        .await
+        .map_err(to_string)?;
+
+    if let Some(work_item_id) = work_item_id {
+        if requeue_work_item {
+            sqlx::query(
+                r#"
+                update agent_work_items
+                set status = 'queued',
+                    run_id = null,
+                    completed_at = null,
+                    updated_at = strftime('%Y-%m-%dT%H:%M:%f+00:00','now')
+                where id = $1
+                "#,
+            )
+            .bind(work_item_id)
+            .execute(pool)
+            .await
+            .map_err(to_string)?;
+            notify_ui_work_item_changed(pool, work_item_id, "work_item_queued").await;
+            let _ = notify_supervisor_wake(pool).await;
+        } else {
+            sqlx::query(
+                r#"
+                update agent_work_items
+                set status = 'failed',
+                    completed_at = strftime('%Y-%m-%dT%H:%M:%f+00:00','now'),
+                    updated_at = strftime('%Y-%m-%dT%H:%M:%f+00:00','now')
+                where id = $1
+                "#,
+            )
+            .bind(work_item_id)
+            .execute(pool)
+            .await
+            .map_err(to_string)?;
+            notify_ui_work_item_changed(pool, work_item_id, "work_item_failed").await;
+        }
+    }
+
+    record_agent_activity(
+        pool,
+        Some(agent_id),
+        Some(run_id),
+        if requeue_work_item {
+            "dispatch"
+        } else {
+            "run_error"
+        },
+        if requeue_work_item {
+            "Request requeued"
+        } else {
+            "Run failed to start"
+        },
+        error.to_owned(),
+    )
+    .await?;
+    Ok(())
+}
+
 async fn get_or_spawn_warm_codex_runtime(
     pool: &SqlitePool,
     registry: &WarmCodexRegistry,
@@ -871,50 +964,75 @@ pub(crate) async fn supervisor_start_codex_streaming_agent(
 
     let pending_stream_key = codex_pending_stream_key(run_id);
     if let Some(channel_id) = channel_id {
-        ensure_streaming_agent_message(
+        if let Err(err) = ensure_streaming_agent_message(
             pool,
             agent_id,
             channel_id,
             thread_root_id,
             &pending_stream_key,
         )
-        .await?;
+        .await
+        {
+            cleanup_failed_warm_codex_start(pool, agent_id, run_id, work_item_id, &err, false)
+                .await?;
+            return Err(err);
+        }
     }
 
-    let request_id = {
+    let cwd = match effective_codex_cwd(&working_directory) {
+        Ok(cwd) => cwd,
+        Err(err) => {
+            cleanup_failed_warm_codex_start(pool, agent_id, run_id, work_item_id, &err, false)
+                .await?;
+            return Err(err);
+        }
+    };
+    let model_value = codex_model_value(&model);
+    let request_id = match {
         let mut state = runtime.state.lock().await;
         if !state.alive {
-            return Err("codex warm runtime exited before turn start".to_owned());
+            Err("codex warm runtime exited before turn start".to_owned())
+        } else if state.active.is_some() {
+            Err("codex warm runtime became busy before turn start".to_owned())
+        } else {
+            let request_id = state.next_request_id;
+            state.next_request_id += 1;
+            state.last_activity = Instant::now();
+            let mut stream_keys = HashSet::new();
+            if channel_id.is_some() {
+                stream_keys.insert(pending_stream_key.clone());
+            }
+            state.active = Some(CodexActiveTurn {
+                run_id,
+                turn_request_id: request_id,
+                turn_id: None,
+                started_at: Instant::now(),
+                first_delta_at: None,
+                work_item_id,
+                channel_id,
+                thread_root_id,
+                stream_keys,
+                steer_requests: HashMap::new(),
+                steer_disabled: false,
+                interrupt_request_id: None,
+            });
+            Ok(request_id)
         }
-        if state.active.is_some() {
-            return Err("codex warm runtime became busy before turn start".to_owned());
+    } {
+        Ok(request_id) => request_id,
+        Err(err) => {
+            cleanup_failed_warm_codex_start(
+                pool,
+                agent_id,
+                run_id,
+                work_item_id,
+                &err,
+                err == "codex warm runtime became busy before turn start",
+            )
+            .await?;
+            return Err(err);
         }
-        let request_id = state.next_request_id;
-        state.next_request_id += 1;
-        state.last_activity = Instant::now();
-        let mut stream_keys = HashSet::new();
-        if channel_id.is_some() {
-            stream_keys.insert(pending_stream_key.clone());
-        }
-        state.active = Some(CodexActiveTurn {
-            run_id,
-            turn_request_id: request_id,
-            turn_id: None,
-            started_at: Instant::now(),
-            first_delta_at: None,
-            work_item_id,
-            channel_id,
-            thread_root_id,
-            stream_keys,
-            steer_requests: HashMap::new(),
-            steer_disabled: false,
-            interrupt_request_id: None,
-        });
-        request_id
     };
-
-    let cwd = effective_codex_cwd(&working_directory)?;
-    let model_value = codex_model_value(&model);
     let write_result = {
         let mut stdin = runtime.stdin.lock().await;
         let mut params = json!({

--- a/src-tauri/src/tests/agent_work_dispatch.rs
+++ b/src-tauri/src/tests/agent_work_dispatch.rs
@@ -384,6 +384,132 @@ async fn task_work_item_queue_and_start_do_not_insert_system_messages() {
 }
 
 #[tokio::test]
+async fn busy_warm_codex_start_requeues_work_item_without_leaving_running_state() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "busy-start-agent").await?;
+        let channel_id = insert_test_channel(&pool, "busy-start").await?;
+        let work_item_id: Uuid = sqlx::query_scalar(
+            r#"
+            insert into agent_work_items (
+                agent_id, channel_id, source_kind, title, context, status
+            )
+            values ($1, $2, 'thread_followup', 'busy start', 'context', 'running')
+            returning id
+            "#,
+        )
+        .bind(agent_id)
+        .bind(channel_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        let run_id: Uuid = sqlx::query_scalar(
+            r#"
+            insert into agent_runs (agent_id, work_item_id, command, working_directory, status, pid, log)
+            values ($1, $2, 'codex app-server --listen stdio://', '', 'running', 51932, '$ codex app-server --listen stdio://')
+            returning id
+            "#,
+        )
+        .bind(agent_id)
+        .bind(work_item_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        sqlx::query(
+            r#"
+            update agent_work_items
+            set run_id = $2
+            where id = $1
+            "#,
+        )
+        .bind(work_item_id)
+        .bind(run_id)
+        .execute(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        sqlx::query("update agents set status = 'running' where id = $1")
+            .bind(agent_id)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+        crate::runtime::codex::cleanup_failed_warm_codex_start(
+            &pool,
+            agent_id,
+            run_id,
+            Some(work_item_id),
+            "codex warm runtime became busy before turn start",
+            true,
+        )
+        .await?;
+
+        let run_row = sqlx::query(
+            r#"
+            select status, stopped_at, log
+            from agent_runs
+            where id = $1
+            "#,
+        )
+        .bind(run_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        let run_status: String = run_row.get("status");
+        let run_stopped_at: Option<String> = run_row.get("stopped_at");
+        let run_log: String = run_row.get("log");
+        assert_eq!(run_status, "failed");
+        assert!(run_stopped_at.is_some());
+        assert!(run_log.contains("codex warm runtime became busy before turn start"));
+
+        let work_row = sqlx::query(
+            r#"
+            select status, run_id, completed_at
+            from agent_work_items
+            where id = $1
+            "#,
+        )
+        .bind(work_item_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        let work_status: String = work_row.get("status");
+        let work_run_id: Option<Uuid> = work_row.get("run_id");
+        let work_completed_at: Option<String> = work_row.get("completed_at");
+        assert_eq!(work_status, "queued");
+        assert!(work_run_id.is_none());
+        assert!(work_completed_at.is_none());
+
+        let agent_status: String = sqlx::query_scalar("select status from agents where id = $1")
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+        assert_eq!(agent_status, "running");
+
+        let activity_title: String = sqlx::query_scalar(
+            r#"
+            select title
+            from agent_activities
+            where run_id = $1
+            order by created_at desc
+            limit 1
+            "#,
+        )
+        .bind(run_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(activity_title, "Request requeued");
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    assert!(result.is_ok(), "{:?}", result.err());
+}
+
+#[tokio::test]
 async fn restart_backlog_redispatches_assigned_in_progress_tasks() {
     let Some((pool, schema)) = test_pool().await else {
         return;


### PR DESCRIPTION
## Summary
- fix the warm Codex start race that could leave a work item and run stuck in `running` even though the turn never actually started
- requeue the work item when the second pre-turn check hits `codex warm runtime became busy before turn start`
- add a regression test that proves the busy-start path no longer leaves stale `running` state behind

## What was happening
We had a reproducible stale-state bug in the warm Codex runtime path.

A single Agent warm runtime PID could end up associated with two runs within a few milliseconds:
- one run successfully acquired the active turn and proceeded to `Request acknowledged`
- the second run was already marked as `running` in SQLite, but then immediately failed with `codex warm runtime became busy before turn start`

That second run never actually started a turn, but the database had already been updated as if it had. This left the UI/inspect path showing a misleading `running` request until later cleanup marked it `failed` / `unknown`.

## Root cause
The warm Codex start path had two separate busy checks:
1. an early check before creating the run
2. a second check right before `turn/start`

Between those two checks, the code already:
- created the `agent_runs` row
- updated `agent_work_items.status` to `running`
- updated `agent_runs.status` to `running`
- updated `agents.status` to `running`

If another request claimed the warm runtime in that window, the second check failed with:
- `codex warm runtime became busy before turn start`

But that failure path did not roll back the already-written `running` state.

## Trigger / reproduction shape
The observed production timeline was:
- two Dylan work items were scheduled back-to-back against the same warm runtime
- both were assigned the same warm runtime PID within ~2 ms
- only the first run produced `Request acknowledged` and completed normally
- the second run produced the supervisor error `codex warm runtime became busy before turn start`
- the second run had already emitted `Request started` / `Started working`, so the UI looked like it was still live even though no turn had actually begun

In other words, this is not a model hang. It is a scheduler/state-transition race in the warm-runtime startup path.

## Fix
This patch makes the pre-turn failure path explicit.

For failures that happen after the run/work item were created but before `turn/start` is accepted:
- the run is marked `failed` with a log entry that explains the pre-start failure
- the work item is either failed or requeued depending on the failure mode
- the busy-race case specifically requeues the work item and clears its `run_id` so it can be retried instead of being stranded in `running`
- the UI is notified with `run_failed` / `work_item_queued` or `work_item_failed`

I also moved `effective_codex_cwd()` ahead of active-turn registration so we do not create an active turn before a fallible cwd normalization step.

## Why requeue on `busy before turn start`
This failure is a scheduler race, not user-level execution failure.

The work item did not actually begin a Codex turn, so the correct recovery is to put it back into `queued` and let the normal scheduler retry it (or steer it into the active warm turn if it is the same surface).

## Regression coverage
Added a regression test that asserts the busy-start cleanup path:
- marks the run as `failed`
- clears `stopped_at`
- returns the work item to `queued`
- clears the work item `run_id`
- leaves the agent in `running`
- records `Request requeued`

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml busy_warm_codex_start_requeues_work_item_without_leaving_running_state -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml -- --nocapture`
