### PR TITLE
Keep unread badges fixed width

### DIFF
--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -105,10 +105,47 @@ function taskStatusLabel(status: string) {
   return status.replace("_", " ");
 }
 
-function replyingAgentsLabel(progress: ReturnType<typeof activeProgressByAgent>) {
-  if (progress.length === 0) return "";
-  if (progress.length === 1) return `${progress[0].agent.display_name} is replying`;
-  return `${progress.length} agents are replying`;
+type ReplyProgress = ReturnType<typeof activeProgressByAgent>[number];
+
+function compactReplyProgressText(value: string, limit: number) {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) return "";
+  if (normalized.length <= limit) return normalized;
+  return `${normalized.slice(0, Math.max(0, limit - 1)).trim()}...`;
+}
+
+function replyProgressSummary(progress: ReplyProgress) {
+  if (progress.latestActivity) {
+    const title = (progress.latestActivity.summary || progress.latestActivity.title || "Working").trim() || "Working";
+    const rawDetail = progress.latestActivity.detail.trim();
+    const detail = rawDetail.startsWith("{") || rawDetail.startsWith("[")
+      ? ""
+      : compactReplyProgressText(rawDetail, 72);
+    return {
+      title,
+      detail: detail && detail !== title ? detail : "",
+    };
+  }
+  if (progress.queuedItems.length > 0) {
+    return {
+      title: progress.queuedItems.length === 1 ? "Queued" : `${progress.queuedItems.length} queued`,
+      detail: "Waiting to start",
+    };
+  }
+  return {
+    title: "Working",
+    detail: "",
+  };
+}
+
+function ActiveReplyIndicator({ label }: { label: string }) {
+  return (
+    <span className="thread-reply-status-text" aria-label={label}>
+      <span className="thread-reply-status-dot" aria-hidden="true" />
+      <span className="thread-reply-status-dot" aria-hidden="true" />
+      <span className="thread-reply-status-dot" aria-hidden="true" />
+    </span>
+  );
 }
 
 function shouldCollapseChannelMessage(body: string) {
@@ -685,7 +722,10 @@ export function Conversation({
             const replySummary = threadReplySummaries[message.id] ?? null;
             const activeReplyProgress = activeReplyProgressByRoot[message.id] ?? [];
             const hasActiveReplyProgress = activeReplyProgress.length > 0;
-            const replyingLabel = replyingAgentsLabel(activeReplyProgress);
+            const activeReplyStatus = hasActiveReplyProgress
+              ? replyProgressSummary(activeReplyProgress[0]).title
+              : "";
+            const replyingAgents = activeReplyProgress.map((progress) => progress.agent.display_name).join(", ");
             const activeReplyAgentIds = new Set(activeReplyProgress.map((progress) => progress.agent.id).filter(Boolean));
             const replyParticipants = (replySummary?.participants ?? [])
               .filter((participant) => !participant.sender_agent_id || !activeReplyAgentIds.has(participant.sender_agent_id))
@@ -862,7 +902,7 @@ export function Conversation({
                         className={`thread-reply-summary ${hasActiveReplyProgress ? "active-reply" : ""}`}
                         title="View thread replies"
                         aria-label={hasActiveReplyProgress
-                          ? `${replyingLabel}. View thread`
+                          ? `${activeReplyStatus}${replyingAgents ? `: ${replyingAgents}` : ""}. View thread`
                           : `View ${replyCount} ${replyCount === 1 ? "reply" : "replies"} in thread`}
                         onPointerDown={(event) => event.stopPropagation()}
                         onClick={(event) => {
@@ -870,23 +910,52 @@ export function Conversation({
                           setActiveThreadId(message.id);
                         }}
                       >
-                        <div className="thread-reply-avatars">
-                          {activeReplyProgress.slice(0, 3).map((progress) => (
-                            <span key={`active:${progress.key}`}>
-                              <AgentAvatar agent={progress.agent} size="sm" showStatus={false} />
-                            </span>
-                          ))}
-                          {replyParticipants.map((participant) => (
-                            <span key={`${participant.sender_role}:${participant.sender_agent_id ?? participant.sender_name}`}>
-                              {renderReplyParticipantAvatar(participant)}
-                            </span>
-                          ))}
-                        </div>
-                        <strong>{replyCount > 0 ? `${replyCount} ${replyCount === 1 ? "reply" : "replies"}` : "Replying"}</strong>
+                        {replyParticipants.length > 0 && (
+                          <div className="thread-reply-avatars">
+                            {replyParticipants.map((participant) => (
+                              <span key={`${participant.sender_role}:${participant.sender_agent_id ?? participant.sender_name}`}>
+                                {renderReplyParticipantAvatar(participant)}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                        <strong>
+                          {replyCount > 0 ? (
+                            `${replyCount} ${replyCount === 1 ? "reply" : "replies"}`
+                          ) : (
+                            <ActiveReplyIndicator label={activeReplyStatus} />
+                          )}
+                        </strong>
                         {(hasActiveReplyProgress || replySummary?.latest) && (
                           <span className="thread-reply-summary-action">
                             {hasActiveReplyProgress ? (
-                              <span className="thread-reply-summary-status">{replyingLabel}</span>
+                              <span className="thread-reply-summary-status">
+                                <span className="thread-reply-status-avatar-stack" aria-hidden="true">
+                                  {activeReplyProgress.slice(0, 3).map((progress) => (
+                                    <AgentAvatar key={`status:${progress.key}`} agent={progress.agent} size="sm" showStatus={false} />
+                                  ))}
+                                </span>
+                                {replyCount > 0 && (
+                                  <ActiveReplyIndicator label={activeReplyStatus} />
+                                )}
+                                <span className="thread-reply-active-menu" aria-hidden="true">
+                                  {activeReplyProgress.map((progress) => {
+                                    const summary = replyProgressSummary(progress);
+                                    return (
+                                      <span key={`menu:${progress.key}`} className="thread-reply-active-agent">
+                                        <AgentAvatar agent={progress.agent} size="sm" showStatus={false} />
+                                        <span className="thread-reply-active-agent-copy">
+                                          <span className="thread-reply-active-agent-name">{progress.agent.display_name}</span>
+                                          <span className="thread-reply-active-agent-status">
+                                            <span>{summary.title}</span>
+                                            {summary.detail && <em>{summary.detail}</em>}
+                                          </span>
+                                        </span>
+                                      </span>
+                                    );
+                                  })}
+                                </span>
+                              </span>
                             ) : replySummary?.latest ? (
                               <time dateTime={replySummary.latest.created_at}>Last reply {formatTime(replySummary.latest.created_at)}</time>
                             ) : null}

--- a/src/components/UnreadBadge.tsx
+++ b/src/components/UnreadBadge.tsx
@@ -4,9 +4,14 @@ type UnreadBadgeProps = {
 };
 
 export function UnreadBadge({ value, className }: UnreadBadgeProps) {
+  const rawValue = String(value);
+  const numericValue = Number(rawValue);
+  const displayValue = Number.isFinite(numericValue) && numericValue >= 10 ? "10+" : rawValue;
+  const badgeClassName = ["unread-badge", className ?? ""].filter(Boolean).join(" ");
+
   return (
-    <span className={className ? `unread-badge ${className}` : "unread-badge"}>
-      {value}
+    <span className={badgeClassName} title={displayValue !== rawValue ? `${rawValue} unread` : undefined}>
+      {displayValue}
     </span>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2117,6 +2117,7 @@ button,
 }
 
 .thread-reply-summary {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -2152,6 +2153,9 @@ button,
 }
 
 .thread-reply-summary strong {
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
   color: var(--accent);
   font-size: var(--type-size-body);
   font-weight: var(--type-weight-semibold);
@@ -2209,8 +2213,188 @@ button,
   color: #4f5560;
 }
 
+.thread-reply-summary.active-reply:hover,
+.thread-reply-summary.active-reply:focus-visible {
+  z-index: 7;
+}
+
+.thread-reply-summary.active-reply .thread-reply-summary-action {
+  overflow: visible;
+}
+
 .thread-reply-summary.active-reply strong {
   color: #1f7a4d;
+}
+
+.thread-reply-summary.active-reply .thread-reply-summary-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: visible;
+  color: var(--thread-new-ink);
+}
+
+.thread-reply-summary.active-reply:hover .thread-reply-summary-status,
+.thread-reply-summary.active-reply:focus-visible .thread-reply-summary-status {
+  opacity: 1;
+}
+
+.thread-reply-summary.active-reply:hover .thread-reply-summary-open,
+.thread-reply-summary.active-reply:focus-visible .thread-reply-summary-open {
+  opacity: 0;
+}
+
+.thread-reply-status-avatar-stack {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-width: 18px;
+}
+
+.thread-reply-status-avatar-stack .agent-avatar {
+  flex: 0 0 auto;
+  box-shadow: 0 0 0 2px var(--bg-panel);
+}
+
+.thread-reply-status-avatar-stack .agent-avatar + .agent-avatar {
+  margin-left: -7px;
+}
+
+.thread-reply-status-text {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  min-width: 18px;
+  height: 18px;
+  animation: replying-text-sweep 5s ease-in-out infinite;
+  line-height: 1;
+  vertical-align: middle;
+  will-change: clip-path, opacity;
+}
+
+.thread-reply-status-dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+@keyframes replying-text-sweep {
+  0%,
+  40%,
+  100% {
+    clip-path: inset(0 0 0 0);
+    opacity: 1;
+  }
+  70% {
+    clip-path: inset(0 0 0 100%);
+    opacity: 0.24;
+  }
+  70.01% {
+    clip-path: inset(0 100% 0 0);
+    opacity: 0.24;
+  }
+}
+
+.thread-reply-active-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 10px;
+  display: grid;
+  gap: 6px;
+  min-width: min(320px, calc(100vw - 40px));
+  max-width: min(460px, calc(100vw - 40px));
+  padding: 8px;
+  border: 1px solid var(--border-strong);
+  border-radius: 14px;
+  background: var(--bg-panel);
+  box-shadow: var(--surface-shadow);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-2px);
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+:root[data-theme="dark"] .thread-reply-active-menu {
+  background: var(--bg-panel-strong);
+}
+
+.thread-reply-summary.active-reply:hover .thread-reply-active-menu,
+.thread-reply-summary.active-reply:focus-visible .thread-reply-active-menu {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.thread-reply-active-agent {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 6px 8px;
+  border-radius: 10px;
+  background: var(--bg-control-flat);
+  color: var(--ink);
+  font-size: var(--type-size-caption);
+}
+
+.thread-reply-active-agent-copy {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.thread-reply-active-agent-name {
+  overflow: hidden;
+  color: var(--ink);
+  font-size: var(--type-size-meta);
+  font-weight: var(--type-weight-semibold);
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.thread-reply-active-agent-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: var(--muted);
+  font-size: var(--type-size-caption);
+  line-height: 1.3;
+}
+
+.thread-reply-active-agent-status span,
+.thread-reply-active-agent-status em {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.thread-reply-active-agent-status span {
+  flex: 0 0 auto;
+  color: var(--badge-phase-thinking-ink);
+  font-weight: var(--type-weight-semibold);
+}
+
+.thread-reply-active-agent-status em {
+  flex: 1 1 0;
+  color: var(--muted);
+  font-style: normal;
+}
+
+@media (hover: none) {
+  .thread-reply-active-menu {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .thread-reply-status-text {
+    animation: none;
+  }
 }
 
 .thread-reply-summary-icon {

--- a/src/styles.css
+++ b/src/styles.css
@@ -784,9 +784,10 @@ button,
   align-items: center;
   justify-content: center;
   justify-self: end;
-  min-width: 18px;
+  width: 30px;
+  min-width: 30px;
   height: 18px;
-  padding: 0 6px;
+  padding: 0;
   border-radius: 999px;
   background: var(--badge-bg);
   color: var(--badge-ink);


### PR DESCRIPTION
## Summary
- render unread counts 10 and above as `10+`
- keep unread badge geometry fixed at 30x18 so single digits and `10+` align consistently
- preserve the exact unread count in the badge title when the visible label is capped

## Verification
- npm run lint:css-tokens
- git diff --check
- npm run build