### PR TITLE
Sync activity progress working state

### DIFF
--- a/src/components/ActivityProgressDock.tsx
+++ b/src/components/ActivityProgressDock.tsx
@@ -27,6 +27,7 @@ export type ActiveAgentProgress = {
   key: string;
   agent: Pick<Agent, "handle" | "display_name" | "status"> &
     Partial<Pick<Agent, "id" | "runtime" | "model" | "role" | "avatar" | "description">>;
+  state: "working" | "queued";
   workItem: AgentWorkItem | null;
   queuedItems: AgentWorkItem[];
   latestActivity: AgentActivity | null;
@@ -37,6 +38,7 @@ export type ActiveAgentProgress = {
 type ProgressCandidate = {
   message: Message | null;
   workItem: AgentWorkItem | null;
+  state: "working" | "queued";
   latestAt: number;
 };
 
@@ -59,6 +61,14 @@ const ACTIVITY_STATUS_LABELS: Record<string, string> = {
 
 function activityTitle(activity: AgentActivity) {
   return (activity.summary || activity.title || phaseLabel(activity.phase || activity.kind)).trim();
+}
+
+function userFacingActivityTitle(activity: AgentActivity) {
+  const title = activityTitle(activity);
+  const lowered = title.toLowerCase();
+  if (lowered.includes("warm app-server ready") || lowered.includes("warm stream-json ready")) return "Runtime ready";
+  if (lowered === "started working" || lowered === "run started" || lowered === "run created") return "Working";
+  return title;
 }
 
 function statusForActivity(activity: AgentActivity) {
@@ -154,6 +164,23 @@ function activityDetail(activity: AgentActivity) {
 
   const detail = activity.detail.trim();
   if (!detail || detail.startsWith("{") || detail.startsWith("[")) return "";
+  if (detail === "pid unavailable") return "";
+  const parts = detail.split(/[,\n]/).map((part) => part.trim()).filter(Boolean);
+  if (parts.length > 0) {
+    const entries = parts.map((part) => {
+      const separator = part.indexOf("=");
+      return separator > 0
+        ? [part.slice(0, separator).trim(), part.slice(separator + 1).trim()]
+        : null;
+    });
+    if (entries.every(Boolean)) {
+      return entries
+        .filter((entry): entry is string[] => Boolean(entry))
+        .filter(([key]) => !["pid", "thread_id", "session_id", "request_id", "run_id", "reference_id", "uuid"].includes(key))
+        .map(([key, value]) => `${key.replace(/_/g, " ")} ${value}`)
+        .join(", ");
+    }
+  }
   return detail;
 }
 
@@ -176,7 +203,7 @@ function compactProgressActivities(activities: AgentActivity[]) {
   return activities.filter((activity) => {
     if (seen.has(activity.id)) return false;
     seen.add(activity.id);
-    const signature = `${activity.phase || activity.kind || ""}|${activityTitle(activity)}|${activity.detail.trim()}`;
+    const signature = `${activity.phase || activity.kind || ""}|${userFacingActivityTitle(activity)}|${activity.detail.trim()}`;
     if (signature === lastSignature) return false;
     lastSignature = signature;
     return true;
@@ -285,6 +312,7 @@ export function activeProgressByAgent(
     addCandidate(runId, {
       message,
       workItem: null,
+      state: "working",
       latestAt: timestamp(message.updated_at),
     });
   });
@@ -306,6 +334,7 @@ export function activeProgressByAgent(
       addCandidate(runId, {
         message: null,
         workItem,
+        state: "working",
         latestAt: Math.max(
           timestamp(workItem.updated_at),
           timestamp(run?.started_at ?? ""),
@@ -334,6 +363,7 @@ export function activeProgressByAgent(
       agent: existing?.agent ?? agentForProgress(handle, latestActivity, agents),
       workItem: candidate.workItem ?? existing?.workItem ?? null,
       queuedItems: existing?.queuedItems ?? [],
+      state: existing?.state === "working" || candidate.state === "working" ? "working" : "queued",
       latestActivity: existing && existing.latestAt > latestAt ? existing.latestActivity : latestActivity,
       history: compactHistory,
       latestAt: Math.max(existing?.latestAt ?? 0, latestAt),
@@ -359,6 +389,7 @@ export function activeProgressByAgent(
       progressByAgent.set(key, {
         key,
         agent,
+        state: existing?.state ?? "queued",
         workItem: existing?.workItem ?? null,
         queuedItems,
         latestActivity: existing?.latestActivity ?? null,
@@ -383,19 +414,23 @@ export function ActivityProgressDock({
   const progress = activeProgressByAgent(messages, activities, runs, workItems, agents, channelId, threadRootId);
   if (progress.length === 0) return null;
 
-  const latest = progress[0];
+  const workingCount = progress.filter((item) => item.state === "working").length;
+  const latest = progress.find((item) => item.state === "working") ?? progress[0];
   const latestActivity = latest.latestActivity;
+  const latestWorking = latest.state === "working";
   const Icon = progressIcon(latestActivity);
   const providerRetrying = isProviderRetryActivity(latestActivity);
   const queuedCount = progress.reduce((count, item) => count + item.queuedItems.length, 0);
   const title = progress.length === 1
     ? providerRetrying
       ? `${latest.agent.display_name} is waiting on provider`
-      : latestActivity
+      : latestWorking
         ? `${latest.agent.display_name} is working`
         : `${latest.agent.display_name} has queued work`
-    : `${progress.length} agents are working`;
-  const latestTitle = latestActivity ? activityTitle(latestActivity) : "Queued";
+    : workingCount > 0
+      ? `${workingCount} ${workingCount === 1 ? "agent is" : "agents are"} working`
+      : `${progress.length} agents have queued work`;
+  const latestTitle = latestActivity ? userFacingActivityTitle(latestActivity) : latestWorking ? "Working" : "Queued";
   const latestDetail = latestActivity ? activityDetail(latestActivity) : "";
   const history = progress
     .flatMap((item) => item.history.map((activity) => ({ activity, agent: item.agent })))
@@ -404,7 +439,7 @@ export function ActivityProgressDock({
 
   return (
     <details className="activity-progress-dock">
-      <summary data-state={providerRetrying ? "provider-retrying" : latestActivity ? "working" : "queued"}>
+      <summary data-state={providerRetrying ? "provider-retrying" : latestWorking ? "working" : "queued"}>
         <span className="activity-progress-avatar-stack" aria-hidden="true">
           {progress.slice(0, 3).map((item) => (
             <AgentAvatar key={item.key} agent={item.agent} size="sm" showStatus={false} />
@@ -443,7 +478,7 @@ export function ActivityProgressDock({
                 />
                 <div className="activity-timeline-body">
                   <div className="activity-timeline-title">
-                    <strong>{activityTitle(activity)}</strong>
+                    <strong>{userFacingActivityTitle(activity)}</strong>
                     <span className={`activity-status status-${activity.status}`}>
                       {statusForActivity(activity)}
                     </span>

--- a/src/components/AgentDetailDrawer.tsx
+++ b/src/components/AgentDetailDrawer.tsx
@@ -83,8 +83,10 @@ function statusForActivity(activity: AgentActivity) {
 function userFacingActivityTitle(activity: AgentActivity) {
   const title = activity.summary || activity.title;
   const lowered = title.toLowerCase();
+  if (lowered.includes("warm app-server ready") || lowered.includes("warm stream-json ready")) return "Runtime ready";
   if (
     (lowered.includes("warm turn") && lowered.includes("started")) ||
+    lowered === "started working" ||
     lowered === "run started" ||
     lowered === "run created"
   ) {
@@ -110,6 +112,34 @@ function userFacingActivityTitle(activity: AgentActivity) {
     if (lowered.includes("cancelled")) return "Request cancelled";
   }
   return title;
+}
+
+const INTERNAL_ACTIVITY_DETAIL_KEYS = new Set([
+  "pid",
+  "thread_id",
+  "session_id",
+  "request_id",
+  "run_id",
+  "reference_id",
+  "uuid",
+]);
+
+function keyValueActivityDetail(detail: string) {
+  const parts = detail.split(/[,\n]/).map((part) => part.trim()).filter(Boolean);
+  if (parts.length === 0) return null;
+  const entries: Array<[string, string]> = [];
+  for (const part of parts) {
+    const separator = part.indexOf("=");
+    if (separator <= 0) return null;
+    const key = part.slice(0, separator).trim();
+    const value = part.slice(separator + 1).trim();
+    if (!key || !value) return null;
+    entries.push([key, value]);
+  }
+  return entries
+    .filter(([key]) => !INTERNAL_ACTIVITY_DETAIL_KEYS.has(key))
+    .map(([key, value]) => `${key.replace(/_/g, " ")} ${value}`)
+    .join(", ");
 }
 
 function userFacingActivityCategory(activity: AgentActivity) {
@@ -159,21 +189,10 @@ function userFacingActivityDetail(activity: AgentActivity) {
   if (!detail) return "";
   if (isStructuredActivityDetail(detail)) return "";
   if (/^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(detail)) return "";
-  if (["content_block_stop", "message_stop", "status"].includes(detail)) return "";
-  const cleaned = detail
-    .split(",")
-    .map((part) => part.trim())
-    .filter((part) => {
-      const lowered = part.toLowerCase();
-      return !(
-        lowered.startsWith("pid=") ||
-        lowered.startsWith("thread_id=") ||
-        lowered.startsWith("session_id=")
-      );
-    })
-    .join(", ");
-  if (!cleaned) return "";
-  return cleaned
+  if (["content_block_stop", "message_stop", "pid unavailable", "status"].includes(detail)) return "";
+  const keyValueDetail = keyValueActivityDetail(detail);
+  if (keyValueDetail !== null) return keyValueDetail;
+  return detail
     .replace(/^codex warm turn failed:/i, "Failed:")
     .replace(/^claude warm turn failed:/i, "Failed:")
     .replace(/^duration=/i, "duration ");
@@ -251,6 +270,16 @@ function workItemStatusLabel(status: string) {
   if (status === "running") return "Running";
   if (status === "cancelling") return "Cancelling";
   if (status === "done") return "Run done";
+  if (status === "failed") return "Failed";
+  if (status === "cancelled") return "Cancelled";
+  return status.replace(/_/g, " ");
+}
+
+function runStatusLabel(status: string) {
+  if (status === "starting") return "Starting";
+  if (status === "running") return "Running";
+  if (status === "stopping") return "Stopping";
+  if (status === "completed") return "Completed";
   if (status === "failed") return "Failed";
   if (status === "cancelled") return "Cancelled";
   return status.replace(/_/g, " ");
@@ -537,7 +566,7 @@ export function AgentDetailDrawer({
           </div>
           <div>
             <span>Active run</span>
-            <code>{activeRun ? `${activeRun.status}${activeRun.pid ? ` · pid ${activeRun.pid}` : ""}` : "No active run"}</code>
+            <code>{activeRun ? runStatusLabel(activeRun.status) : "No active run"}</code>
           </div>
           <div>
             <span>Role</span>

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -115,19 +115,47 @@ function compactReplyProgressText(value: string, limit: number) {
   return `${normalized.slice(0, Math.max(0, limit - 1)).trim()}...`;
 }
 
+function userFacingReplyProgressTitle(value: string) {
+  const title = value.trim() || "Working";
+  const lowered = title.toLowerCase();
+  if (lowered.includes("warm app-server ready") || lowered.includes("warm stream-json ready")) return "Runtime ready";
+  if (lowered === "started working" || lowered === "run started" || lowered === "run created") return "Working";
+  return title;
+}
+
+function userFacingReplyProgressDetail(value: string) {
+  const detail = value.trim();
+  if (!detail || detail.startsWith("{") || detail.startsWith("[")) return "";
+  const parts = detail.split(/[,\n]/).map((part) => part.trim()).filter(Boolean);
+  if (parts.length > 0) {
+    const entries = parts.map((part) => {
+      const separator = part.indexOf("=");
+      return separator > 0
+        ? [part.slice(0, separator).trim(), part.slice(separator + 1).trim()]
+        : null;
+    });
+    if (entries.every(Boolean)) {
+      return entries
+        .filter((entry): entry is string[] => Boolean(entry))
+        .filter(([key]) => !["pid", "thread_id", "session_id", "request_id", "run_id", "reference_id", "uuid"].includes(key))
+        .map(([key, item]) => `${key.replace(/_/g, " ")} ${item}`)
+        .join(", ");
+    }
+  }
+  if (detail === "pid unavailable") return "";
+  return detail;
+}
+
 function replyProgressSummary(progress: ReplyProgress) {
   if (progress.latestActivity) {
-    const title = (progress.latestActivity.summary || progress.latestActivity.title || "Working").trim() || "Working";
-    const rawDetail = progress.latestActivity.detail.trim();
-    const detail = rawDetail.startsWith("{") || rawDetail.startsWith("[")
-      ? ""
-      : compactReplyProgressText(rawDetail, 72);
+    const title = userFacingReplyProgressTitle(progress.latestActivity.summary || progress.latestActivity.title || "Working");
+    const detail = compactReplyProgressText(userFacingReplyProgressDetail(progress.latestActivity.detail), 72);
     return {
       title,
       detail: detail && detail !== title ? detail : "",
     };
   }
-  if (progress.queuedItems.length > 0) {
+  if (progress.state === "queued" && progress.queuedItems.length > 0) {
     return {
       title: progress.queuedItems.length === 1 ? "Queued" : `${progress.queuedItems.length} queued`,
       detail: "Waiting to start",

--- a/src/styles.css
+++ b/src/styles.css
@@ -2314,36 +2314,40 @@ button,
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 3px;
-  min-width: 18px;
+  gap: 4px;
+  min-width: 24px;
   height: 18px;
-  animation: replying-text-sweep 5s ease-in-out infinite;
   line-height: 1;
   vertical-align: middle;
-  will-change: clip-path, opacity;
 }
 
 .thread-reply-status-dot {
-  width: 3px;
-  height: 3px;
+  width: 4px;
+  height: 4px;
   border-radius: 50%;
   background: currentColor;
+  animation: thread-reply-dot-pulse 1.2s ease-in-out infinite;
+  transform: translateZ(0);
+  will-change: opacity, transform;
 }
 
-@keyframes replying-text-sweep {
+.thread-reply-status-dot:nth-child(2) {
+  animation-delay: 140ms;
+}
+
+.thread-reply-status-dot:nth-child(3) {
+  animation-delay: 280ms;
+}
+
+@keyframes thread-reply-dot-pulse {
   0%,
-  40%,
   100% {
-    clip-path: inset(0 0 0 0);
+    opacity: 0.38;
+    transform: scale(0.84);
+  }
+  45% {
     opacity: 1;
-  }
-  70% {
-    clip-path: inset(0 0 0 100%);
-    opacity: 0.24;
-  }
-  70.01% {
-    clip-path: inset(0 100% 0 0);
-    opacity: 0.24;
+    transform: scale(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- make activity progress entries carry an explicit working/queued state
- use that shared state for the thread activity banner and reply summaries so running work does not display as queued while waiting for the first activity event
- clean runtime/debug copy from user-facing activity surfaces and active-run status labels

## Testing
- git diff --check
- npm run lint:css-tokens
- npm run build