### PR TITLE
Improve hover feedback and reply progress placement

### DIFF
--- a/scripts/styles-raw-color-baseline.json
+++ b/scripts/styles-raw-color-baseline.json
@@ -1167,12 +1167,6 @@
       "n": 0
     },
     {
-      "selector": ".reply-list article:hover",
-      "prop": "background",
-      "literal": "rgba(246, 247, 249, 0.92)",
-      "n": 0
-    },
-    {
       "selector": ".runtime-preflight",
       "prop": "background",
       "literal": "rgba(142, 142, 147, 0.08)",
@@ -1542,18 +1536,6 @@
       "selector": ".thread-browser-row",
       "prop": "border",
       "literal": "rgba(142, 142, 147, 0.18)",
-      "n": 0
-    },
-    {
-      "selector": ".thread-browser-row:hover, .thread-browser-row.selected",
-      "prop": "background",
-      "literal": "rgba(248, 249, 251, 0.94)",
-      "n": 0
-    },
-    {
-      "selector": ".thread-browser-row:hover, .thread-browser-row.selected",
-      "prop": "border-color",
-      "literal": "rgba(20, 23, 31, 0.16)",
       "n": 0
     },
     {

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -107,6 +107,7 @@ function taskStatusLabel(status: string) {
 }
 
 type ReplyProgress = ReturnType<typeof activeProgressByAgent>[number];
+type ActiveReplyMenuPlacement = "above" | "below";
 
 function compactReplyProgressText(value: string, limit: number) {
   const normalized = value.replace(/\s+/g, " ").trim();
@@ -258,6 +259,7 @@ export function Conversation({
   const [showChannelActions, setShowChannelActions] = useState(false);
   const [messageMenu, setMessageMenu] = useState<MessageMenuState>(null);
   const [expandedChannelMessageIds, setExpandedChannelMessageIds] = useState<Set<string>>(() => new Set());
+  const [activeReplyMenuPlacementByMessageId, setActiveReplyMenuPlacementByMessageId] = useState<Record<string, ActiveReplyMenuPlacement>>({});
   const messageListRef = useRef<HTMLDivElement | null>(null);
   const messageListContentRef = useRef<HTMLDivElement | null>(null);
   const messageListBottomAnchorRef = useRef<HTMLDivElement | null>(null);
@@ -408,6 +410,27 @@ export function Conversation({
 
   function handleMessageListTouchMove() {
     stopFollowingMessages();
+  }
+
+  function updateActiveReplyMenuPlacement(messageId: string, summaryElement: HTMLElement) {
+    const menu = summaryElement.querySelector<HTMLElement>(".thread-reply-active-menu");
+    if (!menu) return;
+
+    const boundaryRect = messageListRef.current?.getBoundingClientRect();
+    const summaryRect = summaryElement.getBoundingClientRect();
+    const menuHeight = menu.offsetHeight || menu.getBoundingClientRect().height;
+    const gap = 6;
+    const boundaryTop = boundaryRect?.top ?? 0;
+    const boundaryBottom = boundaryRect?.bottom ?? window.innerHeight;
+    const spaceBelow = boundaryBottom - summaryRect.bottom - gap;
+    const spaceAbove = summaryRect.top - boundaryTop - gap;
+    const placement: ActiveReplyMenuPlacement = spaceBelow < menuHeight && spaceAbove > spaceBelow
+      ? "above"
+      : "below";
+
+    setActiveReplyMenuPlacementByMessageId((current) => (
+      current[messageId] === placement ? current : { ...current, [messageId]: placement }
+    ));
   }
 
   function handleMessageListContentLoad() {
@@ -756,6 +779,7 @@ export function Conversation({
             const activeReplyStatus = hasActiveReplyProgress
               ? replyProgressSummary(activeReplyProgress[0]).title
               : "";
+            const activeReplyMenuPlacement = activeReplyMenuPlacementByMessageId[message.id] ?? "below";
             const replyingAgents = activeReplyProgress.map((progress) => progress.agent.display_name).join(", ");
             const activeReplyAgentIds = new Set(activeReplyProgress.map((progress) => progress.agent.id).filter(Boolean));
             const replySummaryClassName = [
@@ -936,11 +960,18 @@ export function Conversation({
                       <button
                         type="button"
                         className={replySummaryClassName}
+                        data-active-menu-placement={hasActiveReplyProgress ? activeReplyMenuPlacement : undefined}
                         title="View thread replies"
                         aria-label={hasActiveReplyProgress
                           ? `${activeReplyStatus}${replyingAgents ? `: ${replyingAgents}` : ""}. View thread`
                           : `View ${replyCount} ${replyCount === 1 ? "reply" : "replies"} in thread`}
+                        onPointerEnter={(event) => {
+                          if (hasActiveReplyProgress) updateActiveReplyMenuPlacement(message.id, event.currentTarget);
+                        }}
                         onPointerDown={(event) => event.stopPropagation()}
+                        onFocus={(event) => {
+                          if (hasActiveReplyProgress) updateActiveReplyMenuPlacement(message.id, event.currentTarget);
+                        }}
                         onClick={(event) => {
                           event.stopPropagation();
                           setActiveThreadId(message.id);

--- a/src/styles.css
+++ b/src/styles.css
@@ -2370,6 +2370,12 @@ button,
   transition: opacity 120ms ease, transform 120ms ease;
 }
 
+.thread-reply-summary.active-reply[data-active-menu-placement="above"] .thread-reply-active-menu {
+  top: auto;
+  bottom: calc(100% + 6px);
+  transform: translateY(2px);
+}
+
 :root[data-theme="dark"] .thread-reply-active-menu {
   background: var(--bg-panel-strong);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -136,9 +136,9 @@ button,
   --bg-composer: #f4f6f9;
   --bg-control: linear-gradient(180deg, #fbfcfd 0%, #edf1f5 100%);
   --bg-control-flat: rgba(240, 243, 247, 0.92);
-  --bg-control-hover: #fbfcfd;
+  --bg-control-hover: color-mix(in srgb, var(--accent) 7%, var(--bg-panel));
   --bg-control-selected: linear-gradient(180deg, #fbfcfd 0%, #edf1f5 100%);
-  --bg-hover: #edf1f5;
+  --bg-hover: color-mix(in srgb, var(--accent) 8%, var(--bg-panel));
   --bg-selected-soft: rgba(10, 132, 255, 0.09);
   --bg-selected-accent:
     linear-gradient(180deg, rgba(10, 132, 255, 0.18), rgba(10, 132, 255, 0.1)),
@@ -779,7 +779,7 @@ button,
 
 .quick-actions button:hover,
 .channel:hover {
-  background: var(--bg-control-flat);
+  background: var(--bg-hover);
 }
 
 .quick-actions span {
@@ -4955,7 +4955,7 @@ body.resizing-row * {
 .reply-list article:hover {
   transform: none;
   border-color: transparent;
-  background: rgba(246, 247, 249, 0.92);
+  background: var(--bg-hover);
 }
 
 .reply-list article.system-message {
@@ -7689,8 +7689,8 @@ body.resizing-row * {
 
 .thread-browser-row:hover,
 .thread-browser-row.selected {
-  border-color: rgba(20, 23, 31, 0.16);
-  background: rgba(248, 249, 251, 0.94);
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
   box-shadow: 0 12px 26px rgba(15, 23, 42, 0.06);
 }
 


### PR DESCRIPTION
## Summary
- make light theme hover backgrounds more visible using the shared hover tokens
- route channel, thread reply, and thread browser hover states through the same hover token
- let active reply progress popovers open upward when there is not enough space below

## Testing
- git diff --check
- npm run lint:css-tokens
- npm run build