### PR TITLE
Place reply summary below expand control

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -2814,7 +2814,7 @@ mark {
 }
 
 .message-expand-button {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   width: fit-content;
   min-height: 26px;


### PR DESCRIPTION
## Summary
- force the message expand control to occupy its own row
- keep replies, working indicators, and avatars below Show more / Show less on long messages

## Testing
- npm run build