### PR TITLE
Show mobile agent restart and delete actions

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -9217,15 +9217,14 @@ body.resizing-row * {
     display: none;
   }
 
-  .agent-drawer-head-actions button.danger {
-    display: none;
-  }
-
   .agent-drawer-head-actions {
+    flex: 0 0 auto;
+    gap: 6px;
     margin-left: auto;
   }
 
   .agent-drawer-head .agent-head-action {
+    flex: 0 0 auto;
     width: 30px;
     height: 30px;
   }


### PR DESCRIPTION
## Summary
- show the agent delete action on mobile instead of hiding dangerous header buttons
- keep the mobile agent action cluster from shrinking so restart/delete remain visible

## Testing
- npm run build