### PR TITLE
Keep new activity border highlighted

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -8257,7 +8257,9 @@ body.resizing-row * {
 
 .activity-feed-row.new-thread {
   background: var(--thread-new-bg);
-  box-shadow: inset 0 0 0 1px var(--thread-new-border);
+  box-shadow:
+    inset 0 0 0 1px var(--thread-new-border),
+    var(--thread-new-shadow);
 }
 
 .activity-feed-row.new-thread:hover {


### PR DESCRIPTION
## Summary
- keep new activity feed rows at the strongest green border state by default
- remove the visual jump where the thicker highlight only appeared during hover/emphasis

## Test
- npm run build