### PR TITLE
Hide intermediate Codex draft replies

### DIFF
--- a/src-tauri/src/runtime/codex.rs
+++ b/src-tauri/src/runtime/codex.rs
@@ -24,9 +24,10 @@ use crate::runtime::{
         upsert_runtime_thread_id,
     },
     streaming::{
-        adopt_streaming_agent_message_key, append_streaming_agent_message,
-        consume_streaming_agent_control_lines, ensure_streaming_agent_message,
-        finish_streaming_agent_message, streaming_message_body_is_empty,
+        adopt_streaming_agent_message_key, append_streaming_agent_message_deferred_completion,
+        consume_streaming_agent_control_lines, delete_intermediate_run_messages,
+        ensure_streaming_agent_message, finish_streaming_agent_message_deferred_mentions,
+        streaming_message_body_is_empty,
     },
     surface::{codex_active_turn_schedule_state, same_codex_surface, CodexActiveTurnScheduleState},
 };
@@ -85,6 +86,7 @@ struct CodexActiveTurn {
     channel_id: Option<Uuid>,
     thread_root_id: Option<Uuid>,
     stream_keys: HashSet<String>,
+    completed_agent_message_stream_keys: HashSet<String>,
     steer_requests: HashMap<i64, CodexSteerRequest>,
     steer_disabled: bool,
     interrupt_request_id: Option<i64>,
@@ -1012,6 +1014,7 @@ pub(crate) async fn supervisor_start_codex_streaming_agent(
                 channel_id,
                 thread_root_id,
                 stream_keys,
+                completed_agent_message_stream_keys: HashSet::new(),
                 steer_requests: HashMap::new(),
                 steer_disabled: false,
                 interrupt_request_id: None,
@@ -1120,6 +1123,36 @@ async fn codex_warm_stdout_reader(
     )
     .await;
     remove_warm_codex_runtime_if_same(&registry, agent_id, &runtime).await;
+}
+
+async fn delete_codex_intermediate_replies(
+    pool: &SqlitePool,
+    agent_id: Uuid,
+    runtime: &Arc<WarmCodexRuntime>,
+    run_id: Uuid,
+) -> CommandResult<()> {
+    let active_surface = {
+        let mut state = runtime.state.lock().await;
+        let Some(active) = state.active.as_mut() else {
+            return Ok(());
+        };
+        let run_prefix = format!("{run_id}:");
+        let pending_stream_key = codex_pending_stream_key(run_id);
+        active.stream_keys.retain(|stream_key| {
+            stream_key == &pending_stream_key || !stream_key.starts_with(&run_prefix)
+        });
+        active
+            .completed_agent_message_stream_keys
+            .retain(|stream_key| !stream_key.starts_with(&run_prefix));
+        active
+            .channel_id
+            .map(|channel_id| (active.thread_root_id, channel_id))
+    };
+    if let Some((thread_root_id, channel_id)) = active_surface {
+        delete_intermediate_run_messages(pool, agent_id, channel_id, thread_root_id, run_id)
+            .await?;
+    }
+    Ok(())
 }
 
 async fn handle_codex_warm_stdout_line(
@@ -1285,7 +1318,7 @@ async fn handle_codex_warm_stdout_line(
             }
             if let Some(channel_id) = active.1 {
                 adopt_streaming_agent_message_key(pool, &active.3, &active.4).await?;
-                append_streaming_agent_message(
+                append_streaming_agent_message_deferred_completion(
                     pool, agent_id, channel_id, active.2, &active.4, delta,
                 )
                 .await?;
@@ -1303,7 +1336,10 @@ async fn handle_codex_warm_stdout_line(
                 let pending_stream_key = codex_pending_stream_key(active.run_id);
                 let stream_key = codex_stream_key(active.run_id, item_id);
                 active.stream_keys.remove(&pending_stream_key);
-                active.stream_keys.remove(&stream_key);
+                active.stream_keys.insert(stream_key.clone());
+                active
+                    .completed_agent_message_stream_keys
+                    .insert(stream_key.clone());
                 (
                     active.run_id,
                     active.channel_id,
@@ -1321,7 +1357,7 @@ async fn handle_codex_warm_stdout_line(
                         .and_then(Value::as_str)
                         .filter(|text| !text.is_empty())
                     {
-                        append_streaming_agent_message(
+                        append_streaming_agent_message_deferred_completion(
                             pool, agent_id, channel_id, active.2, &active.5, text,
                         )
                         .await?;
@@ -1332,7 +1368,8 @@ async fn handle_codex_warm_stdout_line(
                 )
                 .await?;
                 if !hidden {
-                    finish_streaming_agent_message(pool, &active.5, "complete").await?;
+                    finish_streaming_agent_message_deferred_mentions(pool, &active.5, "complete")
+                        .await?;
                 }
             }
         }
@@ -1340,6 +1377,9 @@ async fn handle_codex_warm_stdout_line(
             let Some(run_id) = active_run_id else {
                 return Ok(());
             };
+            if codex_item_type(&value) != Some("agentMessage") {
+                delete_codex_intermediate_replies(pool, agent_id, runtime, run_id).await?;
+            }
             if let Some((kind, title, detail)) = codex_tool_completion_activity(&value) {
                 record_agent_activity_throttled(
                     pool,
@@ -1356,6 +1396,9 @@ async fn handle_codex_warm_stdout_line(
             let Some(run_id) = active_run_id else {
                 return Ok(());
             };
+            if codex_item_type(&value) != Some("agentMessage") {
+                delete_codex_intermediate_replies(pool, agent_id, runtime, run_id).await?;
+            }
             let (kind, title, detail) = codex_item_started_activity(&value);
             record_agent_activity_throttled(
                 pool,

--- a/src-tauri/src/runtime/codex/turn.rs
+++ b/src-tauri/src/runtime/codex/turn.rs
@@ -7,7 +7,10 @@ use super::{CodexSteerRequest, WarmCodexRuntime};
 use crate::events::activity::{record_agent_activity, work_status_title};
 use crate::runtime::{
     process::upsert_runtime_thread_id,
-    streaming::{consume_streaming_agent_control_lines, finish_streaming_agent_message},
+    streaming::{
+        consume_streaming_agent_control_lines, dispatch_streaming_agent_message_mentions,
+        finish_streaming_agent_message,
+    },
 };
 use crate::ui_notifications::{
     notify_supervisor_wake, notify_ui_agent_run_changed, notify_ui_work_item_changed,
@@ -109,16 +112,24 @@ pub(super) async fn finish_warm_codex_active_turn(
             false
         };
         if !hidden {
-            finish_streaming_agent_message(
-                pool,
-                &stream_key,
-                if success && !was_cancelled {
-                    "complete"
-                } else {
-                    "error"
-                },
-            )
-            .await?;
+            if active
+                .completed_agent_message_stream_keys
+                .contains(&stream_key)
+            {
+                finish_streaming_agent_message(pool, &stream_key, "complete").await?;
+                dispatch_streaming_agent_message_mentions(pool, &stream_key).await?;
+            } else {
+                finish_streaming_agent_message(
+                    pool,
+                    &stream_key,
+                    if success && !was_cancelled {
+                        "complete"
+                    } else {
+                        "error"
+                    },
+                )
+                .await?;
+            }
         }
     }
 

--- a/src-tauri/src/runtime/streaming.rs
+++ b/src-tauri/src/runtime/streaming.rs
@@ -48,6 +48,47 @@ pub(crate) async fn append_streaming_agent_message(
     stream_key: &str,
     delta: &str,
 ) -> CommandResult<Uuid> {
+    append_streaming_agent_message_inner(
+        pool,
+        agent_id,
+        channel_id,
+        thread_root_id,
+        stream_key,
+        delta,
+        true,
+    )
+    .await
+}
+
+pub(crate) async fn append_streaming_agent_message_deferred_completion(
+    pool: &SqlitePool,
+    agent_id: Uuid,
+    channel_id: Uuid,
+    thread_root_id: Option<Uuid>,
+    stream_key: &str,
+    delta: &str,
+) -> CommandResult<Uuid> {
+    append_streaming_agent_message_inner(
+        pool,
+        agent_id,
+        channel_id,
+        thread_root_id,
+        stream_key,
+        delta,
+        false,
+    )
+    .await
+}
+
+async fn append_streaming_agent_message_inner(
+    pool: &SqlitePool,
+    agent_id: Uuid,
+    channel_id: Uuid,
+    thread_root_id: Option<Uuid>,
+    stream_key: &str,
+    delta: &str,
+    complete_on_truncation: bool,
+) -> CommandResult<Uuid> {
     if stream_key.trim().is_empty() {
         return Err("stream_key is empty".to_owned());
     }
@@ -78,17 +119,23 @@ pub(crate) async fn append_streaming_agent_message(
         let body_len: i32 = row.get("body_len");
         let (append_delta, truncated) = capped_stream_delta(delta, body_len.max(0) as usize);
         if append_delta.is_empty() && truncated {
-            finish_streaming_agent_message(pool, stream_key, "complete").await?;
+            if complete_on_truncation {
+                finish_streaming_agent_message(pool, stream_key, "complete").await?;
+            }
             return Ok(message_id);
         }
+        let delivery_state = if truncated && complete_on_truncation {
+            "complete"
+        } else {
+            "streaming"
+        };
         sqlx::query("update messages set body = body || $2, delivery_state = $3 where id = $1")
             .bind(message_id)
             .bind(&append_delta)
-            .bind(if truncated { "complete" } else { "streaming" })
+            .bind(delivery_state)
             .execute(pool)
             .await
             .map_err(to_string)?;
-        let delivery_state = if truncated { "complete" } else { "streaming" };
         let _ = notify_ui_message_delta(
             pool,
             message_id,
@@ -108,7 +155,7 @@ pub(crate) async fn append_streaming_agent_message(
             )
             .await;
         }
-        if truncated {
+        if truncated && complete_on_truncation {
             queue_agent_message_mentions(pool, message_id).await?;
         }
         return Ok(message_id);
@@ -131,6 +178,11 @@ pub(crate) async fn append_streaming_agent_message(
     let sender_name: String = sender.get("display_name");
     let sender_role: String = sender.get("role");
     let (initial_body, truncated) = capped_stream_delta(delta, 0);
+    let delivery_state = if truncated && complete_on_truncation {
+        "complete"
+    } else {
+        "streaming"
+    };
 
     let message_id: Uuid = sqlx::query_scalar(
         r#"
@@ -155,7 +207,7 @@ pub(crate) async fn append_streaming_agent_message(
     .bind(sender_name)
     .bind(sender_role)
     .bind(initial_body)
-    .bind(if truncated { "complete" } else { "streaming" })
+    .bind(delivery_state)
     .bind(stream_key)
     .fetch_one(pool)
     .await
@@ -177,7 +229,7 @@ pub(crate) async fn append_streaming_agent_message(
         )
         .await;
     }
-    if truncated {
+    if truncated && complete_on_truncation {
         queue_agent_message_mentions(pool, message_id).await?;
     }
     Ok(message_id)
@@ -357,10 +409,60 @@ async fn delete_superseded_empty_run_progress_messages(
     Ok(())
 }
 
+pub(crate) async fn delete_intermediate_run_messages(
+    pool: &SqlitePool,
+    agent_id: Uuid,
+    channel_id: Uuid,
+    thread_root_id: Option<Uuid>,
+    run_id: Uuid,
+) -> CommandResult<()> {
+    let superseded_ids: Vec<Uuid> = sqlx::query_scalar(
+        r#"
+        select id
+        from messages
+        where sender_agent_id = $1
+          and channel_id = $2
+          and thread_root_id is not distinct from $3
+          and stream_key like $4
+          and body <> ''
+          and delivery_state in ('streaming', 'complete')
+        "#,
+    )
+    .bind(agent_id)
+    .bind(channel_id)
+    .bind(thread_root_id)
+    .bind(format!("{run_id}:%"))
+    .fetch_all(pool)
+    .await
+    .map_err(to_string)?;
+
+    for message_id in superseded_ids {
+        delete_streaming_agent_message(pool, message_id, "superseded_intermediate_reply").await?;
+    }
+    Ok(())
+}
+
 pub(crate) async fn finish_streaming_agent_message(
     pool: &SqlitePool,
     stream_key: &str,
     delivery_state: &str,
+) -> CommandResult<()> {
+    finish_streaming_agent_message_inner(pool, stream_key, delivery_state, true).await
+}
+
+pub(crate) async fn finish_streaming_agent_message_deferred_mentions(
+    pool: &SqlitePool,
+    stream_key: &str,
+    delivery_state: &str,
+) -> CommandResult<()> {
+    finish_streaming_agent_message_inner(pool, stream_key, delivery_state, false).await
+}
+
+async fn finish_streaming_agent_message_inner(
+    pool: &SqlitePool,
+    stream_key: &str,
+    delivery_state: &str,
+    dispatch_mentions: bool,
 ) -> CommandResult<()> {
     if delivery_state != "streaming" {
         if let Some((agent_id, run_id, work_item_id)) =
@@ -407,10 +509,27 @@ pub(crate) async fn finish_streaming_agent_message(
             } else {
                 let _ = notify_ui_refresh(pool, "stream_finish").await;
             }
-            if delivery_state == "complete" {
+            if delivery_state == "complete" && dispatch_mentions {
                 queue_agent_message_mentions(pool, message_id).await?;
             }
         }
+    }
+    Ok(())
+}
+
+pub(crate) async fn dispatch_streaming_agent_message_mentions(
+    pool: &SqlitePool,
+    stream_key: &str,
+) -> CommandResult<()> {
+    let message_id: Option<Uuid> = sqlx::query_scalar(
+        "select id from messages where stream_key = $1 and delivery_state = 'complete'",
+    )
+    .bind(stream_key)
+    .fetch_optional(pool)
+    .await
+    .map_err(to_string)?;
+    if let Some(message_id) = message_id {
+        queue_agent_message_mentions(pool, message_id).await?;
     }
     Ok(())
 }

--- a/src-tauri/src/tests/runtime_streaming.rs
+++ b/src-tauri/src/tests/runtime_streaming.rs
@@ -1,8 +1,10 @@
 use super::{
     adopt_streaming_agent_message_key, append_streaming_agent_message,
-    consume_streaming_agent_control_lines, ensure_streaming_agent_message,
-    finish_streaming_agent_message, maybe_hide_silent_streaming_reply,
-    streaming_message_body_is_empty,
+    append_streaming_agent_message_deferred_completion, consume_streaming_agent_control_lines,
+    delete_intermediate_run_messages, dispatch_streaming_agent_message_mentions,
+    ensure_streaming_agent_message, finish_streaming_agent_message,
+    finish_streaming_agent_message_deferred_mentions, maybe_hide_silent_streaming_reply,
+    streaming_message_body_is_empty, STREAMING_MESSAGE_BODY_LIMIT,
 };
 use crate::domain::reminders::load_reminders;
 use crate::message_store::load_messages;
@@ -103,6 +105,232 @@ async fn streaming_placeholder_is_reused_for_visible_reply() {
         assert_eq!(message.body, "Done");
         assert_eq!(message.delivery_state, "complete");
         assert_eq!(message.stream_key, final_stream_key);
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
+async fn streaming_intermediate_reply_is_deleted_when_run_continues() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "draft-agent").await?;
+        let channel_id = insert_test_channel(&pool, "draft-channel").await?;
+        let run_id = Uuid::new_v4();
+        let stream_key = format!("{run_id}:draft-message");
+
+        let message_id = append_streaming_agent_message(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &stream_key,
+            "Need get migrations output.",
+        )
+        .await?;
+        delete_intermediate_run_messages(&pool, agent_id, channel_id, None, run_id).await?;
+
+        let remaining: i64 = sqlx::query_scalar("select count(*) from messages where id = $1")
+            .bind(message_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+        assert_eq!(remaining, 0);
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
+async fn deleted_streaming_intermediate_reply_does_not_dispatch_mentions() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "draft-agent").await?;
+        let target_agent_id = insert_test_agent(&pool, "target-agent").await?;
+        let channel_id = insert_test_channel(&pool, "mention-draft-channel").await?;
+        sqlx::query("insert into channel_members (channel_id, agent_id) values ($1, $2), ($1, $3)")
+            .bind(channel_id)
+            .bind(agent_id)
+            .bind(target_agent_id)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+        let run_id = Uuid::new_v4();
+        let stream_key = format!("{run_id}:draft-message");
+
+        append_streaming_agent_message(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &stream_key,
+            "Need @target-agent migrations output.",
+        )
+        .await?;
+
+        delete_intermediate_run_messages(&pool, agent_id, channel_id, None, run_id).await?;
+
+        let work_items: i64 =
+            sqlx::query_scalar("select count(*) from agent_work_items where agent_id = $1")
+                .bind(target_agent_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        let inbox_items: i64 =
+            sqlx::query_scalar("select count(*) from agent_inbox_items where agent_id = $1")
+                .bind(target_agent_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(work_items, 0);
+        assert_eq!(inbox_items, 0);
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
+async fn truncated_deferred_intermediate_reply_stays_streaming_until_deleted() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "long-draft-agent").await?;
+        let target_agent_id = insert_test_agent(&pool, "long-target-agent").await?;
+        let channel_id = insert_test_channel(&pool, "long-mention-draft-channel").await?;
+        sqlx::query("insert into channel_members (channel_id, agent_id) values ($1, $2), ($1, $3)")
+            .bind(channel_id)
+            .bind(agent_id)
+            .bind(target_agent_id)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+        let run_id = Uuid::new_v4();
+        let stream_key = format!("{run_id}:long-draft-message");
+        let body = format!(
+            "Need @long-target-agent migrations output. {}",
+            "x".repeat(STREAMING_MESSAGE_BODY_LIMIT)
+        );
+
+        let message_id = append_streaming_agent_message_deferred_completion(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &stream_key,
+            &body,
+        )
+        .await?;
+
+        let delivery_state: String =
+            sqlx::query_scalar("select delivery_state from messages where id = $1")
+                .bind(message_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(delivery_state, "streaming");
+
+        delete_intermediate_run_messages(&pool, agent_id, channel_id, None, run_id).await?;
+
+        let remaining: i64 = sqlx::query_scalar("select count(*) from messages where id = $1")
+            .bind(message_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+        let work_items: i64 =
+            sqlx::query_scalar("select count(*) from agent_work_items where agent_id = $1")
+                .bind(target_agent_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        let inbox_items: i64 =
+            sqlx::query_scalar("select count(*) from agent_inbox_items where agent_id = $1")
+                .bind(target_agent_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(remaining, 0);
+        assert_eq!(work_items, 0);
+        assert_eq!(inbox_items, 0);
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
+async fn completed_deferred_final_reply_survives_later_turn_error() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "final-agent").await?;
+        let target_agent_id = insert_test_agent(&pool, "final-target-agent").await?;
+        let channel_id = insert_test_channel(&pool, "final-mention-channel").await?;
+        sqlx::query("insert into channel_members (channel_id, agent_id) values ($1, $2), ($1, $3)")
+            .bind(channel_id)
+            .bind(agent_id)
+            .bind(target_agent_id)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+        let run_id = Uuid::new_v4();
+        let stream_key = format!("{run_id}:final-message");
+
+        let message_id = append_streaming_agent_message_deferred_completion(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &stream_key,
+            "Done, @final-target-agent should see this.",
+        )
+        .await?;
+        finish_streaming_agent_message_deferred_mentions(&pool, &stream_key, "complete").await?;
+
+        let work_items_before: i64 =
+            sqlx::query_scalar("select count(*) from agent_work_items where agent_id = $1")
+                .bind(target_agent_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(work_items_before, 0);
+
+        finish_streaming_agent_message(&pool, &stream_key, "error").await?;
+        dispatch_streaming_agent_message_mentions(&pool, &stream_key).await?;
+
+        let delivery_state: String =
+            sqlx::query_scalar("select delivery_state from messages where id = $1")
+                .bind(message_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        let work_items_after: i64 =
+            sqlx::query_scalar("select count(*) from agent_work_items where agent_id = $1")
+                .bind(target_agent_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        let inbox_items_after: i64 =
+            sqlx::query_scalar("select count(*) from agent_inbox_items where agent_id = $1")
+                .bind(target_agent_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(delivery_state, "complete");
+        assert_eq!(work_items_after, 1);
+        assert_eq!(inbox_items_after, 1);
         Ok(())
     }
     .await;


### PR DESCRIPTION
## Summary
- delete completed same-run Codex assistant text once the turn continues into non-message work
- keep final replies visible while preventing draft/internal notes like "Need get migrations output." from persisting as chat messages
- add a runtime streaming regression test for the leaked draft case

## Test
- cargo test streaming