### PR TITLE
Add backend thread unread activity bootstrap data

### DIFF
--- a/src-tauri/src/bootstrap.rs
+++ b/src-tauri/src/bootstrap.rs
@@ -9,7 +9,7 @@ use crate::{
     activity_store::{load_agent_activities, load_agent_runs, load_agent_work_items},
     agent_profile::{load_agents, load_owner_profile},
     app::CommandResult,
-    channels::{load_channel_members, load_channels},
+    channels::{load_channel_members, load_channels, load_thread_activities},
     domain::{reminders::load_reminders, schedules::load_agent_schedules},
     launch_agent,
     message_store::{load_artifacts, load_messages, load_saved_messages},
@@ -41,6 +41,7 @@ fn configured_web_base_url() -> Option<String> {
 pub(crate) async fn load_bootstrap(pool: &SqlitePool, db_url: String) -> CommandResult<Bootstrap> {
     let owner_profile = load_owner_profile(pool).await?;
     let channels = load_channels(pool).await?;
+    let thread_activities = load_thread_activities(pool).await?;
     let channel_members = load_channel_members(pool).await?;
     let agents = load_agents(pool).await?;
     let messages = load_messages(pool).await?;
@@ -62,6 +63,7 @@ pub(crate) async fn load_bootstrap(pool: &SqlitePool, db_url: String) -> Command
         web_base_url: configured_web_base_url(),
         owner_profile,
         channels,
+        thread_activities,
         channel_members,
         agents,
         messages,

--- a/src-tauri/src/channels.rs
+++ b/src-tauri/src/channels.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::app::{to_string, CommandResult};
 use crate::events::activity::record_agent_activity;
-use crate::models::{Channel, ChannelMember};
+use crate::models::{Channel, ChannelMember, ThreadActivity};
 use crate::ui_notifications::notify_ui_refresh;
 
 pub(crate) async fn load_channels(pool: &SqlitePool) -> CommandResult<Vec<Channel>> {
@@ -62,6 +62,92 @@ pub(crate) async fn load_channels(pool: &SqlitePool) -> CommandResult<Vec<Channe
             kind: row.get("kind"),
             dm_agent_id: row.get("dm_agent_id"),
             unread_count: row.get("unread_count"),
+        })
+        .collect())
+}
+
+pub(crate) async fn load_thread_activities(pool: &SqlitePool) -> CommandResult<Vec<ThreadActivity>> {
+    let rows = sqlx::query(
+        r#"
+        with visible_thread_replies as (
+            select
+                m.id,
+                m.channel_id,
+                m.thread_root_id,
+                m.created_at
+            from messages m
+            where m.thread_root_id is not null
+              and not (
+                m.sender_role <> 'system'
+                and m.sender_role <> 'owner'
+                and m.stream_key glob '????????-????-????-????-????????????:*'
+                and (
+                  m.delivery_state = 'streaming'
+                  or (
+                    m.delivery_state = 'complete'
+                    and trim(m.body) = ''
+                    and not exists (
+                      select 1 from message_attachments ma where ma.message_id = m.id
+                    )
+                    and not exists (
+                      select 1 from artifacts ar where ar.message_id = m.id
+                    )
+                  )
+                )
+              )
+        ),
+        latest_visible_thread_replies as (
+            select
+                ranked.thread_root_id,
+                ranked.id as latest_message_id,
+                ranked.created_at as latest_activity_at
+            from (
+                select
+                    vr.*,
+                    row_number() over (
+                        partition by vr.thread_root_id
+                        order by julianday(vr.created_at) desc, vr.created_at desc, vr.id desc
+                    ) as row_num
+                from visible_thread_replies vr
+            ) ranked
+            where ranked.row_num = 1
+        )
+        select
+            root.id as thread_root_id,
+            root.channel_id,
+            cast(sum(case
+                when julianday(reply.created_at) > julianday(
+                    coalesce(read_state.last_read_at, '0001-01-01T00:00:00+00:00')
+                ) then 1
+                else 0
+            end) as integer) as unread_count,
+            latest.latest_message_id,
+            latest.latest_activity_at
+        from messages root
+        join visible_thread_replies reply on reply.thread_root_id = root.id
+        join latest_visible_thread_replies latest on latest.thread_root_id = root.id
+        left join channel_read_state read_state on read_state.channel_id = root.channel_id
+        where root.thread_root_id is null
+        group by
+            root.id,
+            root.channel_id,
+            latest.latest_message_id,
+            latest.latest_activity_at
+        order by julianday(latest.latest_activity_at) desc, latest.latest_activity_at desc, root.id desc
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(to_string)?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| ThreadActivity {
+            thread_root_id: row.get("thread_root_id"),
+            channel_id: row.get("channel_id"),
+            unread_count: row.get("unread_count"),
+            latest_message_id: row.get("latest_message_id"),
+            latest_activity_at: row.get("latest_activity_at"),
         })
         .collect())
 }
@@ -426,8 +512,9 @@ mod tests {
     use uuid::Uuid;
 
     use super::{
-        create_channel_in_pool, delete_channel_in_pool, load_channels, open_dm_with_agent_in_pool,
-        set_channel_agent_membership_in_pool, update_channel_in_pool,
+        create_channel_in_pool, delete_channel_in_pool, load_channels, load_thread_activities,
+        open_dm_with_agent_in_pool, set_channel_agent_membership_in_pool,
+        update_channel_in_pool,
     };
     use crate::db::{db_connect_with_url, migrate};
 
@@ -640,6 +727,176 @@ mod tests {
                 .find(|channel| channel.id == channel_id)
                 .ok_or_else(|| "missing test channel".to_owned())?;
             assert_eq!(channel.unread_count, 2);
+
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn thread_activities_report_latest_visible_reply_and_unread_counts() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let channel_id = insert_test_channel(&pool, "thread-unread-activity").await?;
+            sqlx::query(
+                r#"
+                insert into channel_read_state (channel_id, last_read_at)
+                values ($1, '2026-05-22T08:00:00+00:00')
+                "#,
+            )
+            .bind(channel_id)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let thread_a_root: Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (channel_id, sender_name, sender_role, body, created_at)
+                values ($1, 'Martin', 'owner', 'thread a root', '2026-05-22T07:00:00+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            sqlx::query(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, created_at
+                )
+                values ($1, $2, 'Dylan', 'agent', 'already read reply', '2026-05-22T07:30:00+00:00')
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_a_root)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            sqlx::query(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, delivery_state, stream_key, created_at
+                )
+                values (
+                    $1,
+                    $2,
+                    'Dylan',
+                    'agent',
+                    '',
+                    'complete',
+                    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:msg_hidden',
+                    '2026-05-22T08:10:00+00:00'
+                )
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_a_root)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let thread_a_latest_reply: Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, created_at
+                )
+                values ($1, $2, 'Dylan', 'agent', 'visible unread reply', '2026-05-22T08:15:00+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_a_root)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let thread_b_root: Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (channel_id, sender_name, sender_role, body, created_at)
+                values ($1, 'Martin', 'owner', 'thread b root', '2026-05-22T07:05:00+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let thread_b_latest_reply: Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, created_at
+                )
+                values ($1, $2, 'OtherAgent', 'agent', 'second thread latest', '2026-05-22T08:05:00+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_b_root)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let thread_hidden_only_root: Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (channel_id, sender_name, sender_role, body, created_at)
+                values ($1, 'Martin', 'owner', 'hidden-only root', '2026-05-22T07:10:00+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            sqlx::query(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, delivery_state, stream_key, created_at
+                )
+                values (
+                    $1,
+                    $2,
+                    'Dylan',
+                    'agent',
+                    '',
+                    'streaming',
+                    'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb:msg_streaming',
+                    '2026-05-22T08:20:00+00:00'
+                )
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_hidden_only_root)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let activities = load_thread_activities(&pool).await?;
+            assert_eq!(activities.len(), 2);
+
+            let first = &activities[0];
+            assert_eq!(first.thread_root_id, thread_a_root);
+            assert_eq!(first.channel_id, channel_id);
+            assert_eq!(first.unread_count, 1);
+            assert_eq!(first.latest_message_id, thread_a_latest_reply);
+
+            let second = &activities[1];
+            assert_eq!(second.thread_root_id, thread_b_root);
+            assert_eq!(second.channel_id, channel_id);
+            assert_eq!(second.unread_count, 1);
+            assert_eq!(second.latest_message_id, thread_b_latest_reply);
+
+            assert!(activities
+                .iter()
+                .all(|activity| activity.thread_root_id != thread_hidden_only_root));
 
             Ok(())
         }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -79,6 +79,15 @@ pub(crate) struct Channel {
 }
 
 #[derive(Debug, Serialize)]
+pub(crate) struct ThreadActivity {
+    pub(crate) thread_root_id: Uuid,
+    pub(crate) channel_id: Uuid,
+    pub(crate) unread_count: i32,
+    pub(crate) latest_message_id: Uuid,
+    pub(crate) latest_activity_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
 pub(crate) struct ChannelMember {
     pub(crate) channel_id: Uuid,
     pub(crate) agent_id: Uuid,
@@ -340,6 +349,7 @@ pub(crate) struct Bootstrap {
     pub(crate) web_base_url: Option<String>,
     pub(crate) owner_profile: OwnerProfile,
     pub(crate) channels: Vec<Channel>,
+    pub(crate) thread_activities: Vec<ThreadActivity>,
     pub(crate) channel_members: Vec<ChannelMember>,
     pub(crate) agents: Vec<Agent>,
     pub(crate) messages: Vec<Message>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,14 @@ export type Channel = {
   unread_count: number;
 };
 
+export type ThreadActivity = {
+  thread_root_id: string;
+  channel_id: string;
+  unread_count: number;
+  latest_message_id: string;
+  latest_activity_at: string;
+};
+
 export type ChannelMember = {
   channel_id: string;
   agent_id: string;
@@ -271,6 +279,7 @@ export type Bootstrap = {
   web_base_url: string | null;
   owner_profile: OwnerProfile;
   channels: Channel[];
+  thread_activities: ThreadActivity[];
   channel_members: ChannelMember[];
   agents: Agent[];
   messages: Message[];


### PR DESCRIPTION
## Summary
- add thread activity records to bootstrap with per-thread unread count and latest visible activity
- derive the data in the backend using the same hidden progress-message rules as channel unread
- add a regression test covering hidden progress-only replies so they do not become latest activity or unread truth

## Verification
- cargo test --manifest-path src-tauri/Cargo.toml thread_activities_report_latest_visible_reply_and_unread_counts -- --nocapture
- npm run build