### PR TITLE
Wire thread activity bootstrap into frontend

### DIFF
--- a/src-tauri/src/bootstrap.rs
+++ b/src-tauri/src/bootstrap.rs
@@ -9,7 +9,7 @@ use crate::{
     activity_store::{load_agent_activities, load_agent_runs, load_agent_work_items},
     agent_profile::{load_agents, load_owner_profile},
     app::CommandResult,
-    channels::{load_channel_members, load_channels},
+    channels::{load_channel_members, load_channels, load_thread_activities},
     domain::{reminders::load_reminders, schedules::load_agent_schedules},
     launch_agent,
     message_store::{load_artifacts, load_messages, load_saved_messages},
@@ -41,6 +41,7 @@ fn configured_web_base_url() -> Option<String> {
 pub(crate) async fn load_bootstrap(pool: &SqlitePool, db_url: String) -> CommandResult<Bootstrap> {
     let owner_profile = load_owner_profile(pool).await?;
     let channels = load_channels(pool).await?;
+    let thread_activities = load_thread_activities(pool).await?;
     let channel_members = load_channel_members(pool).await?;
     let agents = load_agents(pool).await?;
     let messages = load_messages(pool).await?;
@@ -62,6 +63,7 @@ pub(crate) async fn load_bootstrap(pool: &SqlitePool, db_url: String) -> Command
         web_base_url: configured_web_base_url(),
         owner_profile,
         channels,
+        thread_activities,
         channel_members,
         agents,
         messages,

--- a/src-tauri/src/channels.rs
+++ b/src-tauri/src/channels.rs
@@ -66,7 +66,9 @@ pub(crate) async fn load_channels(pool: &SqlitePool) -> CommandResult<Vec<Channe
         .collect())
 }
 
-pub(crate) async fn load_thread_activities(pool: &SqlitePool) -> CommandResult<Vec<ThreadActivity>> {
+pub(crate) async fn load_thread_activities(
+    pool: &SqlitePool,
+) -> CommandResult<Vec<ThreadActivity>> {
     let rows = sqlx::query(
         r#"
         with visible_thread_replies as (
@@ -74,6 +76,7 @@ pub(crate) async fn load_thread_activities(pool: &SqlitePool) -> CommandResult<V
                 m.id,
                 m.channel_id,
                 m.thread_root_id,
+                m.sender_role,
                 m.created_at
             from messages m
             where m.thread_root_id is not null
@@ -116,9 +119,10 @@ pub(crate) async fn load_thread_activities(pool: &SqlitePool) -> CommandResult<V
             root.id as thread_root_id,
             root.channel_id,
             cast(sum(case
-                when julianday(reply.created_at) > julianday(
-                    coalesce(read_state.last_read_at, '0001-01-01T00:00:00+00:00')
-                ) then 1
+                when reply.sender_role <> 'owner'
+                  and julianday(reply.created_at) > julianday(
+                    coalesce(thread_read_state.read_until, read_state.last_read_at, '0001-01-01T00:00:00+00:00')
+                  ) then 1
                 else 0
             end) as integer) as unread_count,
             latest.latest_message_id,
@@ -127,6 +131,14 @@ pub(crate) async fn load_thread_activities(pool: &SqlitePool) -> CommandResult<V
         join visible_thread_replies reply on reply.thread_root_id = root.id
         join latest_visible_thread_replies latest on latest.thread_root_id = root.id
         left join channel_read_state read_state on read_state.channel_id = root.channel_id
+        left join owner_inbox_read_state thread_read_state
+          on thread_read_state.item_id = 'thread:' || lower(
+            substr(hex(root.id), 1, 8) || '-' ||
+            substr(hex(root.id), 9, 4) || '-' ||
+            substr(hex(root.id), 13, 4) || '-' ||
+            substr(hex(root.id), 17, 4) || '-' ||
+            substr(hex(root.id), 21, 12)
+          )
         where root.thread_root_id is null
         group by
             root.id,
@@ -513,8 +525,7 @@ mod tests {
 
     use super::{
         create_channel_in_pool, delete_channel_in_pool, load_channels, load_thread_activities,
-        open_dm_with_agent_in_pool, set_channel_agent_membership_in_pool,
-        update_channel_in_pool,
+        open_dm_with_agent_in_pool, set_channel_agent_membership_in_pool, update_channel_in_pool,
     };
     use crate::db::{db_connect_with_url, migrate};
 
@@ -802,6 +813,20 @@ mod tests {
             .await
             .map_err(|err| err.to_string())?;
 
+            sqlx::query(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, created_at
+                )
+                values ($1, $2, 'Martin', 'owner', 'owner follow-up should not be unread', '2026-05-22T08:12:00+00:00')
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_a_root)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
             let thread_a_latest_reply: Uuid = sqlx::query_scalar(
                 r#"
                 insert into messages (
@@ -844,6 +869,58 @@ mod tests {
             .await
             .map_err(|err| err.to_string())?;
 
+            let thread_c_root: Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (channel_id, sender_name, sender_role, body, created_at)
+                values ($1, 'Martin', 'owner', 'thread c root', '2026-05-22T07:08:00+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            sqlx::query(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, created_at
+                )
+                values ($1, $2, 'OtherAgent', 'agent', 'thread read before marker', '2026-05-22T08:05:00+00:00')
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_c_root)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let thread_c_latest_reply: Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, created_at
+                )
+                values ($1, $2, 'OtherAgent', 'agent', 'thread unread after marker', '2026-05-22T08:12:30+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_c_root)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            sqlx::query(
+                r#"
+                insert into owner_inbox_read_state (item_id, read_until)
+                values ($1, '2026-05-22T08:10:00+00:00')
+                "#,
+            )
+            .bind(format!("thread:{thread_c_root}"))
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
             let thread_hidden_only_root: Uuid = sqlx::query_scalar(
                 r#"
                 insert into messages (channel_id, sender_name, sender_role, body, created_at)
@@ -880,7 +957,7 @@ mod tests {
             .map_err(|err| err.to_string())?;
 
             let activities = load_thread_activities(&pool).await?;
-            assert_eq!(activities.len(), 2);
+            assert_eq!(activities.len(), 3);
 
             let first = &activities[0];
             assert_eq!(first.thread_root_id, thread_a_root);
@@ -889,10 +966,16 @@ mod tests {
             assert_eq!(first.latest_message_id, thread_a_latest_reply);
 
             let second = &activities[1];
-            assert_eq!(second.thread_root_id, thread_b_root);
+            assert_eq!(second.thread_root_id, thread_c_root);
             assert_eq!(second.channel_id, channel_id);
             assert_eq!(second.unread_count, 1);
-            assert_eq!(second.latest_message_id, thread_b_latest_reply);
+            assert_eq!(second.latest_message_id, thread_c_latest_reply);
+
+            let third = &activities[2];
+            assert_eq!(third.thread_root_id, thread_b_root);
+            assert_eq!(third.channel_id, channel_id);
+            assert_eq!(third.unread_count, 1);
+            assert_eq!(third.latest_message_id, thread_b_latest_reply);
 
             assert!(activities
                 .iter()

--- a/src-tauri/src/channels.rs
+++ b/src-tauri/src/channels.rs
@@ -80,24 +80,42 @@ pub(crate) async fn load_thread_activities(
                 m.created_at
             from messages m
             where m.thread_root_id is not null
+              and m.delivery_state <> 'streaming'
               and not (
                 m.sender_role <> 'system'
                 and m.sender_role <> 'owner'
                 and m.stream_key glob '????????-????-????-????-????????????:*'
-                and (
-                  m.delivery_state = 'streaming'
-                  or (
-                    m.delivery_state = 'complete'
-                    and trim(m.body) = ''
-                    and not exists (
-                      select 1 from message_attachments ma where ma.message_id = m.id
-                    )
-                    and not exists (
-                      select 1 from artifacts ar where ar.message_id = m.id
-                    )
-                  )
+                and m.delivery_state = 'complete'
+                and trim(m.body) = ''
+                and not exists (
+                  select 1 from message_attachments ma where ma.message_id = m.id
+                )
+                and not exists (
+                  select 1 from artifacts ar where ar.message_id = m.id
                 )
               )
+        ),
+        thread_read_markers as (
+            select
+                root.id as thread_root_id,
+                case
+                    when thread_read_state.read_until is null then read_state.last_read_at
+                    when read_state.last_read_at is null then thread_read_state.read_until
+                    when julianday(thread_read_state.read_until) >= julianday(read_state.last_read_at)
+                        then thread_read_state.read_until
+                    else read_state.last_read_at
+                end as read_until
+            from messages root
+            left join channel_read_state read_state on read_state.channel_id = root.channel_id
+            left join owner_inbox_read_state thread_read_state
+              on thread_read_state.item_id = 'thread:' || lower(
+                substr(hex(root.id), 1, 8) || '-' ||
+                substr(hex(root.id), 9, 4) || '-' ||
+                substr(hex(root.id), 13, 4) || '-' ||
+                substr(hex(root.id), 17, 4) || '-' ||
+                substr(hex(root.id), 21, 12)
+              )
+            where root.thread_root_id is null
         ),
         latest_visible_thread_replies as (
             select
@@ -121,7 +139,7 @@ pub(crate) async fn load_thread_activities(
             cast(sum(case
                 when reply.sender_role <> 'owner'
                   and julianday(reply.created_at) > julianday(
-                    coalesce(thread_read_state.read_until, read_state.last_read_at, '0001-01-01T00:00:00+00:00')
+                    coalesce(read_marker.read_until, '0001-01-01T00:00:00+00:00')
                   ) then 1
                 else 0
             end) as integer) as unread_count,
@@ -130,15 +148,7 @@ pub(crate) async fn load_thread_activities(
         from messages root
         join visible_thread_replies reply on reply.thread_root_id = root.id
         join latest_visible_thread_replies latest on latest.thread_root_id = root.id
-        left join channel_read_state read_state on read_state.channel_id = root.channel_id
-        left join owner_inbox_read_state thread_read_state
-          on thread_read_state.item_id = 'thread:' || lower(
-            substr(hex(root.id), 1, 8) || '-' ||
-            substr(hex(root.id), 9, 4) || '-' ||
-            substr(hex(root.id), 13, 4) || '-' ||
-            substr(hex(root.id), 17, 4) || '-' ||
-            substr(hex(root.id), 21, 12)
-          )
+        left join thread_read_markers read_marker on read_marker.thread_root_id = root.id
         where root.thread_root_id is null
         group by
             root.id,
@@ -956,6 +966,29 @@ mod tests {
             .await
             .map_err(|err| err.to_string())?;
 
+            sqlx::query(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, delivery_state, stream_key, created_at
+                )
+                values (
+                    $1,
+                    $2,
+                    'Dylan',
+                    'agent',
+                    'non-uuid streaming should not count',
+                    'streaming',
+                    'manual-stream-key',
+                    '2026-05-22T08:25:00+00:00'
+                )
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_hidden_only_root)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
             let activities = load_thread_activities(&pool).await?;
             assert_eq!(activities.len(), 3);
 
@@ -980,6 +1013,77 @@ mod tests {
             assert!(activities
                 .iter()
                 .all(|activity| activity.thread_root_id != thread_hidden_only_root));
+
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn thread_activities_use_newer_channel_read_marker_over_older_thread_marker() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let channel_id = insert_test_channel(&pool, "thread-read-marker-max").await?;
+            sqlx::query(
+                r#"
+                insert into channel_read_state (channel_id, last_read_at)
+                values ($1, '2026-05-22T08:30:00+00:00')
+                "#,
+            )
+            .bind(channel_id)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let thread_root: Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (channel_id, sender_name, sender_role, body, created_at)
+                values ($1, 'Martin', 'owner', 'thread root', '2026-05-22T07:00:00+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let latest_reply: Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, created_at
+                )
+                values ($1, $2, 'Dylan', 'agent', 'reply after old thread marker', '2026-05-22T08:20:00+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_root)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            sqlx::query(
+                r#"
+                insert into owner_inbox_read_state (item_id, read_until)
+                values ($1, '2026-05-22T08:10:00+00:00')
+                "#,
+            )
+            .bind(format!("thread:{thread_root}"))
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let activities = load_thread_activities(&pool).await?;
+            let activity = activities
+                .iter()
+                .find(|activity| activity.thread_root_id == thread_root)
+                .ok_or_else(|| "missing thread activity".to_owned())?;
+            assert_eq!(activity.latest_message_id, latest_reply);
+            assert_eq!(activity.unread_count, 0);
 
             Ok(())
         }

--- a/src-tauri/src/channels.rs
+++ b/src-tauri/src/channels.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::app::{to_string, CommandResult};
 use crate::events::activity::record_agent_activity;
-use crate::models::{Channel, ChannelMember};
+use crate::models::{Channel, ChannelMember, ThreadActivity};
 use crate::ui_notifications::notify_ui_refresh;
 
 pub(crate) async fn load_channels(pool: &SqlitePool) -> CommandResult<Vec<Channel>> {
@@ -62,6 +62,92 @@ pub(crate) async fn load_channels(pool: &SqlitePool) -> CommandResult<Vec<Channe
             kind: row.get("kind"),
             dm_agent_id: row.get("dm_agent_id"),
             unread_count: row.get("unread_count"),
+        })
+        .collect())
+}
+
+pub(crate) async fn load_thread_activities(pool: &SqlitePool) -> CommandResult<Vec<ThreadActivity>> {
+    let rows = sqlx::query(
+        r#"
+        with visible_thread_replies as (
+            select
+                m.id,
+                m.channel_id,
+                m.thread_root_id,
+                m.created_at
+            from messages m
+            where m.thread_root_id is not null
+              and not (
+                m.sender_role <> 'system'
+                and m.sender_role <> 'owner'
+                and m.stream_key glob '????????-????-????-????-????????????:*'
+                and (
+                  m.delivery_state = 'streaming'
+                  or (
+                    m.delivery_state = 'complete'
+                    and trim(m.body) = ''
+                    and not exists (
+                      select 1 from message_attachments ma where ma.message_id = m.id
+                    )
+                    and not exists (
+                      select 1 from artifacts ar where ar.message_id = m.id
+                    )
+                  )
+                )
+              )
+        ),
+        latest_visible_thread_replies as (
+            select
+                ranked.thread_root_id,
+                ranked.id as latest_message_id,
+                ranked.created_at as latest_activity_at
+            from (
+                select
+                    vr.*,
+                    row_number() over (
+                        partition by vr.thread_root_id
+                        order by julianday(vr.created_at) desc, vr.created_at desc, vr.id desc
+                    ) as row_num
+                from visible_thread_replies vr
+            ) ranked
+            where ranked.row_num = 1
+        )
+        select
+            root.id as thread_root_id,
+            root.channel_id,
+            cast(sum(case
+                when julianday(reply.created_at) > julianday(
+                    coalesce(read_state.last_read_at, '0001-01-01T00:00:00+00:00')
+                ) then 1
+                else 0
+            end) as integer) as unread_count,
+            latest.latest_message_id,
+            latest.latest_activity_at
+        from messages root
+        join visible_thread_replies reply on reply.thread_root_id = root.id
+        join latest_visible_thread_replies latest on latest.thread_root_id = root.id
+        left join channel_read_state read_state on read_state.channel_id = root.channel_id
+        where root.thread_root_id is null
+        group by
+            root.id,
+            root.channel_id,
+            latest.latest_message_id,
+            latest.latest_activity_at
+        order by julianday(latest.latest_activity_at) desc, latest.latest_activity_at desc, root.id desc
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(to_string)?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| ThreadActivity {
+            thread_root_id: row.get("thread_root_id"),
+            channel_id: row.get("channel_id"),
+            unread_count: row.get("unread_count"),
+            latest_message_id: row.get("latest_message_id"),
+            latest_activity_at: row.get("latest_activity_at"),
         })
         .collect())
 }
@@ -426,8 +512,9 @@ mod tests {
     use uuid::Uuid;
 
     use super::{
-        create_channel_in_pool, delete_channel_in_pool, load_channels, open_dm_with_agent_in_pool,
-        set_channel_agent_membership_in_pool, update_channel_in_pool,
+        create_channel_in_pool, delete_channel_in_pool, load_channels, load_thread_activities,
+        open_dm_with_agent_in_pool, set_channel_agent_membership_in_pool,
+        update_channel_in_pool,
     };
     use crate::db::{db_connect_with_url, migrate};
 
@@ -640,6 +727,176 @@ mod tests {
                 .find(|channel| channel.id == channel_id)
                 .ok_or_else(|| "missing test channel".to_owned())?;
             assert_eq!(channel.unread_count, 2);
+
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn thread_activities_report_latest_visible_reply_and_unread_counts() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let channel_id = insert_test_channel(&pool, "thread-unread-activity").await?;
+            sqlx::query(
+                r#"
+                insert into channel_read_state (channel_id, last_read_at)
+                values ($1, '2026-05-22T08:00:00+00:00')
+                "#,
+            )
+            .bind(channel_id)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let thread_a_root: Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (channel_id, sender_name, sender_role, body, created_at)
+                values ($1, 'Martin', 'owner', 'thread a root', '2026-05-22T07:00:00+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            sqlx::query(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, created_at
+                )
+                values ($1, $2, 'Dylan', 'agent', 'already read reply', '2026-05-22T07:30:00+00:00')
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_a_root)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            sqlx::query(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, delivery_state, stream_key, created_at
+                )
+                values (
+                    $1,
+                    $2,
+                    'Dylan',
+                    'agent',
+                    '',
+                    'complete',
+                    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:msg_hidden',
+                    '2026-05-22T08:10:00+00:00'
+                )
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_a_root)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let thread_a_latest_reply: Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, created_at
+                )
+                values ($1, $2, 'Dylan', 'agent', 'visible unread reply', '2026-05-22T08:15:00+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_a_root)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let thread_b_root: Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (channel_id, sender_name, sender_role, body, created_at)
+                values ($1, 'Martin', 'owner', 'thread b root', '2026-05-22T07:05:00+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let thread_b_latest_reply: Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, created_at
+                )
+                values ($1, $2, 'OtherAgent', 'agent', 'second thread latest', '2026-05-22T08:05:00+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_b_root)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let thread_hidden_only_root: Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (channel_id, sender_name, sender_role, body, created_at)
+                values ($1, 'Martin', 'owner', 'hidden-only root', '2026-05-22T07:10:00+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            sqlx::query(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, delivery_state, stream_key, created_at
+                )
+                values (
+                    $1,
+                    $2,
+                    'Dylan',
+                    'agent',
+                    '',
+                    'streaming',
+                    'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb:msg_streaming',
+                    '2026-05-22T08:20:00+00:00'
+                )
+                "#,
+            )
+            .bind(channel_id)
+            .bind(thread_hidden_only_root)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let activities = load_thread_activities(&pool).await?;
+            assert_eq!(activities.len(), 2);
+
+            let first = &activities[0];
+            assert_eq!(first.thread_root_id, thread_a_root);
+            assert_eq!(first.channel_id, channel_id);
+            assert_eq!(first.unread_count, 1);
+            assert_eq!(first.latest_message_id, thread_a_latest_reply);
+
+            let second = &activities[1];
+            assert_eq!(second.thread_root_id, thread_b_root);
+            assert_eq!(second.channel_id, channel_id);
+            assert_eq!(second.unread_count, 1);
+            assert_eq!(second.latest_message_id, thread_b_latest_reply);
+
+            assert!(activities
+                .iter()
+                .all(|activity| activity.thread_root_id != thread_hidden_only_root));
 
             Ok(())
         }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -79,6 +79,15 @@ pub(crate) struct Channel {
 }
 
 #[derive(Debug, Serialize)]
+pub(crate) struct ThreadActivity {
+    pub(crate) thread_root_id: Uuid,
+    pub(crate) channel_id: Uuid,
+    pub(crate) unread_count: i32,
+    pub(crate) latest_message_id: Uuid,
+    pub(crate) latest_activity_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
 pub(crate) struct ChannelMember {
     pub(crate) channel_id: Uuid,
     pub(crate) agent_id: Uuid,
@@ -340,6 +349,7 @@ pub(crate) struct Bootstrap {
     pub(crate) web_base_url: Option<String>,
     pub(crate) owner_profile: OwnerProfile,
     pub(crate) channels: Vec<Channel>,
+    pub(crate) thread_activities: Vec<ThreadActivity>,
     pub(crate) channel_members: Vec<ChannelMember>,
     pub(crate) agents: Vec<Agent>,
     pub(crate) messages: Vec<Message>,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2565,10 +2565,26 @@ function App() {
     return new Date(cutoffTime).toISOString();
   }
 
+  async function persistThreadReadMarkers(markers: { threadId: string; dismissedUntil: string }[]) {
+    const cutoffByThreadId = new Map<string, string>();
+    for (const marker of markers) {
+      const existing = cutoffByThreadId.get(marker.threadId);
+      if (!existing || new Date(marker.dismissedUntil).getTime() > new Date(existing).getTime()) {
+        cutoffByThreadId.set(marker.threadId, marker.dismissedUntil);
+      }
+    }
+    const items = Array.from(cutoffByThreadId, ([threadId, dismissedUntil]) => ({
+      itemId: `thread:${threadId}`,
+      dismissedUntil,
+    }));
+    if (items.length === 0) return;
+    await apiInvoke("mark_inbox_items_read", { items });
+  }
+
   function markThreadRead(threadId: string) {
-    void apiInvoke("mark_inbox_items_read", {
-      items: [{ itemId: `thread:${threadId}`, dismissedUntil: threadReadCutoff(threadId) }],
-    }).catch((err) => console.error(err));
+    void persistThreadReadMarkers([
+      { threadId, dismissedUntil: threadReadCutoff(threadId) },
+    ]).catch((err) => console.error(err));
   }
 
   function forgetChannelThread(channelId: string | null | undefined) {
@@ -3235,6 +3251,7 @@ function App() {
         delete next[item.threadId!];
         return next;
       });
+      operations.push(persistThreadReadMarkers([{ threadId: item.threadId, dismissedUntil }]));
     }
     if (item.channelId) {
       setChannelAlertIds((current) => {
@@ -3308,6 +3325,14 @@ function App() {
     });
     await Promise.all([
       persistReadActivityFeedItems(markReadItems, (item) => cutoffByItemId.get(item.id) ?? item.timestamp),
+      persistThreadReadMarkers(
+        markReadItems
+          .filter((item): item is ActivityFeedItem & { threadId: string } => Boolean(item.threadId))
+          .map((item) => ({
+            threadId: item.threadId,
+            dismissedUntil: cutoffByItemId.get(item.id) ?? item.timestamp,
+          })),
+      ),
       ...Array.from(
         new Set(markReadItems.map((item) => item.channelId).filter((id): id is string => Boolean(id))),
         (channelId) => apiInvoke("mark_channel_read", { channelId }),

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -55,6 +55,7 @@ import {
   SearchScope,
   SearchTimeRange,
   Task,
+  ThreadActivity,
   ThreadReplySummary,
 } from "./types";
 import { agentRequestSourceLabel, buildPresetCommand, firstLines, formatTime, visibleChannelDescription } from "./ui-utils";
@@ -1425,6 +1426,15 @@ function App() {
     setReadActivityFeedItems(data?.read_inbox_items ?? {});
   }, [data?.read_inbox_items]);
 
+  useEffect(() => {
+    const unreadCounts = Object.fromEntries(
+      (data?.thread_activities ?? [])
+        .filter((activity) => activity.unread_count > 0)
+        .map((activity) => [activity.thread_root_id, activity.unread_count]),
+    );
+    setThreadUnreadCounts(unreadCounts);
+  }, [data?.thread_activities]);
+
   function adjustChatTextSize(delta: number) {
     setChatTextSize((current) => {
       const index = CHAT_TEXT_SIZE_OPTIONS.indexOf(current);
@@ -1864,12 +1874,26 @@ function App() {
     );
   }, [threadReplySummaries]);
 
+  const messagesById = useMemo(() => {
+    return new Map(visibleMessages.map((message) => [message.id, message]));
+  }, [visibleMessages]);
+
+  const threadActivitiesByRoot = useMemo(() => {
+    return new Map((data?.thread_activities ?? []).map((activity) => [activity.thread_root_id, activity]));
+  }, [data?.thread_activities]);
+
   const allThreadRootMessages = useMemo(() => {
     const latestByRoot = new Map<string, number>();
     for (const message of visibleMessages) {
       if (!message.thread_root_id) continue;
       const timestamp = new Date(message.created_at).getTime();
       latestByRoot.set(message.thread_root_id, Math.max(latestByRoot.get(message.thread_root_id) ?? 0, timestamp));
+    }
+    for (const activity of data?.thread_activities ?? []) {
+      const timestamp = new Date(activity.latest_activity_at).getTime();
+      if (Number.isFinite(timestamp)) {
+        latestByRoot.set(activity.thread_root_id, Math.max(latestByRoot.get(activity.thread_root_id) ?? 0, timestamp));
+      }
     }
     return visibleMessages
       .filter((message) =>
@@ -1878,7 +1902,7 @@ function App() {
         (message.thread_followed || (threadUnreadCounts[message.id] ?? 0) > 0) &&
         !locallyUnfollowedThreadIds.has(message.id))
       .sort((left, right) => (latestByRoot.get(right.id) ?? 0) - (latestByRoot.get(left.id) ?? 0));
-  }, [visibleMessages, locallyUnfollowedThreadIds, threadUnreadCounts]);
+  }, [data?.thread_activities, visibleMessages, locallyUnfollowedThreadIds, threadUnreadCounts]);
 
   const allActivityFeedItems = useMemo(() => {
     if (!data) return [];
@@ -1946,8 +1970,11 @@ function App() {
 
     for (const root of allThreadRootMessages) {
       const replies = repliesByRoot.get(root.id) ?? [];
-      const unreadCount = threadUnreadCounts[root.id] ?? 0;
-      const latestActivity = replies.length > 0 ? replies[replies.length - 1] : root;
+      const threadActivity = threadActivitiesByRoot.get(root.id);
+      const unreadCount = threadUnreadCounts[root.id] ?? threadActivity?.unread_count ?? 0;
+      const latestActivity = threadActivity
+        ? messagesById.get(threadActivity.latest_message_id) ?? replies[replies.length - 1] ?? root
+        : replies[replies.length - 1] ?? root;
       const unread = unreadCount > 0;
       items.push({
         id: `thread:${root.id}`,
@@ -2045,7 +2072,7 @@ function App() {
       });
 
     return items;
-  }, [allThreadRootMessages, channelAlertIds, data, threadReplyCounts, threadUnreadCounts, visibleMessages]);
+  }, [allThreadRootMessages, channelAlertIds, data, messagesById, threadActivitiesByRoot, threadReplyCounts, threadUnreadCounts, visibleMessages]);
 
   const activityFeedItems = useMemo(() => {
     return allActivityFeedItems
@@ -2519,6 +2546,31 @@ function App() {
     });
   }
 
+  function latestThreadActivity(threadId: string): ThreadActivity | null {
+    return threadActivitiesByRoot.get(threadId) ?? null;
+  }
+
+  function threadReadCutoff(threadId: string) {
+    const activity = latestThreadActivity(threadId);
+    const latestMessage = activity ? messagesById.get(activity.latest_message_id) : null;
+    const latestReply = visibleMessages
+      .filter((message) => message.thread_root_id === threadId)
+      .reduce<Message | null>((latest, message) => {
+        if (!latest || new Date(message.created_at) > new Date(latest.created_at)) return message;
+        return latest;
+      }, null);
+    const latestAt = activity?.latest_activity_at ?? latestMessage?.created_at ?? latestReply?.created_at;
+    const latestTime = latestAt ? new Date(latestAt).getTime() : 0;
+    const cutoffTime = Math.max(Date.now(), Number.isFinite(latestTime) ? latestTime : 0);
+    return new Date(cutoffTime).toISOString();
+  }
+
+  function markThreadRead(threadId: string) {
+    void apiInvoke("mark_inbox_items_read", {
+      items: [{ itemId: `thread:${threadId}`, dismissedUntil: threadReadCutoff(threadId) }],
+    }).catch((err) => console.error(err));
+  }
+
   function forgetChannelThread(channelId: string | null | undefined) {
     if (!channelId) return;
     setChannelThreadMemory((current) => {
@@ -2559,6 +2611,7 @@ function App() {
       delete next[threadId];
       return next;
     });
+    markThreadRead(threadId);
   }
 
   function revealThread(threadId: string | null, channelId = activeChannelId) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,14 @@ export type Channel = {
   unread_count: number;
 };
 
+export type ThreadActivity = {
+  thread_root_id: string;
+  channel_id: string;
+  unread_count: number;
+  latest_message_id: string;
+  latest_activity_at: string;
+};
+
 export type ChannelMember = {
   channel_id: string;
   agent_id: string;
@@ -271,6 +279,7 @@ export type Bootstrap = {
   web_base_url: string | null;
   owner_profile: OwnerProfile;
   channels: Channel[];
+  thread_activities: ThreadActivity[];
   channel_members: ChannelMember[];
   agents: Agent[];
   messages: Message[];


### PR DESCRIPTION
## Summary

Fixes #91.
Supersedes #89.

This replaces the backend-only thread activity bootstrap PR with the full thread unread/activity path:

- adds backend `thread_activities` bootstrap records with unread count, latest visible message, and latest activity timestamp
- wires bootstrap `thread_activities` into frontend thread unread counts and Activity Feed ordering
- excludes owner-authored replies from thread unread counts
- aligns thread activity filtering with channel unread filtering for streaming and hidden progress-only messages
- uses NULL-safe newer-marker precedence between `thread:<rootId>` and channel read markers
- persists thread read markers from opening a thread and from Activity Feed single/bulk mark-read actions

## Verification

- `cargo test channels::tests`
- `cargo test`
- `npm run build`
