### PR TITLE
Open draft image attachments in the same lightbox preview

### DIFF
--- a/src/components/DraftAttachmentsPreview.tsx
+++ b/src/components/DraftAttachmentsPreview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { type MouseEvent, type PointerEvent, useEffect, useState } from "react";
 import { FileText, X } from "lucide-react";
 import { DraftAttachment } from "../types";
 
@@ -7,12 +7,22 @@ type DraftAttachmentsPreviewProps = {
   onRemove: (id: string) => void;
 };
 
+type ImagePreview = {
+  src: string;
+  alt: string;
+};
+
 type DraftAttachmentPreviewItemProps = {
   attachment: DraftAttachment;
   onRemove: (id: string) => void;
+  onOpenImage: (preview: ImagePreview) => void;
 };
 
-function DraftAttachmentPreviewItem({ attachment, onRemove }: DraftAttachmentPreviewItemProps) {
+function isolateDraftAttachmentEvent(event: MouseEvent<HTMLElement> | PointerEvent<HTMLElement>) {
+  event.stopPropagation();
+}
+
+function DraftAttachmentPreviewItem({ attachment, onRemove, onOpenImage }: DraftAttachmentPreviewItemProps) {
   const isImage = attachment.mime_type.startsWith("image/");
   const [objectUrl, setObjectUrl] = useState("");
 
@@ -30,10 +40,26 @@ function DraftAttachmentPreviewItem({ attachment, onRemove }: DraftAttachmentPre
   if (isImage) {
     return (
       <div className="draft-attachment image">
-        {objectUrl && <img src={objectUrl} alt="" />}
+        <button
+          type="button"
+          className="draft-attachment-trigger"
+          aria-label={`Preview ${attachment.original_name || "image"}`}
+          onPointerDown={isolateDraftAttachmentEvent}
+          onClick={(event) => {
+            event.stopPropagation();
+            if (!objectUrl) return;
+            onOpenImage({
+              src: objectUrl,
+              alt: attachment.original_name || "image",
+            });
+          }}
+        >
+          {objectUrl && <img src={objectUrl} alt="" />}
+        </button>
         <button
           type="button"
           className="draft-attachment-remove"
+          onPointerDown={isolateDraftAttachmentEvent}
           onClick={() => onRemove(attachment.id)}
           aria-label={`Remove ${attachment.original_name || "image"}`}
         >
@@ -50,6 +76,7 @@ function DraftAttachmentPreviewItem({ attachment, onRemove }: DraftAttachmentPre
       <button
         type="button"
         className="draft-attachment-remove"
+        onPointerDown={isolateDraftAttachmentEvent}
         onClick={() => onRemove(attachment.id)}
         aria-label={`Remove ${attachment.original_name || "attachment"}`}
       >
@@ -60,17 +87,74 @@ function DraftAttachmentPreviewItem({ attachment, onRemove }: DraftAttachmentPre
 }
 
 export function DraftAttachmentsPreview({ attachments, onRemove }: DraftAttachmentsPreviewProps) {
+  const [imagePreview, setImagePreview] = useState<ImagePreview | null>(null);
+
+  function closeImagePreview(event: MouseEvent<HTMLButtonElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    setImagePreview(null);
+  }
+
+  useEffect(() => {
+    if (!imagePreview) return;
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setImagePreview(null);
+    }
+    function handleHistoryNavigation() {
+      setImagePreview(null);
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("popstate", handleHistoryNavigation);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("popstate", handleHistoryNavigation);
+    };
+  }, [imagePreview]);
+
   if (attachments.length === 0) return null;
 
   return (
-    <div className="draft-attachments">
-      {attachments.map((attachment) => (
-        <DraftAttachmentPreviewItem
-          key={attachment.id}
-          attachment={attachment}
-          onRemove={onRemove}
-        />
-      ))}
-    </div>
+    <>
+      <div className="draft-attachments">
+        {attachments.map((attachment) => (
+          <DraftAttachmentPreviewItem
+            key={attachment.id}
+            attachment={attachment}
+            onRemove={onRemove}
+            onOpenImage={setImagePreview}
+          />
+        ))}
+      </div>
+      {imagePreview && (
+        <div
+          className="attachment-lightbox"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Image preview"
+          onPointerDown={isolateDraftAttachmentEvent}
+          onClick={isolateDraftAttachmentEvent}
+        >
+          <button
+            type="button"
+            className="attachment-lightbox-backdrop"
+            aria-label="Close image preview"
+            onPointerDown={isolateDraftAttachmentEvent}
+            onClick={closeImagePreview}
+          />
+          <button
+            type="button"
+            className="attachment-lightbox-close"
+            aria-label="Close image preview"
+            onPointerDown={isolateDraftAttachmentEvent}
+            onClick={closeImagePreview}
+          >
+            <X size={18} />
+          </button>
+          <div className="attachment-lightbox-content">
+            <img src={imagePreview.src} alt={imagePreview.alt} />
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -4511,6 +4511,16 @@ mark {
   background: var(--bg-control-flat);
 }
 
+.draft-attachment-trigger {
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: zoom-in;
+}
+
 .draft-attachment.image img {
   display: block;
   width: 100%;


### PR DESCRIPTION
## Summary
- make draft image tiles in the composer clickable before the message is sent
- reuse the existing attachment lightbox pattern for unsent image previews
- preserve the draft remove button and stop preview clicks from leaking into parent composer handlers

## Code path
- `src/components/DraftAttachmentsPreview.tsx`
  - wrap draft image thumbnails in a button trigger
  - add local lightbox state for unsent image previews
  - support `Esc`, backdrop click, and close button dismissal
- `src/styles.css`
  - add `draft-attachment-trigger` so image tiles behave like an explicit preview target

## Coverage
- applies to both the root composer and the thread reply composer because both already use `DraftAttachmentsPreview`
- applies to both desktop and web because the change is in the shared React frontend layer

## Verification
- `npm run build`
- `git diff --check`

## Potential regressions checked
- image draft remove button still works independently of preview click
- non-image draft attachments keep existing behavior
- sent message attachments are unchanged because this PR only touches the draft preview component
