### PR TITLE
Add thread root locator from side panel

### DIFF
--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowLeft, Bookmark, CheckCircle2, Hash, MessageSquare, Paperclip, RotateCcw, Send, X } from "lucide-react";
+import { ArrowDown, ArrowLeft, Bookmark, CheckCircle2, Crosshair, Hash, MessageSquare, Paperclip, RotateCcw, Send, X } from "lucide-react";
 import { Fragment, useEffect, useLayoutEffect, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent, type PointerEvent as ReactPointerEvent, type WheelEvent as ReactWheelEvent } from "react";
 import { useAutoGrowTextarea } from "../hooks/useAutoGrowTextarea";
 import { useMentionPicker } from "../hooks/useMentionPicker";
@@ -101,6 +101,7 @@ type ThreadPanelProps = {
   openAgentDetail: (agent: Agent) => void;
   openArtifact: (artifact: Artifact) => void;
   openWorkItem?: (item: AgentWorkItem, focusedMessageIdOverride?: string | null) => void;
+  onLocateRoot: (message: Message) => void;
   shareBaseUrl: string | null;
   savedMessageIds: Set<string>;
   focusedMessageId: string | null;
@@ -141,6 +142,7 @@ export function ThreadPanel({
   openAgentDetail,
   openArtifact,
   openWorkItem,
+  onLocateRoot,
   shareBaseUrl,
   savedMessageIds,
   focusedMessageId,
@@ -455,7 +457,22 @@ export function ThreadPanel({
             Thread <span>{channel ? isDm ? `- @${dmAgent?.handle || "agent"}` : `- #${channel.name}` : "- no channel"}</span>
           </h2>
         </div>
-        <button type="button" className="thread-close" onClick={onClose} aria-label="Close thread panel"><X size={18} /></button>
+        <div className="thread-header-actions">
+          <button
+            type="button"
+            className="thread-locate-root"
+            onClick={() => {
+              if (activeRoot) onLocateRoot(activeRoot);
+            }}
+            disabled={!activeRoot}
+            data-tooltip={isDm ? "Locate this thread in DM" : "Locate this thread in channel"}
+            aria-label={isDm ? "Locate this thread in direct message" : "Locate this thread in channel"}
+          >
+            <Crosshair size={16} />
+            <span>Locate</span>
+          </button>
+          <button type="button" className="thread-close" onClick={onClose} aria-label="Close thread panel"><X size={18} /></button>
+        </div>
       </header>
 
       <section className="thread-focus">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2638,6 +2638,19 @@ function App() {
     }
   }
 
+  function revealThreadRootInChannel(message: Message) {
+    setSelectedAgentId(null);
+    setActiveTab("chat");
+    setActiveChannelId(message.channel_id);
+    if (isMobileViewport()) {
+      setShowThread(false);
+    }
+    setFocusedMessageId(null);
+    window.requestAnimationFrame(() => {
+      setFocusedMessageId(message.id);
+    });
+  }
+
   function canNavigateBack() {
     if (isMobileViewport()) return false;
     return appHistoryReadyRef.current && appHistoryIndexRef.current > 0;
@@ -3688,6 +3701,7 @@ function App() {
           openAgentDetail={(agent) => setSelectedAgentId(agent.id)}
           openArtifact={openArtifact}
           openWorkItem={openWorkItem}
+          onLocateRoot={revealThreadRootInChannel}
           shareBaseUrl={shareBaseUrl}
           savedMessageIds={savedMessageIds}
           focusedMessageId={focusedMessageId}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1921,6 +1921,88 @@ button,
   color: var(--ink-control);
 }
 
+.thread-header-actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.thread-locate-root {
+  width: auto;
+  padding: 0 12px;
+  font-size: var(--type-size-body);
+  font-weight: var(--type-weight-semibold);
+}
+
+.thread-locate-root span {
+  white-space: nowrap;
+}
+
+.thread-header-actions .thread-locate-root[data-tooltip] {
+  position: relative;
+}
+
+.thread-header-actions .thread-locate-root[data-tooltip]::after {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 50%;
+  z-index: 4;
+  max-width: 180px;
+  padding: 5px 8px;
+  border-radius: 6px;
+  background: var(--surface-tooltip);
+  color: var(--ink-on-tooltip);
+  content: attr(data-tooltip);
+  font-size: var(--type-size-caption);
+  font-weight: var(--type-weight-semibold);
+  line-height: 14px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(50%, -2px);
+  transition:
+    opacity 90ms ease,
+    transform 90ms ease;
+  white-space: nowrap;
+}
+
+.thread-header-actions .thread-locate-root[data-tooltip]::before {
+  position: absolute;
+  top: calc(100% + 3px);
+  right: 50%;
+  z-index: 4;
+  width: 8px;
+  height: 8px;
+  background: var(--surface-tooltip);
+  content: "";
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(50%, -2px) rotate(45deg);
+  transition:
+    opacity 90ms ease,
+    transform 90ms ease;
+}
+
+.thread-header-actions .thread-locate-root[data-tooltip]:hover::after,
+.thread-header-actions .thread-locate-root[data-tooltip]:focus-visible::after,
+.thread-header-actions .thread-locate-root[data-tooltip]:hover::before,
+.thread-header-actions .thread-locate-root[data-tooltip]:focus-visible::before {
+  opacity: 1;
+  transform: translate(50%, 0) rotate(45deg);
+}
+
+.thread-header-actions .thread-locate-root[data-tooltip]:hover::after,
+.thread-header-actions .thread-locate-root[data-tooltip]:focus-visible::after {
+  transform: translate(50%, 0);
+}
+
+.thread header button:disabled {
+  color: var(--ink-disabled);
+  cursor: default;
+  opacity: 0.65;
+}
+
 .thread header .thread-mobile-back {
   display: none;
 }
@@ -5516,6 +5598,11 @@ body.resizing-row * {
 
   .thread .message-hover-actions button[data-tooltip]::before,
   .thread .message-hover-actions button[data-tooltip]::after {
+    display: none;
+  }
+
+  .thread-header-actions .thread-locate-root[data-tooltip]::before,
+  .thread-header-actions .thread-locate-root[data-tooltip]::after {
     display: none;
   }
 
@@ -9174,6 +9261,15 @@ body.resizing-row * {
 
   .channel-title .hash-card {
     flex: 0 0 auto;
+  }
+
+  .thread-locate-root {
+    width: 38px;
+    padding: 0;
+  }
+
+  .thread-locate-root span {
+    display: none;
   }
 
   .channel-header-actions {


### PR DESCRIPTION
## Summary
- add a locate action in the thread side panel header so the root message can be found in the channel view
- scroll and highlight the root message in the main conversation, closing the thread panel on mobile so the message is immediately visible
- replace the delayed native title hover with an immediate tooltip reading "Locate this thread in channel"

## Validation
- npm run build
- npm run lint:css-tokens
- git diff --check