### PR TITLE
Locate thread root message in channel from thread panel

### DIFF
--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowLeft, Bookmark, CheckCircle2, Hash, MessageSquare, Paperclip, RotateCcw, Send, X } from "lucide-react";
+import { ArrowDown, ArrowLeft, Bookmark, CheckCircle2, Crosshair, Hash, MessageSquare, Paperclip, RotateCcw, Send, X } from "lucide-react";
 import { Fragment, useEffect, useLayoutEffect, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent, type PointerEvent as ReactPointerEvent, type WheelEvent as ReactWheelEvent } from "react";
 import { useAutoGrowTextarea } from "../hooks/useAutoGrowTextarea";
 import { useMentionPicker } from "../hooks/useMentionPicker";
@@ -101,6 +101,7 @@ type ThreadPanelProps = {
   openAgentDetail: (agent: Agent) => void;
   openArtifact: (artifact: Artifact) => void;
   openWorkItem?: (item: AgentWorkItem, focusedMessageIdOverride?: string | null) => void;
+  onLocateRoot: (message: Message) => void;
   shareBaseUrl: string | null;
   savedMessageIds: Set<string>;
   focusedMessageId: string | null;
@@ -141,6 +142,7 @@ export function ThreadPanel({
   openAgentDetail,
   openArtifact,
   openWorkItem,
+  onLocateRoot,
   shareBaseUrl,
   savedMessageIds,
   focusedMessageId,
@@ -455,7 +457,21 @@ export function ThreadPanel({
             Thread <span>{channel ? isDm ? `- @${dmAgent?.handle || "agent"}` : `- #${channel.name}` : "- no channel"}</span>
           </h2>
         </div>
-        <button type="button" className="thread-close" onClick={onClose} aria-label="Close thread panel"><X size={18} /></button>
+        <span className="thread-header-actions">
+          <button
+            type="button"
+            className="thread-locate-root"
+            onClick={() => {
+              if (activeRoot) onLocateRoot(activeRoot);
+            }}
+            disabled={!activeRoot}
+            data-tooltip={isDm ? "Locate this thread in the DM" : "Locate this thread in the channel"}
+            aria-label={isDm ? "Locate this thread in the DM" : "Locate this thread in the channel"}
+          >
+            <Crosshair size={18} />
+          </button>
+          <button type="button" className="thread-close" onClick={onClose} aria-label="Close thread panel"><X size={18} /></button>
+        </span>
       </header>
 
       <section className="thread-focus">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2638,6 +2638,19 @@ function App() {
     }
   }
 
+  function revealThreadRootInChannel(message: Message) {
+    setSelectedAgentId(null);
+    setActiveTab("chat");
+    setActiveChannelId(message.channel_id);
+    if (isMobileViewport()) {
+      setShowThread(false);
+    }
+    setFocusedMessageId(null);
+    window.requestAnimationFrame(() => {
+      setFocusedMessageId(message.id);
+    });
+  }
+
   function canNavigateBack() {
     if (isMobileViewport()) return false;
     return appHistoryReadyRef.current && appHistoryIndexRef.current > 0;
@@ -3688,6 +3701,7 @@ function App() {
           openAgentDetail={(agent) => setSelectedAgentId(agent.id)}
           openArtifact={openArtifact}
           openWorkItem={openWorkItem}
+          onLocateRoot={revealThreadRootInChannel}
           shareBaseUrl={shareBaseUrl}
           savedMessageIds={savedMessageIds}
           focusedMessageId={focusedMessageId}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1921,6 +1921,71 @@ button,
   color: var(--ink-control);
 }
 
+.thread-header-actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.thread-header-actions button[data-tooltip] {
+  position: relative;
+}
+
+.thread-header-actions button[data-tooltip]:not(:disabled)::after {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 8;
+  max-width: 220px;
+  padding: 5px 8px;
+  border-radius: 6px;
+  background: var(--surface-tooltip);
+  color: var(--ink-on-tooltip);
+  content: attr(data-tooltip);
+  font-size: var(--type-size-caption);
+  font-weight: var(--type-weight-semibold);
+  line-height: 14px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-2px);
+  transition:
+    opacity 60ms ease,
+    transform 60ms ease;
+  white-space: nowrap;
+}
+
+.thread-header-actions button[data-tooltip]:not(:disabled)::before {
+  position: absolute;
+  top: calc(100% + 3px);
+  right: 15px;
+  z-index: 8;
+  width: 8px;
+  height: 8px;
+  background: var(--surface-tooltip);
+  content: "";
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-2px) rotate(45deg);
+  transition:
+    opacity 60ms ease,
+    transform 60ms ease;
+}
+
+.thread-header-actions button[data-tooltip]:not(:disabled):hover::after,
+.thread-header-actions button[data-tooltip]:not(:disabled):focus-visible::after,
+.thread-header-actions button[data-tooltip]:not(:disabled):hover::before,
+.thread-header-actions button[data-tooltip]:not(:disabled):focus-visible::before {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.thread-header-actions button[data-tooltip]:not(:disabled):hover::before,
+.thread-header-actions button[data-tooltip]:not(:disabled):focus-visible::before {
+  transform: translateY(0) rotate(45deg);
+}
+
 .thread header .thread-mobile-back {
   display: none;
 }


### PR DESCRIPTION
## Summary
- Add a Crosshair button to the thread panel header that scrolls the channel/DM timeline to the thread's root message and triggers the existing focus-highlight animation.
- Mobile collapses the thread panel first so the channel view is actually visible after the jump.
- Tooltip uses the existing `data-tooltip` CSS pattern (60ms fade) instead of native `title=` so it appears instantly on hover instead of waiting for the browser's ~500ms delay.

## Changes
- `src/components/ThreadPanel.tsx`: new `onLocateRoot` prop, new `.thread-locate-root` button in a `.thread-header-actions` wrapper next to the existing close button.
- `src/main.tsx`: `revealThreadRootInChannel` switches to chat tab + channel, collapses thread on mobile, then sets `focusedMessageId` on next frame (reuses the existing scroll/highlight path used by saved messages + work-item open).
- `src/styles.css`: tooltip block for `.thread-header-actions button[data-tooltip]` — instant fade in, no native delay.

## Test plan
- [x] `npm run lint:css-tokens` passes (no new raw colors).
- [x] `npm run build` passes (zero TS / vite errors).
- [ ] Manual: open a thread, click the crosshair icon → channel scrolls to root and highlights for 2.6s.
- [ ] Manual: hover the crosshair → tooltip appears immediately (no native browser delay).
- [ ] Manual: on mobile viewport, click crosshair → thread panel closes and channel reveals + highlights root.
- [ ] Manual: open a thread in a DM → tooltip says "Locate this thread in the DM"; same scroll behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)