### PR TITLE
Scroll channel to task root when opening task

### DIFF
--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -614,9 +614,31 @@ export function Conversation({
 
   useEffect(() => {
     if (!focusedMessageId) return;
-    const element = messageListRef.current?.querySelector<HTMLElement>(`[data-message-id="${focusedMessageId}"]`);
-    element?.scrollIntoView({ block: "center" });
-  }, [channel?.id, focusedMessageId]);
+    let frameId = 0;
+    let attemptsRemaining = 6;
+    function scrollFocusedMessage() {
+      const element = messageListRef.current?.querySelector<HTMLElement>(`[data-message-id="${focusedMessageId}"]`);
+      if (element) {
+        element.scrollIntoView({ block: "center" });
+        return;
+      }
+      if (attemptsRemaining <= 0) return;
+      attemptsRemaining -= 1;
+      frameId = window.requestAnimationFrame(scrollFocusedMessage);
+    }
+    scrollFocusedMessage();
+    return () => {
+      if (frameId) window.cancelAnimationFrame(frameId);
+    };
+  }, [
+    channel?.id,
+    focusedMessageId,
+    messageListProgressVersion,
+    rootMessages.length,
+    lastRootMessage?.id,
+    lastRootMessage?.updated_at,
+    lastRootMessage?.delivery_state,
+  ]);
 
   return (
     <section className="conversation">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3137,6 +3137,10 @@ function App() {
     setActiveChannelId(task.channel_id);
     revealThread(task.message_id, task.channel_id);
     setActiveTab("chat");
+    setFocusedMessageId(null);
+    window.requestAnimationFrame(() => {
+      setFocusedMessageId(task.message_id);
+    });
   }
 
   function openWorkItem(item: AgentWorkItem, focusedMessageIdOverride?: string | null) {


### PR DESCRIPTION
## Summary
- focus the task's root message when opening a task so the channel timeline scrolls to the same message as the thread panel
- retry the Conversation focus scroll for a few frames while the channel layout settles, but stop immediately once the target message is found
- keep the patch limited to src/main.tsx and src/components/Conversation.tsx

## Validation
- npm run build
- git diff --check
