### PR TITLE
Fix publish gate stuck loop

### DIFF
--- a/src-tauri/src/events/control.rs
+++ b/src-tauri/src/events/control.rs
@@ -26,7 +26,8 @@ use crate::message_store::{
 };
 use crate::publish_guard::{
     can_publish_public_output, control_action_kind_for_event_type, hold_visible_control_event,
-    resolve_interrupted_action, run_work_item_id, work_item_public_surface, PublishDecision,
+    repin_run_work_item_base_thread_version_for_surface, resolve_interrupted_action,
+    run_work_item_id, work_item_public_surface, PublishDecision,
 };
 use crate::runtime::streaming::mark_run_work_item_silent;
 use crate::task_messages::create_agent_task_thread;
@@ -484,6 +485,7 @@ pub(crate) async fn handle_streaming_agent_event_json(
             if !claim_agent_event(pool, run_id, json).await? {
                 return Ok(());
             }
+            let should_repin_after_accept = streaming_agent_event_is_visible_side_effect(json);
             if let Some(note) =
                 maybe_hold_visible_streaming_event(pool, agent_id, run_id, json, &event).await?
             {
@@ -501,6 +503,15 @@ pub(crate) async fn handle_streaming_agent_event_json(
             }
             match handle_agent_event(pool, agent_id, run_id, event).await {
                 Ok(note) => {
+                    if should_repin_after_accept {
+                        repin_run_work_item_base_thread_version_for_surface(
+                            pool,
+                            run_id,
+                            Uuid::nil(),
+                            None,
+                        )
+                        .await?;
+                    }
                     append_run_log(pool, run_id, format!("[stream-event] {note}\n")).await?;
                     record_agent_activity(
                         pool,

--- a/src-tauri/src/publish_guard.rs
+++ b/src-tauri/src/publish_guard.rs
@@ -2,6 +2,7 @@ use serde_json::{json, Value};
 use sqlx::{Row, SqlitePool};
 use uuid::Uuid;
 
+use crate::agent_inbox_wake::ensure_agent_inbox_wake_work_item;
 use crate::agent_routing::queue_agent_message_mentions;
 use crate::app::{to_string, CommandResult};
 use crate::events::{
@@ -199,26 +200,23 @@ async fn work_item_base_thread_version(
     let Some(work_item_id) = work_item_id else {
         return Ok(None);
     };
-    let payload: Option<String> = sqlx::query_scalar(
+    let payloads: Vec<String> = sqlx::query_scalar(
         r#"
         select i.payload
         from agent_inbox_items i
         where i.work_item_id = $1
         order by i.created_at asc
-        limit 1
         "#,
     )
     .bind(work_item_id)
-    .fetch_optional(pool)
+    .fetch_all(pool)
     .await
     .map_err(to_string)?;
-    let Some(payload) = payload else {
-        return Ok(None);
-    };
-    let Ok(value) = serde_json::from_str::<Value>(&payload) else {
-        return Ok(None);
-    };
-    Ok(value.get("base_thread_version").and_then(Value::as_i64))
+    Ok(payloads
+        .iter()
+        .filter_map(|payload| serde_json::from_str::<Value>(payload).ok())
+        .filter_map(|value| value.get("base_thread_version").and_then(Value::as_i64))
+        .max())
 }
 
 async fn repin_work_item_base_thread_version(
@@ -243,6 +241,23 @@ async fn repin_work_item_base_thread_version(
     .await
     .map_err(to_string)?;
     Ok(())
+}
+
+pub(crate) async fn repin_run_work_item_base_thread_version_for_surface(
+    pool: &SqlitePool,
+    run_id: Uuid,
+    fallback_channel_id: Uuid,
+    fallback_thread_root_id: Option<Uuid>,
+) -> CommandResult<()> {
+    let work_item_id = run_work_item_id(pool, run_id).await?;
+    let Some(work_item_id) = work_item_id else {
+        return Ok(());
+    };
+    let (channel_id, thread_root_id) = work_item_public_surface(pool, Some(work_item_id))
+        .await?
+        .unwrap_or((fallback_channel_id, fallback_thread_root_id));
+    let current_version = current_thread_version(pool, channel_id, thread_root_id).await?;
+    repin_work_item_base_thread_version(pool, Some(work_item_id), current_version).await
 }
 
 pub(crate) async fn work_item_public_surface(
@@ -517,7 +532,7 @@ async fn parse_and_apply_buffer_control_events(
 async fn upsert_interrupted_action(
     pool: &SqlitePool,
     agent_id: Uuid,
-    work_item_id: Option<Uuid>,
+    _work_item_id: Option<Uuid>,
     channel_id: Uuid,
     thread_root_id: Option<Uuid>,
     stream_key: &str,
@@ -551,6 +566,9 @@ async fn upsert_interrupted_action(
             set title = $2,
                 body_preview = $3,
                 payload = $4,
+                work_item_id = null,
+                state = 'unread',
+                archived_at = null,
                 updated_at = strftime('%Y-%m-%dT%H:%M:%f+00:00','now')
             where id = $1
             "#,
@@ -562,6 +580,7 @@ async fn upsert_interrupted_action(
         .execute(pool)
         .await
         .map_err(to_string)?;
+        let _ = Box::pin(ensure_agent_inbox_wake_work_item(pool, agent_id)).await?;
         return Ok(());
     }
 
@@ -569,9 +588,9 @@ async fn upsert_interrupted_action(
         r#"
         insert into agent_inbox_items (
             agent_id, channel_id, thread_root_id, kind, priority, state,
-            title, body_preview, payload, work_item_id
+            title, body_preview, payload
         )
-        values ($1, $2, $3, 'interrupted_action', 95, 'unread', $4, $5, $6, $7)
+        values ($1, $2, $3, 'interrupted_action', 95, 'unread', $4, $5, $6)
         "#,
     )
     .bind(agent_id)
@@ -580,10 +599,10 @@ async fn upsert_interrupted_action(
     .bind(title)
     .bind(reason)
     .bind(payload.to_string())
-    .bind(work_item_id)
     .execute(pool)
     .await
     .map_err(to_string)?;
+    let _ = Box::pin(ensure_agent_inbox_wake_work_item(pool, agent_id)).await?;
     Ok(())
 }
 

--- a/src-tauri/src/runtime/streaming.rs
+++ b/src-tauri/src/runtime/streaming.rs
@@ -15,7 +15,8 @@ use crate::events::{
 use crate::message_store::load_message;
 use crate::publish_guard::{
     bump_thread_version, can_publish_public_output, hold_streaming_public_output,
-    output_buffer_exists, PublishActionKind, PublishDecision,
+    output_buffer_exists, repin_run_work_item_base_thread_version_for_surface, PublishActionKind,
+    PublishDecision,
 };
 use crate::ui_notifications::{
     notify_ui_message_delete, notify_ui_message_delta, notify_ui_message_upsert, notify_ui_refresh,
@@ -183,6 +184,15 @@ async fn append_streaming_agent_message_inner(
         }
         if truncated && complete_on_truncation {
             bump_thread_version(pool, channel_id, thread_root_id).await?;
+            if let Some((_, run_id, _)) = load_streaming_control_context(pool, stream_key).await? {
+                repin_run_work_item_base_thread_version_for_surface(
+                    pool,
+                    run_id,
+                    channel_id,
+                    thread_root_id,
+                )
+                .await?;
+            }
             queue_agent_message_mentions(pool, message_id).await?;
         }
         return Ok(message_id);
@@ -287,6 +297,15 @@ async fn append_streaming_agent_message_inner(
     }
     if truncated && complete_on_truncation {
         bump_thread_version(pool, channel_id, thread_root_id).await?;
+        if let Some((_, run_id, _)) = load_streaming_control_context(pool, stream_key).await? {
+            repin_run_work_item_base_thread_version_for_surface(
+                pool,
+                run_id,
+                channel_id,
+                thread_root_id,
+            )
+            .await?;
+        }
         queue_agent_message_mentions(pool, message_id).await?;
     }
     Ok(message_id)
@@ -630,6 +649,17 @@ async fn finish_streaming_agent_message_inner(
             if let Ok(message) = load_message(pool, message_id).await {
                 if delivery_state == "complete" {
                     bump_thread_version(pool, message.channel_id, message.thread_root_id).await?;
+                    if let Some((_, run_id, _)) =
+                        load_streaming_control_context(pool, stream_key).await?
+                    {
+                        repin_run_work_item_base_thread_version_for_surface(
+                            pool,
+                            run_id,
+                            message.channel_id,
+                            message.thread_root_id,
+                        )
+                        .await?;
+                    }
                 }
                 let _ = notify_ui_message_upsert(pool, &message, "stream_finish").await;
             } else {

--- a/src-tauri/src/tests/runtime_streaming.rs
+++ b/src-tauri/src/tests/runtime_streaming.rs
@@ -324,6 +324,144 @@ async fn interrupted_action_revise_allows_revised_reply_on_same_stream_key() {
 }
 
 #[tokio::test]
+async fn interrupted_action_is_redispatched_as_new_inbox_wake() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "redispatch-held-agent").await?;
+        let channel_id = insert_test_channel(&pool, "redispatch-held-channel").await?;
+        let (work_item_id, run_id) =
+            insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
+        bump_thread_version(&pool, channel_id, None).await?;
+        let stream_key = format!("{run_id}:claude-assistant");
+
+        append_streaming_agent_message(&pool, agent_id, channel_id, None, &stream_key, "Held")
+            .await?;
+
+        let original_status: String =
+            sqlx::query_scalar("select status from agent_work_items where id = $1")
+                .bind(work_item_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(original_status, "interrupted");
+
+        let (redispatch_work_item_id, inbox_state): (Uuid, String) = sqlx::query_as(
+            r#"
+            select work_item_id, state
+            from agent_inbox_items
+            where kind = 'interrupted_action'
+              and json_extract(payload, '$.stream_key') = $1
+              and state <> 'archived'
+            "#,
+        )
+        .bind(&stream_key)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_ne!(
+            redispatch_work_item_id, work_item_id,
+            "a held output must be redispatched as a fresh inbox wake, not left attached to the interrupted work item"
+        );
+        assert_eq!(
+            inbox_state, "processing",
+            "the interrupted_action item should be claimed by the redispatch work item"
+        );
+
+        let start_commands: i64 = sqlx::query_scalar(
+            r#"
+            select count(*)
+            from supervisor_commands
+            where command_type = 'start_agent'
+              and work_item_id = $1
+              and status in ('pending', 'running')
+            "#,
+        )
+        .bind(redispatch_work_item_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(
+            start_commands, 1,
+            "redispatched interrupted_action should wake the agent for re-decision"
+        );
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
+async fn completed_reply_repins_base_version_before_followup_visible_event() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "self-publish-agent").await?;
+        let channel_id = insert_test_channel(&pool, "self-publish-channel").await?;
+        sqlx::query("insert into channel_members (channel_id, agent_id) values ($1, $2)")
+            .bind(channel_id)
+            .bind(agent_id)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+        let (_work_item_id, run_id) =
+            insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
+        let stream_key = format!("{run_id}:assistant-reply");
+
+        append_streaming_agent_message(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &stream_key,
+            "Final answer",
+        )
+        .await?;
+        finish_streaming_agent_message(&pool, &stream_key, "complete").await?;
+        assert_eq!(
+            current_thread_version(&pool, channel_id, None).await?,
+            1,
+            "completed visible reply should still advance thread freshness"
+        );
+
+        let event = json!({
+            "type": "channel_message_create",
+            "channel_id": channel_id,
+            "body": "follow-up visible side effect"
+        })
+        .to_string();
+        handle_streaming_agent_event_json(&pool, agent_id, run_id, &event).await?;
+
+        let posted_side_effects: i64 = sqlx::query_scalar(
+            "select count(*) from messages where channel_id = $1 and body = 'follow-up visible side effect'",
+        )
+        .bind(channel_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(
+            posted_side_effects, 1,
+            "a run's own completed reply must not make its later visible output stale"
+        );
+
+        let interrupted_items: i64 = sqlx::query_scalar(
+            "select count(*) from agent_inbox_items where kind = 'interrupted_action' and state <> 'archived'",
+        )
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(interrupted_items, 0);
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
 async fn held_visible_preserves_internal_control_events() {
     let Some((pool, schema)) = test_pool().await else {
         return;

--- a/src-tauri/src/tests/runtime_streaming.rs
+++ b/src-tauri/src/tests/runtime_streaming.rs
@@ -324,6 +324,53 @@ async fn interrupted_action_revise_allows_revised_reply_on_same_stream_key() {
 }
 
 #[tokio::test]
+async fn streaming_placeholder_creation_does_not_bump_thread_version() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "placeholder-version-agent").await?;
+        let channel_id = insert_test_channel(&pool, "placeholder-version-channel").await?;
+        let stream_key = "placeholder-version-stream";
+
+        ensure_streaming_agent_message(&pool, agent_id, channel_id, None, stream_key).await?;
+
+        assert_eq!(
+            current_thread_version(&pool, channel_id, None).await?,
+            0,
+            "streaming placeholder creation is framework state and must not advance publish freshness"
+        );
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
+async fn system_message_does_not_bump_thread_version() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let channel_id = insert_test_channel(&pool, "system-version-channel").await?;
+
+        crate::ui_notifications::insert_system_message(&pool, channel_id, None, "patrol reminder")
+            .await?;
+
+        assert_eq!(
+            current_thread_version(&pool, channel_id, None).await?,
+            0,
+            "framework/system messages must not make an agent's active context stale"
+        );
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
 async fn interrupted_action_is_redispatched_as_new_inbox_wake() {
     let Some((pool, schema)) = test_pool().await else {
         return;

--- a/src/styles.css
+++ b/src/styles.css
@@ -270,6 +270,8 @@ button,
     inset 0 1px 0 rgba(255, 255, 255, 0.46),
     0 -1px 2px rgba(32, 36, 44, 0.035);
   --surface-menu-overlay: var(--panel);
+  --modal-mobile-backdrop-bg: rgba(17, 24, 39, 0.55);
+  --modal-mobile-card-border: rgba(15, 23, 42, 0.18);
   --activity-feed-panel-bg: rgba(247, 248, 250, 0.98);
   --activity-feed-panel-border: rgba(20, 23, 31, 0.14);
   --activity-feed-panel-shadow: 0 32px 86px rgba(15, 23, 42, 0.24);
@@ -10175,11 +10177,11 @@ body.resizing-row * {
      WKWebView even though React state updates instantly. Desktop keeps the
      frosted look. */
   .modal-backdrop {
-    background: rgba(17, 24, 39, 0.55);
+    background: var(--modal-mobile-backdrop-bg);
     backdrop-filter: none;
   }
 
   .modal-card {
-    border-color: rgba(15, 23, 42, 0.18);
+    border-color: var(--modal-mobile-card-border);
   }
 }


### PR DESCRIPTION
## Summary
- add regression tests for the real publish-gate stuck-loop failures: held output must be redispatched as a fresh inbox wake, and a run's own completed reply must not stale its later visible output
- add freshness invariants for framework state: streaming placeholders and system messages must not bump thread freshness
- redispatch held `interrupted_action` inbox items by detaching them from the interrupted work item and scheduling a fresh inbox wake
- repin the active work item's base thread version after accepted visible outputs from that same run so multi-output turns do not self-stale

## Validation
- `cd src-tauri && cargo fmt --check`
- `cd src-tauri && cargo test`

## Test-first evidence
- commit `14d9070` adds the P0 regression tests only; both fail on clean `origin/main`
- commit `5be053f` adds Layer 2 freshness invariant tests
- commit `b8b0703` changes implementation; all tests pass
