### PR TITLE
fix: harden publish gate recovery edges

### DIFF
--- a/src-tauri/src/publish_guard.rs
+++ b/src-tauri/src/publish_guard.rs
@@ -659,7 +659,11 @@ pub(crate) async fn hold_streaming_public_output(
     let (existing_body, existing_held_events) = existing
         .map(|(body, events, _, _, _)| (body, events))
         .unwrap_or_default();
-    let combined_body = format!("{existing_body}{delta}");
+    let combined_body = if !delta.is_empty() && existing_body == delta {
+        existing_body
+    } else {
+        format!("{existing_body}{delta}")
+    };
     let (visible_body, mut held_visible_events) =
         parse_and_apply_buffer_control_events(pool, agent_id, run_id, &combined_body, terminal)
             .await?;
@@ -779,6 +783,33 @@ pub(crate) async fn resolve_interrupted_action(
     stream_key: &str,
     action: &str,
 ) -> CommandResult<String> {
+    let requested_terminal_state = match action {
+        "yield" => Some("yielded"),
+        "revise" => Some("revised"),
+        "force_send" | "send_as_is" => Some("force_sent"),
+        _ => None,
+    };
+    if let Some(state) = sqlx::query_scalar::<_, String>(
+        r#"
+        select state
+        from agent_output_buffers
+        where stream_key = $1 and agent_id = $2 and state in ('yielded', 'revised', 'force_sent')
+        "#,
+    )
+    .bind(stream_key)
+    .bind(agent_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(to_string)?
+    {
+        if requested_terminal_state == Some(state.as_str()) {
+            return Ok(format!("interrupted action already resolved as {state}"));
+        }
+        return Err(format!(
+            "interrupted action already resolved as {state}; cannot apply action '{action}'"
+        ));
+    }
+
     let Some(row) = sqlx::query(
         r#"
         select work_item_id, channel_id, thread_root_id, body, held_visible_events, current_version

--- a/src-tauri/src/runtime/claude.rs
+++ b/src-tauri/src/runtime/claude.rs
@@ -13,6 +13,7 @@ use crate::agent_memory::append_run_log;
 use crate::app::{to_string, CommandResult};
 use crate::events::activity::{record_agent_activity, record_agent_activity_throttled};
 use crate::prompts::{build_claude_streaming_prompt, claude_system_prompt};
+use crate::publish_guard::output_buffer_exists;
 use crate::runtime::{
     process::{
         classify_agent_output_activity, configure_agent_context_tool_env,
@@ -637,17 +638,15 @@ async fn handle_claude_warm_stdout_line(
             })
         };
         if let Some((_, Some(channel_id), thread_root_id, stream_key)) = active {
-            if !streaming_message_exists(pool, &stream_key).await? {
-                append_streaming_agent_message(
-                    pool,
-                    agent_id,
-                    channel_id,
-                    thread_root_id,
-                    &stream_key,
-                    &text,
-                )
-                .await?;
-            }
+            append_claude_final_text_if_needed(
+                pool,
+                agent_id,
+                channel_id,
+                thread_root_id,
+                &stream_key,
+                &text,
+            )
+            .await?;
         }
     }
 
@@ -745,5 +744,158 @@ async fn remove_warm_claude_runtime_if_same(
         .unwrap_or(false)
     {
         runtimes.remove(&agent_id);
+    }
+}
+
+async fn append_claude_final_text_if_needed(
+    pool: &SqlitePool,
+    agent_id: Uuid,
+    channel_id: Uuid,
+    thread_root_id: Option<Uuid>,
+    stream_key: &str,
+    text: &str,
+) -> CommandResult<()> {
+    if !streaming_message_exists(pool, stream_key).await?
+        && !output_buffer_exists(pool, stream_key).await?
+    {
+        append_streaming_agent_message(
+            pool,
+            agent_id,
+            channel_id,
+            thread_root_id,
+            stream_key,
+            text,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::publish_guard::{bump_thread_version, output_buffer_exists};
+    use crate::runtime::streaming::append_streaming_agent_message;
+    use crate::test_support::{
+        drop_test_schema, insert_test_agent, insert_test_channel, test_pool,
+    };
+    use serde_json::json;
+
+    async fn insert_publish_gate_work(
+        pool: &SqlitePool,
+        agent_id: Uuid,
+        channel_id: Uuid,
+        thread_root_id: Option<Uuid>,
+        base_thread_version: i64,
+    ) -> Result<(Uuid, Uuid), String> {
+        let inbox_item_id: Uuid = sqlx::query_scalar(
+            r#"
+            insert into agent_inbox_items (
+                agent_id, channel_id, thread_root_id, kind, priority, state, title, payload
+            )
+            values ($1, $2, $3, 'mention', 80, 'processing', 'claude publish gate test', $4)
+            returning id
+            "#,
+        )
+        .bind(agent_id)
+        .bind(channel_id)
+        .bind(thread_root_id)
+        .bind(json!({"base_thread_version": base_thread_version}).to_string())
+        .fetch_one(pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        let work_item_id: Uuid = sqlx::query_scalar(
+            r#"
+            insert into agent_work_items (
+                agent_id, channel_id, thread_root_id, inbox_item_id, source_kind, title, context, status
+            )
+            values ($1, $2, $3, $4, 'inbox_wake', 'claude publish gate test', 'context', 'running')
+            returning id
+            "#,
+        )
+        .bind(agent_id)
+        .bind(channel_id)
+        .bind(thread_root_id)
+        .bind(inbox_item_id)
+        .fetch_one(pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        sqlx::query("update agent_inbox_items set work_item_id = $2 where id = $1")
+            .bind(inbox_item_id)
+            .bind(work_item_id)
+            .execute(pool)
+            .await
+            .map_err(|err| err.to_string())?;
+        let run_id: Uuid = sqlx::query_scalar(
+            r#"
+            insert into agent_runs (agent_id, work_item_id, command, status)
+            values ($1, $2, 'claude stream-json', 'running')
+            returning id
+            "#,
+        )
+        .bind(agent_id)
+        .bind(work_item_id)
+        .fetch_one(pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        Ok((work_item_id, run_id))
+    }
+
+    #[tokio::test]
+    async fn claude_final_text_does_not_duplicate_held_delta_buffer() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let agent_id = insert_test_agent(&pool, "claude-final-agent").await?;
+            let channel_id = insert_test_channel(&pool, "claude-final-channel").await?;
+            let (_work_item_id, run_id) =
+                insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
+            bump_thread_version(&pool, channel_id, None).await?;
+            let stream_key = claude_stream_key(run_id);
+
+            append_streaming_agent_message(
+                &pool,
+                agent_id,
+                channel_id,
+                None,
+                &stream_key,
+                "partial held text",
+            )
+            .await?;
+            assert!(output_buffer_exists(&pool, &stream_key).await?);
+
+            append_claude_final_text_if_needed(
+                &pool,
+                agent_id,
+                channel_id,
+                None,
+                &stream_key,
+                "partial held text final text",
+            )
+            .await?;
+
+            let body: String =
+                sqlx::query_scalar("select body from agent_output_buffers where stream_key = $1")
+                    .bind(&stream_key)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|err| err.to_string())?;
+            assert_eq!(
+                body, "partial held text",
+                "Claude final text fallback must not append a second copy to an already held stream"
+            );
+            let message_count: i64 =
+                sqlx::query_scalar("select count(*) from messages where stream_key = $1")
+                    .bind(&stream_key)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|err| err.to_string())?;
+            assert_eq!(message_count, 0);
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        result.unwrap();
     }
 }

--- a/src-tauri/src/runtime/streaming.rs
+++ b/src-tauri/src/runtime/streaming.rs
@@ -97,6 +97,9 @@ async fn append_streaming_agent_message_inner(
     if stream_key.trim().is_empty() {
         return Err("stream_key is empty".to_owned());
     }
+    if let Some(silent_id) = consume_silent_streaming_agent_delta(pool, stream_key, delta).await? {
+        return Ok(silent_id);
+    }
     if output_buffer_exists(pool, stream_key).await? {
         if let Some((control_agent_id, run_id, work_item_id)) =
             load_streaming_control_context(pool, stream_key).await?
@@ -317,6 +320,24 @@ async fn append_streaming_agent_message_inner(
     Ok(message_id)
 }
 
+async fn consume_silent_streaming_agent_delta(
+    pool: &SqlitePool,
+    stream_key: &str,
+    delta: &str,
+) -> CommandResult<Option<Uuid>> {
+    let Some(reason) = silent_reply_reason(delta) else {
+        return Ok(None);
+    };
+    let Some((control_agent_id, run_id, _work_item_id)) =
+        load_streaming_control_context(pool, stream_key).await?
+    else {
+        return Ok(None);
+    };
+
+    mark_run_work_item_silent(pool, control_agent_id, run_id, &reason).await?;
+    Ok(Some(Uuid::new_v4()))
+}
+
 async fn consume_control_only_streaming_agent_delta(
     pool: &SqlitePool,
     stream_key: &str,
@@ -499,6 +520,9 @@ pub(crate) async fn streaming_message_body_is_empty(
     pool: &SqlitePool,
     stream_key: &str,
 ) -> CommandResult<bool> {
+    if output_buffer_exists(pool, stream_key).await? {
+        return Ok(false);
+    }
     let body: Option<String> =
         sqlx::query_scalar("select body from messages where stream_key = $1")
             .bind(stream_key)

--- a/src-tauri/src/tests/runtime_streaming.rs
+++ b/src-tauri/src/tests/runtime_streaming.rs
@@ -684,6 +684,166 @@ async fn completed_reply_repins_base_version_before_followup_visible_event() {
 }
 
 #[tokio::test]
+async fn same_run_multiple_visible_outputs_repin_across_rapid_version_bumps() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "rapid-self-publish-agent").await?;
+        let channel_id = insert_test_channel(&pool, "rapid-self-publish-channel").await?;
+        sqlx::query("insert into channel_members (channel_id, agent_id) values ($1, $2)")
+            .bind(channel_id)
+            .bind(agent_id)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+        let (_work_item_id, run_id) =
+            insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
+        let stream_key = format!("{run_id}:assistant-reply");
+
+        append_streaming_agent_message(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &stream_key,
+            "primary visible reply",
+        )
+        .await?;
+        finish_streaming_agent_message(&pool, &stream_key, "complete").await?;
+
+        for index in 0..5 {
+            let event = json!({
+                "type": "channel_message_create",
+                "channel_id": channel_id,
+                "body": format!("self visible side effect {index}")
+            })
+            .to_string();
+            handle_streaming_agent_event_json(&pool, agent_id, run_id, &event).await?;
+        }
+
+        assert_eq!(
+            current_thread_version(&pool, channel_id, None).await?,
+            6,
+            "all six visible outputs should advance freshness without making the same run stale"
+        );
+
+        let self_visible_messages: i64 = sqlx::query_scalar(
+            "select count(*) from messages where channel_id = $1 and (body = 'primary visible reply' or body like 'self visible side effect %')",
+        )
+        .bind(channel_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(self_visible_messages, 6);
+
+        let buffers: i64 =
+            sqlx::query_scalar("select count(*) from agent_output_buffers where run_id = $1")
+                .bind(run_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(
+            buffers, 0,
+            "a run's own rapid visible outputs must not recursively hold later output"
+        );
+
+        let interrupted_items: i64 = sqlx::query_scalar(
+            "select count(*) from agent_inbox_items where kind = 'interrupted_action' and state <> 'archived'",
+        )
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(interrupted_items, 0);
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
+async fn control_only_multi_event_delta_bypasses_reply_freshness_gate() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "control-multi-agent").await?;
+        let channel_id = insert_test_channel(&pool, "control-multi-channel").await?;
+        let (_work_item_id, run_id) =
+            insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
+        for _ in 0..5 {
+            bump_thread_version(&pool, channel_id, None).await?;
+        }
+        let stream_key = format!("{run_id}:multi-control");
+        let activity_one = json!({
+            "type": "activity",
+            "kind": "thinking",
+            "title": "Multi control one",
+            "detail": "first event"
+        });
+        let usage = json!({
+            "type": "usage",
+            "input_tokens": 100,
+            "output_tokens": 25,
+            "cost_micros": 7
+        });
+        let activity_two = json!({
+            "type": "activity",
+            "kind": "thinking",
+            "title": "Multi control two",
+            "detail": "third event"
+        });
+        let body = format!("LANTOR_EVENT {activity_one}LANTOR_EVENT {usage}LANTOR_EVENT {activity_two}\n");
+
+        append_streaming_agent_message(&pool, agent_id, channel_id, None, &stream_key, &body)
+            .await?;
+
+        let activity_count: i64 = sqlx::query_scalar(
+            "select count(*) from agent_activities where run_id = $1 and title in ('Multi control one', 'Multi control two', 'Usage recorded')",
+        )
+        .bind(run_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(
+            activity_count, 3,
+            "all non-visible control events in the stale delta should execute"
+        );
+
+        let usage_row = sqlx::query(
+            "select input_tokens, output_tokens, cost_micros from agent_runs where id = $1",
+        )
+        .bind(run_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(usage_row.get::<i64, _>("input_tokens"), 100);
+        assert_eq!(usage_row.get::<i64, _>("output_tokens"), 25);
+        assert_eq!(usage_row.get::<i64, _>("cost_micros"), 7);
+
+        let buffers: i64 =
+            sqlx::query_scalar("select count(*) from agent_output_buffers where stream_key = $1")
+                .bind(&stream_key)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(buffers, 0);
+
+        let messages: i64 = sqlx::query_scalar("select count(*) from messages where stream_key = $1")
+            .bind(&stream_key)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+        assert_eq!(messages, 0);
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
 async fn held_visible_preserves_internal_control_events() {
     let Some((pool, schema)) = test_pool().await else {
         return;
@@ -695,7 +855,7 @@ async fn held_visible_preserves_internal_control_events() {
             insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
         bump_thread_version(&pool, channel_id, None).await?;
         let stream_key = format!("{run_id}:item-1");
-        let body = "Visible text\nLANTOR_EVENT {\"type\":\"activity\",\"title\":\"Buffered internal\",\"detail\":\"kept\"}";
+        let body = "Visible before LANTOR_EVENT {\"type\":\"activity\",\"title\":\"Buffered internal\",\"detail\":\"kept\"}LANTOR_EVENT {\"type\":\"usage\",\"input_tokens\":8,\"output_tokens\":3,\"cost_micros\":2} visible after";
 
         append_streaming_agent_message(&pool, agent_id, channel_id, None, &stream_key, body)
             .await?;
@@ -719,13 +879,24 @@ async fn held_visible_preserves_internal_control_events() {
         .map_err(|err| err.to_string())?;
         assert_eq!(activity_count, 1);
 
+        let usage_row = sqlx::query(
+            "select input_tokens, output_tokens, cost_micros from agent_runs where id = $1",
+        )
+        .bind(run_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(usage_row.get::<i64, _>("input_tokens"), 8);
+        assert_eq!(usage_row.get::<i64, _>("output_tokens"), 3);
+        assert_eq!(usage_row.get::<i64, _>("cost_micros"), 2);
+
         let draft_body: String = sqlx::query_scalar(
             "select json_extract(payload, '$.draft_body') from agent_inbox_items where kind = 'interrupted_action' order by created_at desc limit 1",
         )
         .fetch_one(&pool)
         .await
         .map_err(|err| err.to_string())?;
-        assert_eq!(draft_body, "Visible text");
+        assert_eq!(draft_body, "Visible before  visible after");
         Ok(())
     }
     .await;

--- a/src-tauri/src/tests/runtime_streaming.rs
+++ b/src-tauri/src/tests/runtime_streaming.rs
@@ -1243,6 +1243,14 @@ async fn force_send_replays_held_visible_side_effects() {
         append_streaming_agent_message(&pool, agent_id, channel_id, None, &stream_key, &body)
             .await?;
         finish_streaming_agent_message(&pool, &stream_key, "complete").await?;
+        for _ in 0..3 {
+            bump_thread_version(&pool, channel_id, None).await?;
+        }
+        assert_eq!(
+            current_thread_version(&pool, channel_id, None).await?,
+            4,
+            "force_send should be tested while current version is still ahead of the held draft base"
+        );
 
         crate::publish_guard::resolve_interrupted_action(
             &pool,
@@ -1266,6 +1274,343 @@ async fn force_send_replays_held_visible_side_effects() {
                 .await
                 .map_err(|err| err.to_string())?;
         assert_eq!(forced_side_effects, 1);
+
+        let buffer_state: String =
+            sqlx::query_scalar("select state from agent_output_buffers where stream_key = $1")
+                .bind(&stream_key)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(buffer_state, "force_sent");
+
+        let open_items: i64 = sqlx::query_scalar(
+            "select count(*) from agent_inbox_items where kind = 'interrupted_action' and json_extract(payload, '$.stream_key') = $1 and state <> 'archived'",
+        )
+        .bind(&stream_key)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(open_items, 0);
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
+async fn repeated_interrupted_action_resolve_is_a_noop_after_first_resolution() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "repeat-resolve-agent").await?;
+        let channel_id = insert_test_channel(&pool, "repeat-resolve-channel").await?;
+        let (_work_item_id, run_id) =
+            insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
+        bump_thread_version(&pool, channel_id, None).await?;
+        let stream_key = format!("{run_id}:repeat-resolve");
+
+        append_streaming_agent_message(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &stream_key,
+            "stale visible reply",
+        )
+        .await?;
+        finish_streaming_agent_message(&pool, &stream_key, "complete").await?;
+
+        crate::publish_guard::resolve_interrupted_action(
+            &pool,
+            agent_id,
+            run_id,
+            &stream_key,
+            "yield",
+        )
+        .await?;
+        let second_result = crate::publish_guard::resolve_interrupted_action(
+            &pool,
+            agent_id,
+            run_id,
+            &stream_key,
+            "yield",
+        )
+        .await;
+        assert!(
+            second_result.is_ok(),
+            "repeating the same resolve should be idempotent instead of surfacing a stale error: {:?}",
+            second_result.err()
+        );
+        let conflicting_result = crate::publish_guard::resolve_interrupted_action(
+            &pool,
+            agent_id,
+            run_id,
+            &stream_key,
+            "force_send",
+        )
+        .await;
+        assert!(
+            conflicting_result
+                .as_ref()
+                .is_err_and(|err| err.contains("already resolved as yielded")),
+            "a conflicting second resolve should be rejected instead of silently changing state: {conflicting_result:?}"
+        );
+
+        let buffer_state: String =
+            sqlx::query_scalar("select state from agent_output_buffers where stream_key = $1")
+                .bind(&stream_key)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(buffer_state, "yielded");
+
+        let open_items: i64 = sqlx::query_scalar(
+            "select count(*) from agent_inbox_items where kind = 'interrupted_action' and json_extract(payload, '$.stream_key') = $1 and state <> 'archived'",
+        )
+        .bind(&stream_key)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(open_items, 0);
+
+        let resolve_activities: i64 = sqlx::query_scalar(
+            "select count(*) from agent_activities where run_id = $1 and title = 'Interrupted action resolved'",
+        )
+        .bind(run_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(resolve_activities, 1);
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
+async fn stale_silent_reply_marks_work_silent_without_publish_gate_hold() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "stale-silent-agent").await?;
+        let channel_id = insert_test_channel(&pool, "stale-silent-channel").await?;
+        let (work_item_id, run_id) =
+            insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
+        bump_thread_version(&pool, channel_id, None).await?;
+        let stream_key = format!("{run_id}:silent");
+
+        append_streaming_agent_message(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &stream_key,
+            "LANTOR_SILENT_REPLY: no visible reply needed",
+        )
+        .await?;
+
+        let message_count: i64 =
+            sqlx::query_scalar("select count(*) from messages where stream_key = $1")
+                .bind(&stream_key)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(message_count, 0);
+
+        let buffer_count: i64 =
+            sqlx::query_scalar("select count(*) from agent_output_buffers where stream_key = $1")
+                .bind(&stream_key)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(
+            buffer_count, 0,
+            "silent sentinel is internal control and must not be held as public draft text"
+        );
+
+        let work_status: String =
+            sqlx::query_scalar("select status from agent_work_items where id = $1")
+                .bind(work_item_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(work_status, "silent");
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
+async fn held_buffer_is_not_empty_for_codex_completed_fallback() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "codex-final-agent").await?;
+        let channel_id = insert_test_channel(&pool, "codex-final-channel").await?;
+        let (_work_item_id, run_id) =
+            insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
+        bump_thread_version(&pool, channel_id, None).await?;
+        let stream_key = format!("{run_id}:codex-item-1");
+
+        append_streaming_agent_message_deferred_completion(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &stream_key,
+            "partial held codex text",
+        )
+        .await?;
+
+        assert!(
+            !streaming_message_body_is_empty(&pool, &stream_key).await?,
+            "Codex item/completed final text fallback must treat held output buffers as non-empty"
+        );
+
+        if streaming_message_body_is_empty(&pool, &stream_key).await? {
+            append_streaming_agent_message_deferred_completion(
+                &pool,
+                agent_id,
+                channel_id,
+                None,
+                &stream_key,
+                "partial held codex text final text",
+            )
+            .await?;
+        }
+
+        let body: String =
+            sqlx::query_scalar("select body from agent_output_buffers where stream_key = $1")
+                .bind(&stream_key)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(body, "partial held codex text");
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
+async fn repeated_append_to_held_buffer_does_not_duplicate_same_delta() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "held-repeat-agent").await?;
+        let channel_id = insert_test_channel(&pool, "held-repeat-channel").await?;
+        let (_work_item_id, run_id) =
+            insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
+        bump_thread_version(&pool, channel_id, None).await?;
+        let stream_key = format!("{run_id}:held-repeat");
+
+        append_streaming_agent_message(&pool, agent_id, channel_id, None, &stream_key, "delta_A")
+            .await?;
+        append_streaming_agent_message(&pool, agent_id, channel_id, None, &stream_key, "delta_A")
+            .await?;
+
+        let body: String =
+            sqlx::query_scalar("select body from agent_output_buffers where stream_key = $1")
+                .bind(&stream_key)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(
+            body, "delta_A",
+            "replaying the same held delta should not duplicate the draft body"
+        );
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
+async fn held_buffer_still_appends_distinct_suffix_delta() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "held-suffix-agent").await?;
+        let channel_id = insert_test_channel(&pool, "held-suffix-channel").await?;
+        let (_work_item_id, run_id) =
+            insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
+        bump_thread_version(&pool, channel_id, None).await?;
+        let stream_key = format!("{run_id}:held-suffix");
+
+        append_streaming_agent_message(&pool, agent_id, channel_id, None, &stream_key, "fo")
+            .await?;
+        append_streaming_agent_message(&pool, agent_id, channel_id, None, &stream_key, "o").await?;
+
+        let body: String =
+            sqlx::query_scalar("select body from agent_output_buffers where stream_key = $1")
+                .bind(&stream_key)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(
+            body, "foo",
+            "dedupe must not drop a legitimate streaming delta just because it is a suffix"
+        );
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
+async fn held_buffer_terminal_finish_strips_incomplete_control_tail() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "held-partial-control-agent").await?;
+        let channel_id = insert_test_channel(&pool, "held-partial-control-channel").await?;
+        let (_work_item_id, run_id) =
+            insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
+        bump_thread_version(&pool, channel_id, None).await?;
+        let stream_key = format!("{run_id}:partial-control-held");
+
+        append_streaming_agent_message(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &stream_key,
+            "Visible draft\nLANTOR_EVENT {\"type\":\"activity\"",
+        )
+        .await?;
+        let held_before: String =
+            sqlx::query_scalar("select body from agent_output_buffers where stream_key = $1")
+                .bind(&stream_key)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert!(
+            held_before.contains("LANTOR_EVENT"),
+            "incremental held buffers keep incomplete control tails until terminal finish"
+        );
+
+        finish_streaming_agent_message(&pool, &stream_key, "complete").await?;
+
+        let held_after: String =
+            sqlx::query_scalar("select body from agent_output_buffers where stream_key = $1")
+                .bind(&stream_key)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(held_after, "Visible draft");
         Ok(())
     }
     .await;


### PR DESCRIPTION
## Summary
- Add publish-gate stress coverage for rapid same-run visible output, stale control-only multi-event deltas, mixed visible/internal-control held drafts, force-send while current thread version is far ahead of the held draft, repeated interrupted-action resolution, stale silent sentinels, terminal cleanup of incomplete control-event tails in held buffers, Codex/Claude final-text fallback against held buffers, and repeated held-delta replay.
- Fix repeated `interrupted_action_resolve` handling: repeating the same action is idempotent; trying a different action after the buffer is terminal now returns a conflict instead of surfacing a stale "buffer not found" or silently changing state.
- Fix final-text fallback duplicate accumulation: Claude final `assistant`/`result` text now skips when a held output buffer already exists, and Codex `item/completed` fallback now treats held output buffers as non-empty.
- Fix `LANTOR_SILENT_REPLY` under stale thread versions so the internal sentinel marks the work item silent without creating a visible message or held public draft.
- Harden held-buffer merge against exact duplicate delta replay while preserving normal distinct suffix deltas.

## Validation
- cargo test repeated_append_to_held_buffer_does_not_duplicate_same_delta -- --nocapture (failed before fix with `delta_Adelta_A`; passes after exact duplicate-delta dedupe)
- cargo test held_buffer_still_appends_distinct_suffix_delta -- --nocapture (guards against over-broad dedupe dropping normal incremental chunks)
- cargo test held_buffer_is_not_empty_for_codex_completed_fallback -- --nocapture (failed before fix; passes after `streaming_message_body_is_empty` treats held buffers as non-empty)
- cargo test stale_silent_reply_marks_work_silent_without_publish_gate_hold -- --nocapture (failed before fix with `agent_output_buffers` count=1; passes after fix)
- cargo test claude_final_text_does_not_duplicate_held_delta_buffer -- --nocapture (failed before fix with duplicated held body; passes after fix)
- cargo test repeated_interrupted_action_resolve_is_a_noop_after_first_resolution -- --nocapture
- cargo test force_send_replays_held_visible_side_effects -- --nocapture
- cargo test held_buffer_terminal_finish_strips_incomplete_control_tail -- --nocapture
- cargo test runtime::streaming -- --nocapture
- cargo test runtime::claude -- --nocapture
- cargo test -- --nocapture
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- git diff --check

## Notes
The Claude held-buffer regression was test-first: before the fix, `claude_final_text_does_not_duplicate_held_delta_buffer` failed with the held body becoming `partial held textpartial held text final text`. The Codex parallel regression was also test-first: before the fix, `held_buffer_is_not_empty_for_codex_completed_fallback` failed because held streams looked empty to `item/completed` fallback. The silent sentinel regression was test-first as well: before the fix, `stale_silent_reply_marks_work_silent_without_publish_gate_hold` failed because the sentinel was stored as a held public draft. The exact duplicate-delta replay regression was verified test-first and fixed narrowly; a paired suffix-delta test prevents corrupting legitimate incremental streaming.
