### PR TITLE
fix: consume split control-only held output

### DIFF
--- a/src-tauri/src/agent_inbox_wake.rs
+++ b/src-tauri/src/agent_inbox_wake.rs
@@ -509,8 +509,7 @@ async fn load_unresolved_held_reply_hints(
             let channel_kind: Option<String> = row.get("channel_kind");
             let thread_root_id: Option<Uuid> = row.get("thread_root_id");
             let payload: String = row.get("payload");
-            let payload_value: Value =
-                serde_json::from_str(&payload).unwrap_or_else(|_| Value::Null);
+            let payload_value: Value = serde_json::from_str(&payload).unwrap_or(Value::Null);
             let stream_key = payload_value
                 .get("stream_key")
                 .and_then(Value::as_str)

--- a/src-tauri/src/publish_guard.rs
+++ b/src-tauri/src/publish_guard.rs
@@ -762,6 +762,89 @@ pub(crate) async fn hold_streaming_public_output(
     Ok(buffer_id)
 }
 
+pub(crate) async fn consume_accumulated_control_only_output(
+    pool: &SqlitePool,
+    agent_id: Uuid,
+    run_id: Uuid,
+    stream_key: &str,
+    delta: &str,
+) -> CommandResult<Option<Uuid>> {
+    let Some(row) = sqlx::query(
+        "select body from agent_output_buffers where stream_key = $1 and agent_id = $2 and state = 'held'",
+    )
+    .bind(stream_key)
+    .bind(agent_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(to_string)?
+    else {
+        return Ok(None);
+    };
+    let existing_body: String = row.get("body");
+    let combined_body = if !delta.is_empty() && existing_body == delta {
+        existing_body
+    } else {
+        format!("{existing_body}{delta}")
+    };
+    let (visible_body, event_jsons) = split_complete_streaming_agent_event_lines(&combined_body);
+    if event_jsons.is_empty() || !visible_body.trim().is_empty() {
+        return Ok(None);
+    }
+    if event_jsons
+        .iter()
+        .any(|json| streaming_agent_event_is_visible_side_effect(json))
+    {
+        return Ok(None);
+    }
+
+    for event_json in &event_jsons {
+        handle_streaming_agent_event_json(pool, agent_id, run_id, event_json).await?;
+    }
+
+    sqlx::query(
+        r#"
+        update agent_output_buffers
+        set state = 'yielded',
+            body = '',
+            held_visible_events = '[]',
+            updated_at = strftime('%Y-%m-%dT%H:%M:%f+00:00','now')
+        where stream_key = $1 and agent_id = $2 and state = 'held'
+        "#,
+    )
+    .bind(stream_key)
+    .bind(agent_id)
+    .execute(pool)
+    .await
+    .map_err(to_string)?;
+    sqlx::query(
+        r#"
+        update agent_inbox_items
+        set state = 'archived',
+            archived_at = strftime('%Y-%m-%dT%H:%M:%f+00:00','now'),
+            updated_at = strftime('%Y-%m-%dT%H:%M:%f+00:00','now')
+        where agent_id = $1
+          and kind = 'interrupted_action'
+          and json_extract(payload, '$.stream_key') = $2
+          and state <> 'archived'
+        "#,
+    )
+    .bind(agent_id)
+    .bind(stream_key)
+    .execute(pool)
+    .await
+    .map_err(to_string)?;
+    record_agent_activity(
+        pool,
+        Some(agent_id),
+        Some(run_id),
+        "decision",
+        "Control-only held output consumed",
+        json!({ "stream_key": stream_key }).to_string(),
+    )
+    .await?;
+    Ok(Some(Uuid::new_v4()))
+}
+
 pub(crate) async fn output_buffer_exists(
     pool: &SqlitePool,
     stream_key: &str,

--- a/src-tauri/src/runtime/streaming.rs
+++ b/src-tauri/src/runtime/streaming.rs
@@ -14,9 +14,9 @@ use crate::events::{
 };
 use crate::message_store::load_message;
 use crate::publish_guard::{
-    bump_thread_version, can_publish_public_output, hold_streaming_public_output,
-    output_buffer_exists, repin_run_work_item_base_thread_version_for_surface, PublishActionKind,
-    PublishDecision,
+    bump_thread_version, can_publish_public_output, consume_accumulated_control_only_output,
+    hold_streaming_public_output, output_buffer_exists,
+    repin_run_work_item_base_thread_version_for_surface, PublishActionKind, PublishDecision,
 };
 use crate::ui_notifications::{
     notify_ui_message_delete, notify_ui_message_delta, notify_ui_message_upsert, notify_ui_refresh,
@@ -104,6 +104,17 @@ async fn append_streaming_agent_message_inner(
         if let Some((control_agent_id, run_id, work_item_id)) =
             load_streaming_control_context(pool, stream_key).await?
         {
+            if let Some(control_only_id) = consume_accumulated_control_only_output(
+                pool,
+                control_agent_id,
+                run_id,
+                stream_key,
+                delta,
+            )
+            .await?
+            {
+                return Ok(control_only_id);
+            }
             return hold_streaming_public_output(
                 pool,
                 control_agent_id,

--- a/src-tauri/src/tests/agent_inbox_wake.rs
+++ b/src-tauri/src/tests/agent_inbox_wake.rs
@@ -620,15 +620,17 @@ async fn requeue_orphan_interrupted_actions_releases_held_drafts_from_closed_wor
         let affected = requeue_orphan_interrupted_actions(&pool, agent_id)
             .await
             .map_err(|err| err.to_string())?;
-        assert_eq!(affected, 1, "only the orphaned held draft should be requeued");
+        assert_eq!(
+            affected, 1,
+            "only the orphaned held draft should be requeued"
+        );
 
-        let stale_row = sqlx::query(
-            "select state, work_item_id from agent_inbox_items where id = $1",
-        )
-        .bind(stale_inbox_id)
-        .fetch_one(&pool)
-        .await
-        .map_err(|err| err.to_string())?;
+        let stale_row =
+            sqlx::query("select state, work_item_id from agent_inbox_items where id = $1")
+                .bind(stale_inbox_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
         assert_eq!(stale_row.get::<String, _>("state"), "unread");
         assert!(
             stale_row.get::<Option<Uuid>, _>("work_item_id").is_none(),

--- a/src-tauri/src/tests/runtime_streaming.rs
+++ b/src-tauri/src/tests/runtime_streaming.rs
@@ -434,6 +434,108 @@ async fn control_only_interrupted_action_resolve_bypasses_reply_freshness_gate()
 }
 
 #[tokio::test]
+async fn split_control_only_interrupted_action_resolve_bypasses_reply_freshness_gate() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "split-control-resolve-agent").await?;
+        let channel_id = insert_test_channel(&pool, "split-control-resolve-channel").await?;
+
+        let (_held_work_item_id, held_run_id) =
+            insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
+        bump_thread_version(&pool, channel_id, None).await?;
+        let held_stream_key = format!("{held_run_id}:held-reply");
+
+        append_streaming_agent_message(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &held_stream_key,
+            "stale visible reply",
+        )
+        .await?;
+
+        let (_resolve_work_item_id, resolve_run_id) =
+            insert_publish_gate_work(&pool, agent_id, channel_id, None, 1).await?;
+        bump_thread_version(&pool, channel_id, None).await?;
+        let resolve_stream_key = format!("{resolve_run_id}:split-resolve-control");
+        let first_delta = "LANTOR_EVENT {\"type\":\"interrupted_action_resolve\",";
+        let second_delta =
+            format!("\"stream_key\":\"{held_stream_key}\",\"action\":\"yield\"}}\n");
+
+        append_streaming_agent_message(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &resolve_stream_key,
+            first_delta,
+        )
+        .await?;
+        append_streaming_agent_message(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &resolve_stream_key,
+            &second_delta,
+        )
+        .await?;
+
+        let held_state: String =
+            sqlx::query_scalar("select state from agent_output_buffers where stream_key = $1")
+                .bind(&held_stream_key)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(
+            held_state, "yielded",
+            "the split control-only resolve event should execute once its JSON is complete"
+        );
+
+        let resolve_held_buffers: i64 = sqlx::query_scalar(
+            "select count(*) from agent_output_buffers where stream_key = $1 and state = 'held'",
+        )
+        .bind(&resolve_stream_key)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(
+            resolve_held_buffers, 0,
+            "a split control-only resolve event must not leave its own public held buffer"
+        );
+
+        let active_interrupted_items: i64 = sqlx::query_scalar(
+            "select count(*) from agent_inbox_items where kind = 'interrupted_action' and state <> 'archived'",
+        )
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(
+            active_interrupted_items, 0,
+            "split control-only output should not leave a follow-up interrupted_action"
+        );
+
+        let resolve_messages: i64 =
+            sqlx::query_scalar("select count(*) from messages where stream_key = $1")
+                .bind(&resolve_stream_key)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(
+            resolve_messages, 0,
+            "split control-only output should not create a visible streaming message"
+        );
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
 async fn control_only_activity_bypasses_reply_freshness_gate() {
     let Some((pool, schema)) = test_pool().await else {
         return;


### PR DESCRIPTION
## Summary
- add a regression test for stale-context split `LANTOR_EVENT interrupted_action_resolve` deltas
- consume accumulated non-visible control-only held output once the JSON becomes complete
- archive the transient interrupted_action for the resolver stream instead of leaving it in a new publish-gate loop

## Validation
- test-only commit `2b52bf3` fails before the implementation: `split_control_only_interrupted_action_resolve_bypasses_reply_freshness_gate` leaves one held buffer
- `cargo test split_control_only_interrupted_action_resolve_bypasses_reply_freshness_gate -- --nocapture`
- `cargo test control_only -- --nocapture`
- `cargo test repeated_interrupted_action_resolve_is_a_noop_after_first_resolution -- --nocapture`
- `cargo test force_send_replays_held_visible_side_effects -- --nocapture`
- `cargo test`
- `cargo fmt --check`
