### PR TITLE
Fix split silent reply recovery

### DIFF
--- a/src-tauri/src/publish_guard.rs
+++ b/src-tauri/src/publish_guard.rs
@@ -606,6 +606,45 @@ async fn upsert_interrupted_action(
     Ok(())
 }
 
+fn interrupted_action_title(reason: &str) -> &'static str {
+    match reason {
+        "not_owner" => "Public reply held because another agent owns this task",
+        _ => "Public reply held because the thread changed",
+    }
+}
+
+async fn refresh_interrupted_action_payload_without_wake(
+    pool: &SqlitePool,
+    agent_id: Uuid,
+    stream_key: &str,
+    reason: &str,
+    payload: Value,
+) -> CommandResult<bool> {
+    let affected = sqlx::query(
+        r#"
+        update agent_inbox_items
+        set title = $3,
+            body_preview = $4,
+            payload = $5,
+            updated_at = strftime('%Y-%m-%dT%H:%M:%f+00:00','now')
+        where agent_id = $1
+          and kind = 'interrupted_action'
+          and json_extract(payload, '$.stream_key') = $2
+          and state <> 'archived'
+        "#,
+    )
+    .bind(agent_id)
+    .bind(stream_key)
+    .bind(interrupted_action_title(reason))
+    .bind(reason)
+    .bind(payload.to_string())
+    .execute(pool)
+    .await
+    .map_err(to_string)?
+    .rows_affected();
+    Ok(affected > 0)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn hold_streaming_public_output(
     pool: &SqlitePool,
@@ -640,6 +679,7 @@ pub(crate) async fn hold_streaming_public_output(
     .fetch_optional(pool)
     .await
     .map_err(to_string)?;
+    let had_existing_buffer = existing.is_some();
     let existing_reason = existing.as_ref().map(|row| row.2.clone());
     let existing_base_version = existing.as_ref().map(|row| row.3);
     let existing_current_version = existing.as_ref().map(|row| row.4);
@@ -702,6 +742,33 @@ pub(crate) async fn hold_streaming_public_output(
     .await
     .map_err(to_string)?;
 
+    let kind = InterruptedActionKind::from_buffer(&visible_body, held_visible_events.len());
+    let payload = json!({
+        "interrupted_action": kind.as_str(),
+        "reason": reason,
+        "draft_body": visible_body,
+        "base_version": base_version,
+        "current_version": current_version,
+        "base_thread_version": current_version,
+        "stream_key": buffer_stream_key,
+        "action_kind": PublishActionKind::ReplyText.as_str(),
+        "held_visible_events": held_visible_events,
+        "allowed_actions": kind.allowed_actions(),
+    });
+
+    if had_existing_buffer
+        && refresh_interrupted_action_payload_without_wake(
+            pool,
+            agent_id,
+            &buffer_stream_key,
+            reason,
+            payload.clone(),
+        )
+        .await?
+    {
+        return Ok(buffer_id);
+    }
+
     if let Some(work_item_id) = work_item_id {
         sqlx::query(
             r#"
@@ -719,19 +786,6 @@ pub(crate) async fn hold_streaming_public_output(
         notify_ui_work_item_changed(pool, work_item_id, "work_item_interrupted").await;
     }
 
-    let kind = InterruptedActionKind::from_buffer(&visible_body, held_visible_events.len());
-    let payload = json!({
-        "interrupted_action": kind.as_str(),
-        "reason": reason,
-        "draft_body": visible_body,
-        "base_version": base_version,
-        "current_version": current_version,
-        "base_thread_version": current_version,
-        "stream_key": buffer_stream_key,
-        "action_kind": PublishActionKind::ReplyText.as_str(),
-        "held_visible_events": held_visible_events,
-        "allowed_actions": kind.allowed_actions(),
-    });
     upsert_interrupted_action(
         pool,
         agent_id,

--- a/src-tauri/src/runtime/streaming.rs
+++ b/src-tauri/src/runtime/streaming.rs
@@ -104,6 +104,12 @@ async fn append_streaming_agent_message_inner(
         if let Some((control_agent_id, run_id, work_item_id)) =
             load_streaming_control_context(pool, stream_key).await?
         {
+            if let Some(silent_id) =
+                consume_accumulated_silent_output(pool, control_agent_id, run_id, stream_key, delta)
+                    .await?
+            {
+                return Ok(silent_id);
+            }
             if let Some(control_only_id) = consume_accumulated_control_only_output(
                 pool,
                 control_agent_id,
@@ -346,6 +352,79 @@ async fn consume_silent_streaming_agent_delta(
     };
 
     mark_run_work_item_silent(pool, control_agent_id, run_id, &reason).await?;
+    Ok(Some(Uuid::new_v4()))
+}
+
+async fn consume_accumulated_silent_output(
+    pool: &SqlitePool,
+    agent_id: Uuid,
+    run_id: Uuid,
+    stream_key: &str,
+    delta: &str,
+) -> CommandResult<Option<Uuid>> {
+    let Some(row) = sqlx::query(
+        "select body from agent_output_buffers where stream_key = $1 and agent_id = $2 and state = 'held'",
+    )
+    .bind(stream_key)
+    .bind(agent_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(to_string)?
+    else {
+        return Ok(None);
+    };
+    let existing_body: String = row.get("body");
+    let combined_body = if !delta.is_empty() && existing_body == delta {
+        existing_body
+    } else {
+        format!("{existing_body}{delta}")
+    };
+    let Some(reason) = silent_reply_reason(&combined_body) else {
+        return Ok(None);
+    };
+
+    mark_run_work_item_silent(pool, agent_id, run_id, &reason).await?;
+    sqlx::query(
+        r#"
+        update agent_output_buffers
+        set state = 'yielded',
+            body = '',
+            held_visible_events = '[]',
+            updated_at = strftime('%Y-%m-%dT%H:%M:%f+00:00','now')
+        where stream_key = $1 and agent_id = $2 and state = 'held'
+        "#,
+    )
+    .bind(stream_key)
+    .bind(agent_id)
+    .execute(pool)
+    .await
+    .map_err(to_string)?;
+    sqlx::query(
+        r#"
+        update agent_inbox_items
+        set state = 'archived',
+            archived_at = strftime('%Y-%m-%dT%H:%M:%f+00:00','now'),
+            updated_at = strftime('%Y-%m-%dT%H:%M:%f+00:00','now')
+        where agent_id = $1
+          and kind = 'interrupted_action'
+          and json_extract(payload, '$.stream_key') = $2
+          and state <> 'archived'
+        "#,
+    )
+    .bind(agent_id)
+    .bind(stream_key)
+    .execute(pool)
+    .await
+    .map_err(to_string)?;
+    record_agent_activity(
+        pool,
+        Some(agent_id),
+        Some(run_id),
+        "decision",
+        "Silent held output consumed",
+        json!({ "stream_key": stream_key }).to_string(),
+    )
+    .await?;
     Ok(Some(Uuid::new_v4()))
 }
 

--- a/src-tauri/src/tests/runtime_streaming.rs
+++ b/src-tauri/src/tests/runtime_streaming.rs
@@ -1549,6 +1549,84 @@ async fn stale_silent_reply_marks_work_silent_without_publish_gate_hold() {
 }
 
 #[tokio::test]
+async fn split_stale_silent_reply_marks_work_silent_without_publish_gate_hold() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "split-stale-silent-agent").await?;
+        let channel_id = insert_test_channel(&pool, "split-stale-silent-channel").await?;
+        let (work_item_id, run_id) =
+            insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
+        bump_thread_version(&pool, channel_id, None).await?;
+        let stream_key = format!("{run_id}:split-silent");
+
+        append_streaming_agent_message(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &stream_key,
+            "LANTOR_SILENT_R",
+        )
+        .await?;
+        append_streaming_agent_message(
+            &pool,
+            agent_id,
+            channel_id,
+            None,
+            &stream_key,
+            "EPLY: no active held buffers remain",
+        )
+        .await?;
+
+        let message_count: i64 =
+            sqlx::query_scalar("select count(*) from messages where stream_key = $1")
+                .bind(&stream_key)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(message_count, 0);
+
+        let held_count: i64 = sqlx::query_scalar(
+            "select count(*) from agent_output_buffers where stream_key = $1 and state = 'held'",
+        )
+        .bind(&stream_key)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(
+            held_count, 0,
+            "split silent sentinel is internal control and must not remain held"
+        );
+
+        let work_status: String =
+            sqlx::query_scalar("select status from agent_work_items where id = $1")
+                .bind(work_item_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(work_status, "silent");
+
+        let open_interrupted: i64 = sqlx::query_scalar(
+            "select count(*) from agent_inbox_items where kind = 'interrupted_action' and json_extract(payload, '$.stream_key') = $1 and state <> 'archived'",
+        )
+        .bind(&stream_key)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(
+            open_interrupted, 0,
+            "split silent sentinel must not leave an active interrupted_action"
+        );
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
 async fn held_buffer_is_not_empty_for_codex_completed_fallback() {
     let Some((pool, schema)) = test_pool().await else {
         return;

--- a/src-tauri/src/tests/runtime_streaming.rs
+++ b/src-tauri/src/tests/runtime_streaming.rs
@@ -1716,6 +1716,111 @@ async fn repeated_append_to_held_buffer_does_not_duplicate_same_delta() {
 }
 
 #[tokio::test]
+async fn repeated_append_to_existing_held_buffer_does_not_rewake() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "held-rewake-agent").await?;
+        let channel_id = insert_test_channel(&pool, "held-rewake-channel").await?;
+        let (_work_item_id, run_id) =
+            insert_publish_gate_work(&pool, agent_id, channel_id, None, 0).await?;
+        bump_thread_version(&pool, channel_id, None).await?;
+        let stream_key = format!("{run_id}:held-rewake");
+
+        append_streaming_agent_message(&pool, agent_id, channel_id, None, &stream_key, "first")
+            .await?;
+        append_streaming_agent_message(&pool, agent_id, channel_id, None, &stream_key, "-second")
+            .await?;
+        append_streaming_agent_message(&pool, agent_id, channel_id, None, &stream_key, "-third")
+            .await?;
+
+        let body: String =
+            sqlx::query_scalar("select body from agent_output_buffers where stream_key = $1")
+                .bind(&stream_key)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert_eq!(body, "first-second-third");
+
+        let interrupted_count: i64 = sqlx::query_scalar(
+            r#"
+            select count(*)
+            from agent_inbox_items
+            where agent_id = $1
+              and kind = 'interrupted_action'
+              and json_extract(payload, '$.stream_key') = $2
+              and state <> 'archived'
+            "#,
+        )
+        .bind(agent_id)
+        .bind(&stream_key)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(interrupted_count, 1);
+
+        let draft_body: String = sqlx::query_scalar(
+            r#"
+            select json_extract(payload, '$.draft_body')
+            from agent_inbox_items
+            where agent_id = $1
+              and kind = 'interrupted_action'
+              and json_extract(payload, '$.stream_key') = $2
+              and state <> 'archived'
+            "#,
+        )
+        .bind(agent_id)
+        .bind(&stream_key)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(draft_body, "first-second-third");
+
+        let held_activity_count: i64 = sqlx::query_scalar(
+            r#"
+            select count(*)
+            from agent_activities
+            where agent_id = $1
+              and run_id = $2
+              and title = 'Public reply held'
+            "#,
+        )
+        .bind(agent_id)
+        .bind(run_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(
+            held_activity_count, 1,
+            "only the first stale delta for a stream should create a hold event"
+        );
+
+        let wake_activity_count: i64 = sqlx::query_scalar(
+            r#"
+            select count(*)
+            from agent_activities
+            where agent_id = $1
+              and title like 'Inbox wake%'
+            "#,
+        )
+        .bind(agent_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(
+            wake_activity_count, 1,
+            "subsequent deltas appended to an existing held buffer must not redispatch inbox wake"
+        );
+
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
 async fn held_buffer_still_appends_distinct_suffix_delta() {
     let Some((pool, schema)) = test_pool().await else {
         return;


### PR DESCRIPTION
## Summary
- add a regression for stale split `LANTOR_SILENT_REPLY` deltas
- consume accumulated silent held output before treating the buffer as a public draft
- mark the run work item silent and archive the stale interrupted_action once the sentinel is complete
- add a regression for repeated stale deltas on an existing held buffer
- refresh the interrupted_action payload for later deltas without re-marking it unread, clearing `work_item_id`, redispatching inbox wake, or recording another `Public reply held` activity

## Verification
- test-only split-silent regression failed before implementation with `held_count = 1`
- test-only repeated-held-delta regression failed before implementation with `Public reply held` count `3` instead of `1`
- `cargo test split_stale_silent_reply_marks_work_silent_without_publish_gate_hold -- --nocapture`
- `cargo test repeated_append_to_existing_held_buffer_does_not_rewake -- --nocapture`
- `cargo test runtime::streaming::relocated_tests:: -- --nocapture`
- `cargo test`
- `cargo fmt --check`

## Local live check
- deployed this branch locally and drove a new #lantor thread through `POST /api/send_message`
- current local DB after the live run: `held_count = 0`, active interrupted actions = `0`
- this live path did not reproduce a stale hold after the latest runtime restart, so T-S11 is the machine-checkable regression for the repeated-wake failure observed in the earlier live run
