### PR TITLE
Fix owner optimistic message flicker

### DIFF
--- a/src-tauri/src/commands/messages.rs
+++ b/src-tauri/src/commands/messages.rs
@@ -3,10 +3,7 @@ use uuid::Uuid;
 
 use crate::{
     app::{AppState, CommandResult},
-    message_store::{
-        delete_message_in_pool, send_owner_message_in_pool, set_message_saved_in_pool,
-        update_message_in_pool,
-    },
+    message_store::{delete_message_in_pool, set_message_saved_in_pool, update_message_in_pool},
     models::{AttachmentUpload, Message},
 };
 
@@ -16,16 +13,18 @@ pub(crate) async fn send_message(
     thread_root_id: Option<Uuid>,
     body: String,
     as_task: bool,
+    client_message_id: Option<String>,
     attachments: Option<Vec<AttachmentUpload>>,
     state: State<'_, AppState>,
 ) -> CommandResult<Message> {
-    send_owner_message_in_pool(
+    crate::message_store::send_owner_message_in_pool_with_client_id(
         &state.pool,
         channel_id,
         thread_root_id,
         &body,
         as_task,
         attachments.unwrap_or_default(),
+        client_message_id.as_deref(),
     )
     .await
 }

--- a/src-tauri/src/message_store.rs
+++ b/src-tauri/src/message_store.rs
@@ -401,6 +401,7 @@ pub(crate) async fn insert_agent_message_with_options(
     Ok(msg_id)
 }
 
+#[cfg(test)]
 pub(crate) async fn send_owner_message_in_pool(
     pool: &SqlitePool,
     channel_id: Uuid,
@@ -409,13 +410,54 @@ pub(crate) async fn send_owner_message_in_pool(
     as_task: bool,
     attachments: Vec<AttachmentUpload>,
 ) -> CommandResult<Message> {
+    send_owner_message_in_pool_with_client_id(
+        pool,
+        channel_id,
+        thread_root_id,
+        body,
+        as_task,
+        attachments,
+        None,
+    )
+    .await
+}
+
+pub(crate) async fn send_owner_message_in_pool_with_client_id(
+    pool: &SqlitePool,
+    channel_id: Uuid,
+    thread_root_id: Option<Uuid>,
+    body: &str,
+    as_task: bool,
+    attachments: Vec<AttachmentUpload>,
+    client_message_id: Option<&str>,
+) -> CommandResult<Message> {
     if body.trim().is_empty() && attachments.is_empty() {
         return Err("message body or attachment is required".to_owned());
     }
+    let client_message_id = client_message_id.unwrap_or_default().trim();
+    let client_message_key =
+        if client_message_id.starts_with("client-message:") && client_message_id.len() <= 160 {
+            client_message_id.to_owned()
+        } else {
+            String::new()
+        };
     let mut tx = pool
         .begin_with("BEGIN IMMEDIATE")
         .await
         .map_err(to_string)?;
+    if !client_message_key.is_empty() {
+        let existing_id: Option<Uuid> = sqlx::query_scalar(
+            "select id from messages where stream_key = $1 and sender_role = 'owner'",
+        )
+        .bind(&client_message_key)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(to_string)?;
+        if let Some(existing_id) = existing_id {
+            tx.rollback().await.map_err(to_string)?;
+            return load_message(pool, existing_id).await;
+        }
+    }
     let channel_kind: Option<String> =
         sqlx::query_scalar("select kind from channels where id = $1")
             .bind(channel_id)
@@ -438,8 +480,16 @@ pub(crate) async fn send_owner_message_in_pool(
 
     let msg_id: Uuid = sqlx::query_scalar(
         r#"
-        insert into messages (channel_id, thread_root_id, sender_name, sender_role, body, is_task)
-        values ($1, $2, $3, 'owner', $4, $5)
+        insert into messages (
+            channel_id,
+            thread_root_id,
+            sender_name,
+            sender_role,
+            body,
+            is_task,
+            stream_key
+        )
+        values ($1, $2, $3, 'owner', $4, $5, $6)
         returning id
         "#,
     )
@@ -448,6 +498,7 @@ pub(crate) async fn send_owner_message_in_pool(
     .bind(owner_display_name)
     .bind(body.trim())
     .bind(as_task)
+    .bind(&client_message_key)
     .fetch_one(&mut *tx)
     .await
     .map_err(to_string)?;
@@ -474,6 +525,9 @@ pub(crate) async fn send_owner_message_in_pool(
     }
 
     tx.commit().await.map_err(to_string)?;
+    let message = load_message(pool, msg_id).await?;
+    let _ = notify_ui_message_upsert(pool, &message, "message").await;
+
     queue_mentions_as_work_items(
         pool,
         channel_id,
@@ -486,9 +540,8 @@ pub(crate) async fn send_owner_message_in_pool(
     .await?;
     if let Some(task_id) = task_id {
         dispatch_unassigned_task_availability(pool, task_id).await?;
+        let _ = notify_ui_refresh(pool, "task_message").await;
     }
-    let message = load_message(pool, msg_id).await?;
-    let _ = notify_ui_message_upsert(pool, &message, "message").await;
     let _ = notify_ui_refresh(pool, "message").await;
     Ok(message)
 }

--- a/src-tauri/src/runtime/streaming.rs
+++ b/src-tauri/src/runtime/streaming.rs
@@ -466,6 +466,28 @@ async fn finish_streaming_agent_message_inner(
         }
     }
 
+    let pending_row = sqlx::query(
+        r#"
+        select id, body
+        from messages
+        where stream_key = $1
+          and delivery_state = 'streaming'
+        "#,
+    )
+    .bind(stream_key)
+    .fetch_optional(pool)
+    .await
+    .map_err(to_string)?;
+
+    if let Some(row) = pending_row {
+        let message_id: Uuid = row.get("id");
+        let body: String = row.get("body");
+        if body.trim().is_empty() && delivery_state == "error" {
+            delete_streaming_agent_message(pool, message_id, "empty_streaming_reply").await?;
+            return Ok(());
+        }
+    }
+
     let affected = sqlx::query(
         r#"
         update messages

--- a/src-tauri/src/tests/agent_routing.rs
+++ b/src-tauri/src/tests/agent_routing.rs
@@ -3,7 +3,9 @@ use super::{
     MentionDispatchOrigin,
 };
 use crate::channels::open_dm_with_agent_in_pool;
-use crate::message_store::{insert_agent_message, send_owner_message_in_pool};
+use crate::message_store::{
+    insert_agent_message, send_owner_message_in_pool, send_owner_message_in_pool_with_client_id,
+};
 use crate::test_support::{drop_test_schema, insert_test_agent, insert_test_channel, test_pool};
 use sqlx::Row;
 use uuid::Uuid;
@@ -108,6 +110,54 @@ async fn dm_rejects_tasks_and_auto_dispatches_owner_messages() {
     .await;
     drop_test_schema(pool, schema).await;
     assert!(result.is_ok(), "{:?}", result.err());
+}
+
+#[tokio::test]
+async fn owner_client_message_id_is_idempotent_and_returned() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let channel_id = insert_test_channel(&pool, "client-id-channel").await?;
+        let client_message_id = "client-message:local-test-send";
+
+        let first = send_owner_message_in_pool_with_client_id(
+            &pool,
+            channel_id,
+            None,
+            "hello once",
+            false,
+            vec![],
+            Some(client_message_id),
+        )
+        .await?;
+        let second = send_owner_message_in_pool_with_client_id(
+            &pool,
+            channel_id,
+            None,
+            "hello once",
+            false,
+            vec![],
+            Some(client_message_id),
+        )
+        .await?;
+
+        assert_eq!(first.id, second.id);
+        assert_eq!(first.stream_key, client_message_id);
+        assert_eq!(second.body, "hello once");
+        let message_count: i64 = sqlx::query_scalar(
+            "select count(*) from messages where stream_key = $1 and sender_role = 'owner'",
+        )
+        .bind(client_message_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| err.to_string())?;
+        assert_eq!(message_count, 1);
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
 }
 
 #[tokio::test]

--- a/src-tauri/src/tests/runtime_streaming.rs
+++ b/src-tauri/src/tests/runtime_streaming.rs
@@ -112,6 +112,34 @@ async fn streaming_placeholder_is_reused_for_visible_reply() {
 }
 
 #[tokio::test]
+async fn empty_streaming_placeholder_is_deleted_on_error() {
+    let Some((pool, schema)) = test_pool().await else {
+        return;
+    };
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "empty-placeholder-agent").await?;
+        let channel_id = insert_test_channel(&pool, "empty-placeholder-channel").await?;
+
+        let stream_key = "empty-run:error";
+        let message_id =
+            ensure_streaming_agent_message(&pool, agent_id, channel_id, None, stream_key).await?;
+        finish_streaming_agent_message(&pool, stream_key, "error").await?;
+
+        let exists: bool =
+            sqlx::query_scalar("select exists(select 1 from messages where id = $1)")
+                .bind(message_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+        assert!(!exists, "empty error placeholder should be hidden");
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
 async fn completed_deferred_final_reply_survives_later_turn_error() {
     let Some((pool, schema)) = test_pool().await else {
         return;

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -43,8 +43,8 @@ use crate::channels::{
 use crate::domain::reminders::complete_reminder_in_pool;
 use crate::launch_agent;
 use crate::lifecycle_commands::start_agent_in_pool;
-use crate::message_store::{load_artifact, send_owner_message_in_pool, set_message_saved_in_pool};
-use crate::models::AttachmentUpload;
+use crate::message_store::{load_artifact, set_message_saved_in_pool};
+use crate::models::{AttachmentUpload, Message};
 use crate::owner_inbox::{
     dismiss_inbox_items_in_pool, mark_all_owner_inbox_read_in_pool, mark_channel_read_in_pool,
     mark_inbox_items_read_in_pool,
@@ -77,6 +77,7 @@ struct SendMessageRequest {
     thread_root_id: Option<Uuid>,
     body: String,
     as_task: bool,
+    client_message_id: Option<String>,
     attachments: Option<Vec<AttachmentUpload>>,
 }
 
@@ -418,16 +419,17 @@ async fn api_send_message(
     State(state): State<Arc<WebState>>,
     Json(request): Json<SendMessageRequest>,
 ) -> Result<impl IntoResponse, Response> {
-    send_owner_message_in_pool(
+    crate::message_store::send_owner_message_in_pool_with_client_id(
         &state.pool,
         request.channel_id,
         request.thread_root_id,
         &request.body,
         request.as_task,
         request.attachments.unwrap_or_default(),
+        request.client_message_id.as_deref(),
     )
     .await
-    .map(Json)
+    .map(Json::<Message>)
     .map_err(api_error)
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -431,6 +431,10 @@ function clientId() {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 }
 
+function clientMessageStreamKey(messageId: string) {
+  return `client-message:${messageId}`;
+}
+
 function draftAttachmentFromFile(file: File): DraftAttachment {
   return {
     id: `${file.name}-${file.size}-${file.lastModified}-${clientId()}`,
@@ -858,7 +862,16 @@ function App() {
     setData((current) => {
       if (!current || refreshInvalidation === refreshInvalidationRef.current) return refreshed;
       const refreshedMessageIds = new Set(refreshed.messages.map((message) => message.id));
-      const currentOnlyMessages = current.messages.filter((message) => !refreshedMessageIds.has(message.id));
+      const refreshedStreamKeys = new Set(
+        refreshed.messages
+          .map((message) => message.stream_key || null)
+          .filter((value): value is string => Boolean(value)),
+      );
+      const currentOnlyMessages = current.messages.filter((message) => {
+        if (refreshedMessageIds.has(message.id)) return false;
+        const optimisticKey = optimisticMessageIdentityKey(message);
+        return !optimisticKey || !refreshedStreamKeys.has(optimisticKey);
+      });
       if (currentOnlyMessages.length === 0) return refreshed;
       return {
         ...refreshed,
@@ -911,21 +924,26 @@ function App() {
   function applyMessageUpsert(message: Message) {
     messageDeltaBufferRef.current.delete(message.id);
     invalidatePendingRefreshResult();
+    const confirmedOptimisticIds = consumeConfirmedOptimisticMessages([message]);
     setData((current) => {
       if (!current) {
         requestRefresh(`Failed to refresh ${APP_DISPLAY_NAME} state after message update`);
         return current;
       }
-      const existingIndex = current.messages.findIndex((item) => item.id === message.id);
+      const currentMessages = confirmedOptimisticIds.size > 0
+        ? current.messages.filter((item) => !confirmedOptimisticIds.has(item.id))
+        : current.messages;
+      const existingIndex = currentMessages.findIndex((item) => item.id === message.id);
       const messages = existingIndex >= 0
-        ? current.messages.map((item) => item.id === message.id ? message : item)
-        : [...current.messages, message];
+        ? currentMessages.map((item) => item.id === message.id ? message : item)
+        : [...currentMessages, message];
       return { ...current, messages: sortedMessages(messages) };
     });
   }
 
   function withOptimisticMessages(next: Bootstrap): Bootstrap {
     if (optimisticMessagesRef.current.size === 0) return next;
+    consumeConfirmedOptimisticMessages(next.messages);
     const existingIds = new Set(next.messages.map((message) => message.id));
     const optimisticMessages = Array.from(optimisticMessagesRef.current.values())
       .filter((message) => !existingIds.has(message.id));
@@ -2884,6 +2902,44 @@ function App() {
     optimisticAttachmentUrlsRef.current.delete(messageId);
   }
 
+  function isLocalOptimisticMessage(message: Message) {
+    return message.id.startsWith("local-") && message.sender_role === "owner";
+  }
+
+  function optimisticMessageIdentityKey(message: Message) {
+    return isLocalOptimisticMessage(message) && message.stream_key ? message.stream_key : null;
+  }
+
+  function matchesConfirmedOptimisticMessage(confirmed: Message, optimistic: Message) {
+    if (confirmed.id === optimistic.id || !isLocalOptimisticMessage(optimistic)) return false;
+    if (confirmed.sender_role !== "owner") return false;
+    return Boolean(confirmed.stream_key) && confirmed.stream_key === optimistic.stream_key;
+  }
+
+  function consumeConfirmedOptimisticMessages(confirmedMessages: Message[]) {
+    if (optimisticMessagesRef.current.size === 0) return new Set<string>();
+    const confirmedOptimisticIds = new Set<string>();
+    const optimisticMessages = Array.from(optimisticMessagesRef.current.values())
+      .sort((left, right) => timestampSortValue(left.created_at) - timestampSortValue(right.created_at));
+
+    for (const confirmed of confirmedMessages) {
+      if (confirmed.sender_role !== "owner" || isLocalOptimisticMessage(confirmed)) continue;
+      const matched = optimisticMessages.find((optimistic) =>
+        !confirmedOptimisticIds.has(optimistic.id)
+        && matchesConfirmedOptimisticMessage(confirmed, optimistic)
+      );
+      if (!matched) continue;
+      confirmedOptimisticIds.add(matched.id);
+    }
+
+    for (const messageId of confirmedOptimisticIds) {
+      optimisticMessagesRef.current.delete(messageId);
+      releaseOptimisticAttachmentUrls(messageId);
+      knownMessageIdsRef.current?.delete(messageId);
+    }
+    return confirmedOptimisticIds;
+  }
+
   function addOptimisticOwnerMessage(
     channelId: string,
     threadRootId: string | null,
@@ -2893,6 +2949,7 @@ function App() {
   ) {
     const id = `local-${clientId()}`;
     const createdAt = new Date().toISOString();
+    const streamKey = clientMessageStreamKey(id);
     const optimisticMessage: Message = {
       id,
       channel_id: channelId,
@@ -2904,7 +2961,7 @@ function App() {
       is_task: asTask,
       thread_followed: true,
       delivery_state: attachments.length > 0 ? "sending" : "complete",
-      stream_key: "",
+      stream_key: streamKey,
       task_number: null,
       task_status: null,
       attachments: optimisticMessageAttachments(id, attachments),
@@ -3196,9 +3253,11 @@ function App() {
         threadRootId: null,
         body,
         asTask: sendAsTask,
+        clientMessageId: clientMessageStreamKey(optimisticId),
         attachments: await attachmentUploads(attachments),
       });
       settleOptimisticMessage(optimisticId, persistedMessage);
+      if (sendAsTask) requestRefresh(`Failed to refresh ${APP_DISPLAY_NAME} state after task message`);
     } catch (err) {
       removeOptimisticMessage(optimisticId);
       updateRootComposerDraft(channel.id, () => ({ text: body, attachments }));
@@ -3236,6 +3295,7 @@ function App() {
         threadRootId: activeRoot.id,
         body,
         asTask: false,
+        clientMessageId: clientMessageStreamKey(optimisticId),
         attachments: await attachmentUploads(attachments),
       });
       settleOptimisticMessage(optimisticId, persistedMessage);


### PR DESCRIPTION
## Summary
- pass a stable `client-message:*` id from owner optimistic messages through the IPC/web send path and persist it in `messages.stream_key`
- reconcile optimistic owner messages by `stream_key` during upserts, bootstrap refreshes, and stale refresh merges so confirmed `local-*` messages do not reappear as short-lived duplicates
- make owner send retries idempotent inside the write transaction and hide empty streaming placeholders when an agent run ends in error

## Testing
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml owner_client_message_id_is_idempotent_and_returned`
- `cargo test --manifest-path src-tauri/Cargo.toml empty_streaming_placeholder_is_deleted_on_error`
