### PR TITLE
Fix follow-bottom jitter on composer growth

### DIFF
--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -357,6 +357,13 @@ export function Conversation({
     };
   }
 
+  function isMessageListViewportOnlyResize(element: HTMLDivElement) {
+    const previous = messageListMetricsRef.current;
+    return previous.scrollHeight > 0 &&
+      previous.scrollHeight === element.scrollHeight &&
+      previous.clientHeight !== element.clientHeight;
+  }
+
   function cancelPendingMessageBottomScroll() {
     if (bottomScrollFrameRef.current !== null) {
       window.cancelAnimationFrame(bottomScrollFrameRef.current);
@@ -569,37 +576,47 @@ export function Conversation({
     const content = messageListContentRef.current;
     const bottomAnchor = messageListBottomAnchorRef.current;
     if (!root || !content || !bottomAnchor) return;
-    function keepBottomVisible() {
+    function keepBottomVisible(source: "viewport" | "content") {
       const list = messageListRef.current;
       if (!list) return;
+      if (source === "viewport" && isMessageListViewportOnlyResize(list)) {
+        rememberMessageListMetrics(list);
+        return;
+      }
       if (shouldFollowMessagesRef.current && !isUserScrollingMessages()) {
         scrollMessagesToBottom();
       } else {
         rememberMessageListMetrics(list);
       }
     }
-    const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(keepBottomVisible);
+    const observer = typeof ResizeObserver === "undefined"
+      ? null
+      : new ResizeObserver((entries) => {
+        const hasContentResize = entries.some((entry) => entry.target === content);
+        keepBottomVisible(hasContentResize ? "content" : "viewport");
+      });
     const intersectionObserver = typeof IntersectionObserver === "undefined"
       ? null
       : new IntersectionObserver((entries) => {
         if (!shouldFollowMessagesRef.current) return;
         if (entries.some((entry) => !entry.isIntersecting || entry.intersectionRatio < 1)) {
-          keepBottomVisible();
+          keepBottomVisible("viewport");
         }
       }, { root, threshold: 1 });
     const mutationObserver = typeof MutationObserver === "undefined"
       ? null
-      : new MutationObserver(keepBottomVisible);
+      : new MutationObserver(() => keepBottomVisible("content"));
     observer?.observe(root);
     observer?.observe(content);
     intersectionObserver?.observe(bottomAnchor);
     mutationObserver?.observe(content, { childList: true, characterData: true, subtree: true });
-    window.addEventListener("resize", keepBottomVisible);
+    const handleWindowResize = () => keepBottomVisible("viewport");
+    window.addEventListener("resize", handleWindowResize);
     return () => {
       observer?.disconnect();
       intersectionObserver?.disconnect();
       mutationObserver?.disconnect();
-      window.removeEventListener("resize", keepBottomVisible);
+      window.removeEventListener("resize", handleWindowResize);
     };
   }, [activeTab, channel?.id]);
 

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -199,6 +199,13 @@ export function ThreadPanel({
     };
   }
 
+  function isThreadViewportOnlyResize(element: HTMLDivElement) {
+    const previous = threadScrollMetricsRef.current;
+    return previous.scrollHeight > 0 &&
+      previous.scrollHeight === element.scrollHeight &&
+      previous.clientHeight !== element.clientHeight;
+  }
+
   function cancelPendingThreadBottomScroll() {
     if (threadScrollFrameRef.current !== null) {
       window.cancelAnimationFrame(threadScrollFrameRef.current);
@@ -343,6 +350,10 @@ export function ThreadPanel({
     function keepBottomVisible() {
       const scrollRoot = threadScrollRef.current;
       if (!scrollRoot) return;
+      if (isThreadViewportOnlyResize(scrollRoot)) {
+        rememberThreadScrollMetrics(scrollRoot);
+        return;
+      }
       if (shouldFollowThreadRef.current && !isUserScrollingThread()) {
         scrollThreadToBottom();
         setShowBackToBottom(false);


### PR DESCRIPTION
## Summary
- Skip forced bottom-follow when the thread scroll viewport shrinks from reply composer auto-grow without content height changes
- Apply the same viewport-only resize guard to the main channel message list composer
- Preserve content-driven bottom-follow for new messages, mutations, and loaded message content

## Verification
- npm run build

## Notes
- Focused manual checks: type continuously in both the main channel composer and thread reply composer while activity updates are visible; the scroll area should not jitter on each textarea growth. New incoming messages/content growth should still follow bottom when already at bottom.