### PR TITLE
Enlarge channel header hash icon

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1641,9 +1641,13 @@ button,
   gap: 6px;
 }
 
-.channel-title .hash-card,
-.thread-title-card {
-  width: 22px;
+.channel-title .hash-card {
+  width: 34px;
+}
+
+.channel-title .hash-card svg {
+  width: 30px;
+  height: 30px;
 }
 
 .channel-title > div,


### PR DESCRIPTION
## Summary
- enlarge the channel page header # icon to improve visual weight
- keep the channel name typography unchanged

## Verification
- npm run build
- npm run lint:css-tokens
- git diff --check