### PR TITLE
Align sidebar brand label

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -697,7 +697,7 @@ button,
   align-items: center;
   gap: 10px;
   max-width: 100%;
-  padding: 0;
+  padding: 0 0 0 6px;
   border-radius: 0;
   background: transparent;
   color: var(--ink-primary);


### PR DESCRIPTION
## Summary
- shift the sidebar brand row slightly so the Lantor label aligns with Search / Activity / Saved labels
- keep sidebar row typography and icon sizing unchanged

## Verification
- npm run build
- npm run lint:css-tokens
- git diff --check