### PR TITLE
Add web-only dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,39 @@ npm install
 npm run tauri:dev
 ```
 
+To run only the browser UI and local backend, without opening the macOS
+desktop window:
+
+```bash
+npm run web:dev
+```
+
+This builds the web bundle, starts the same local SQLite database, supervisor,
+reminder worker, event pruning, and web server, then serves Lantor at
+`http://127.0.0.1:8787/` by default. Set `LANTOR_WEB_BIND` to choose another
+bind address, for example `LANTOR_WEB_BIND=127.0.0.1:8787 npm run web:dev` for
+loopback-only access.
+
+For frontend hot reload in browser-only development, run two terminals:
+
+```bash
+# Terminal 1: local backend and API/SSE server, no desktop window
+npm run web:backend
+
+# Terminal 2: Vite frontend with /api proxied to the backend above
+npm run dev
+```
+
+Open `http://127.0.0.1:5173/` for the hot-reload UI. The Vite dev server
+proxies `/api` and `/api/events` to `http://127.0.0.1:8787/` by default. If
+the backend uses a non-default bind, set `LANTOR_WEB_BIND` in both terminals
+or set `LANTOR_WEB_PROXY_TARGET=http://127.0.0.1:<port>` for the Vite terminal.
+
+Do not run `npm run tauri:dev` and `npm run web:dev` / `npm run web:backend`
+at the same time against the same SQLite database. Use one backend-owning
+process at a time so the local supervisor and background workers have a single
+owner.
+
 When the desktop app opens, add your first agent:
 
 1. Install and sign in to the CLI runtime you want to use. You only need the
@@ -137,6 +170,12 @@ The optional mobile web UI is served by the same local desktop process and
 shares the same SQLite database and attachment store. There is still no
 separate hosted Lantor service in the path.
 
+If you do not need the desktop window, run `npm run web:dev` instead. Web-only
+mode starts the same local backend and serves the same browser UI, but skips
+the Tauri window and desktop-only event listener. Browser refreshes continue
+to use the web SSE stream. During frontend development, use `npm run
+web:backend` plus `npm run dev` for Vite hot reload.
+
 ## Mobile
 
 The same desktop process also serves a mobile-friendly web UI, so you can
@@ -212,6 +251,9 @@ npm run build                                              # frontend bundle
 cargo check --manifest-path src-tauri/Cargo.toml           # rust typecheck
 cargo test  --manifest-path src-tauri/Cargo.toml --no-run  # compile tests
 npm run tauri:dev                                          # desktop app
+npm run web:dev                                            # built web UI + backend, no desktop window
+npm run web:backend                                        # backend only for Vite hot reload
+npm run dev                                                # Vite frontend; proxies /api to web backend
 ```
 
 Composer input latency benchmarks live in

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",
+    "web:backend": "cargo run --manifest-path src-tauri/Cargo.toml -- --web-only",
+    "web:dev": "npm run build && npm run web:backend",
     "build": "tsc && vite build",
     "build:bench": "tsc && vite build --mode bench",
     "bench:composer": "node bench/composer-input-latency.mjs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,5 +20,5 @@ sha2 = "0.10.8"
 sqlx = { version = "0.8.5", features = ["runtime-tokio-rustls", "sqlite", "uuid", "chrono"] }
 tauri = { version = "2.5.1", features = ["protocol-asset"] }
 tower-http = { version = "0.6.2", features = ["compression-gzip", "fs"] }
-tokio = { version = "1.44.2", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.44.2", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 uuid = { version = "1.16.0", features = ["serde", "v4"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -233,6 +233,22 @@ fn install_window_state_persistence(window: &WebviewWindow, path: PathBuf) {
     });
 }
 
+fn initialize_backend() -> (String, SqlitePool) {
+    let database_url = db_url();
+    let pool = tauri::async_runtime::block_on(db_connect_with_url(&database_url, 5))
+        .expect("failed to connect Lantor SQLite database");
+
+    tauri::async_runtime::block_on(migrate(&pool)).expect("failed to initialize Lantor schema");
+    launch_agent::spawn_supervisor_process(&database_url);
+    (database_url, pool)
+}
+
+fn spawn_shared_background_workers(pool: SqlitePool, database_url: String) {
+    spawn_ui_events_pruner(pool.clone());
+    web::spawn_web_server_if_configured(pool.clone(), database_url);
+    spawn_reminder_worker(pool);
+}
+
 async fn resolve_run_reminder_anchor(
     pool: &SqlitePool,
     agent_id: Uuid,
@@ -300,12 +316,7 @@ async fn resolve_event_channel(
 }
 
 pub fn run() {
-    let database_url = db_url();
-    let pool = tauri::async_runtime::block_on(db_connect_with_url(&database_url, 5))
-        .expect("failed to connect Lantor SQLite database");
-
-    tauri::async_runtime::block_on(migrate(&pool)).expect("failed to initialize Lantor schema");
-    launch_agent::spawn_supervisor_process(&database_url);
+    let (database_url, pool) = initialize_backend();
     let state_db_url = database_url.clone();
     let reminder_pool = pool.clone();
 
@@ -313,9 +324,7 @@ pub fn run() {
         .manage(AppState::new(pool, state_db_url))
         .setup(move |app| {
             spawn_ui_refresh_listener(app.handle().clone(), reminder_pool.clone());
-            spawn_ui_events_pruner(reminder_pool.clone());
-            web::spawn_web_server_if_configured(reminder_pool.clone(), database_url.clone());
-            spawn_reminder_worker(reminder_pool.clone());
+            spawn_shared_background_workers(reminder_pool.clone(), database_url.clone());
             if let Some(window) = app.get_webview_window("main") {
                 let _ = window.set_title("Lantor");
                 if let Some(path) = window_state_path(app.handle()) {
@@ -370,6 +379,19 @@ pub fn run() {
         .expect("error while running Lantor");
 }
 
+fn run_web_only() {
+    let (database_url, pool) = initialize_backend();
+    spawn_shared_background_workers(pool, database_url);
+    eprintln!("Lantor web-only mode is running. Press Ctrl-C to stop.");
+    tauri::async_runtime::block_on(async {
+        if let Err(err) = tokio::signal::ctrl_c().await {
+            eprintln!("failed to listen for Ctrl-C: {err}");
+            std::future::pending::<()>().await;
+        }
+    });
+    eprintln!("Lantor web-only mode stopped.");
+}
+
 fn main() {
     let args = env::args().collect::<Vec<_>>();
     if let Some(tool_arg_index) = args.iter().position(|arg| arg == "--agent-context-tool") {
@@ -394,6 +416,8 @@ fn main() {
             eprintln!("Lantor supervisor stopped: {err}");
             std::process::exit(1);
         }
+    } else if args.iter().any(|arg| arg == "--web-only") {
+        run_web_only();
     } else {
         run();
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,26 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+function webBackendProxyTarget() {
+  if (process.env.LANTOR_WEB_PROXY_TARGET) {
+    return process.env.LANTOR_WEB_PROXY_TARGET;
+  }
+  const bind = process.env.LANTOR_WEB_BIND?.trim() || "127.0.0.1:8787";
+  const match = bind.match(/^(?:\[(.*)\]|([^:]+)):(\d+)$/);
+  if (!match) {
+    return "http://127.0.0.1:8787";
+  }
+  const host = match[1] || match[2];
+  const port = match[3];
+  if (host === "0.0.0.0") {
+    return `http://127.0.0.1:${port}`;
+  }
+  if (host === "::") {
+    return `http://[::1]:${port}`;
+  }
+  return host.includes(":") ? `http://[${host}]:${port}` : `http://${host}:${port}`;
+}
+
 export default defineConfig(({ mode }) => ({
   plugins: [react()],
   resolve: {
@@ -9,5 +29,13 @@ export default defineConfig(({ mode }) => ({
         { find: /^react-dom\/client$/, replacement: "react-dom/profiling" },
       ]
       : [],
+  },
+  server: {
+    proxy: {
+      "/api": {
+        target: webBackendProxyTarget(),
+        changeOrigin: true,
+      },
+    },
   },
 }));


### PR DESCRIPTION
## Summary
- add a shared backend initialization path for desktop and web-only startup
- add a `--web-only` runtime mode that starts the local backend, supervisor, reminder worker, event pruner, and Axum web server without opening the Tauri window
- add `npm run web:dev` for built web-only serving, `npm run web:backend` for hot-reload development, and README usage / concurrency caveats
- add Vite `/api` proxy support so `npm run dev` can hot-reload against the web-only backend

## Validation
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- Built web-only serve smoke:
  - `LANTOR_DATABASE_URL=sqlite:///tmp/lantor-web-serve-pr-test.sqlite LANTOR_WEB_BIND=127.0.0.1:8881 npm run web:dev`
  - `curl -fsS http://127.0.0.1:8881/api/health` -> `{"ok":true}`
  - `curl -fsS http://127.0.0.1:8881/ | head -n 5` returned built HTML
- Hot-reload proxy smoke:
  - terminal 1: `LANTOR_DATABASE_URL=sqlite:///tmp/lantor-web-hot-test.sqlite LANTOR_WEB_BIND=127.0.0.1:8880 npm run web:backend`
  - terminal 2: `LANTOR_WEB_BIND=127.0.0.1:8880 npm run dev -- --port 5183 --strictPort`
  - `curl -fsS http://127.0.0.1:5183/api/health` -> `{"ok":true}`
  - `curl -fsS http://127.0.0.1:5183/ | head -n 5` returned Vite React-refresh HTML

## Notes
- Web-only mode intentionally skips the Tauri-only `spawn_ui_refresh_listener(app.handle(), ...)`; browser refreshes continue through the existing web SSE stream.
- README warns not to run `tauri:dev` and `web:dev` / `web:backend` concurrently against the same SQLite database.
