### PR TITLE
Add image thumbnail display setting

### DIFF
--- a/scripts/styles-raw-color-baseline.json
+++ b/scripts/styles-raw-color-baseline.json
@@ -93,12 +93,6 @@
       "n": 0
     },
     {
-      "selector": ":root[data-theme=\"dark\"] .theme-choice-grid button.selected",
-      "prop": "border-color",
-      "literal": "rgba(105, 170, 252, 0.72)",
-      "n": 0
-    },
-    {
       "selector": ".activity-progress-avatar-stack .agent-avatar",
       "prop": "box-shadow",
       "literal": "rgba(20, 22, 28, 0.16)",

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -81,6 +81,7 @@ type ConversationProps = {
   shareBaseUrl: string | null;
   savedMessageIds: Set<string>;
   focusedMessageId: string | null;
+  showImageThumbnails: boolean;
   onToggleMessageSaved: (message: Message, saved: boolean) => void;
 };
 
@@ -257,6 +258,7 @@ export function Conversation({
   shareBaseUrl,
   savedMessageIds,
   focusedMessageId,
+  showImageThumbnails,
   onToggleMessageSaved,
 }: ConversationProps) {
   const [showChannelActions, setShowChannelActions] = useState(false);
@@ -1043,7 +1045,7 @@ export function Conversation({
                         )}
                       </>
                     )}
-                    <MessageAttachments attachments={message.attachments} />
+                    <MessageAttachments attachments={message.attachments} showImageThumbnails={showImageThumbnails} />
                     <MessageArtifacts artifacts={message.artifacts} onOpenArtifact={openArtifact} />
                     {message.delivery_state === "sending" && (
                       <div className="message-stream-state sending">Sending...</div>

--- a/src/components/MessageAttachments.tsx
+++ b/src/components/MessageAttachments.tsx
@@ -1,10 +1,11 @@
 import { type MouseEvent, type PointerEvent, useEffect, useState } from "react";
-import { FileText, X } from "lucide-react";
+import { FileText, Image, X } from "lucide-react";
 import { attachmentAssetUrl, isTauriRuntime, openExternalUrl } from "../apiClient";
 import { MessageAttachment } from "../types";
 
 type MessageAttachmentsProps = {
   attachments: MessageAttachment[];
+  showImageThumbnails: boolean;
 };
 
 type ImagePreview = {
@@ -33,7 +34,7 @@ function isolateAttachmentEvent(event: MouseEvent<HTMLElement> | PointerEvent<HT
   event.stopPropagation();
 }
 
-export function MessageAttachments({ attachments }: MessageAttachmentsProps) {
+export function MessageAttachments({ attachments, showImageThumbnails }: MessageAttachmentsProps) {
   const [imagePreview, setImagePreview] = useState<ImagePreview | null>(null);
 
   function closeImagePreview(event: MouseEvent<HTMLButtonElement>) {
@@ -71,15 +72,26 @@ export function MessageAttachments({ attachments }: MessageAttachmentsProps) {
               <button
                 key={attachment.id}
                 type="button"
-                className={`message-attachment image ${attachment.local_url ? "pending" : ""}`}
+                className={`message-attachment image ${showImageThumbnails ? "" : "compact-image"} ${attachment.local_url ? "pending" : ""}`}
                 aria-label={`Preview ${attachment.original_name}`}
+                title={attachment.original_name}
                 onPointerDown={isolateAttachmentEvent}
                 onClick={(event) => {
                   event.stopPropagation();
                   setImagePreview({ src, alt: attachment.original_name });
                 }}
               >
-                <img src={src} alt="" loading="lazy" />
+                {showImageThumbnails ? (
+                  <img src={src} alt="" loading="lazy" />
+                ) : (
+                  <>
+                    <span className="attachment-icon"><Image size={18} /></span>
+                    <span className="attachment-meta">
+                      <span><Image size={13} /> {attachment.original_name}</span>
+                      <small>{attachment.mime_type || "image"} · {formatBytes(attachment.size_bytes)}</small>
+                    </span>
+                  </>
+                )}
               </button>
             );
           }

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { Monitor, Moon, Sun, Type } from "lucide-react";
+import { Image, Monitor, Moon, Sun, Type } from "lucide-react";
 import { Modal } from "./Modal";
 
 export type ThemePreference = "auto" | "light" | "dark";
@@ -8,8 +8,10 @@ type SettingsModalProps = {
   open: boolean;
   themePreference: ThemePreference;
   chatTextSize: ChatTextSize;
+  showImageThumbnails: boolean;
   onThemePreferenceChange: (value: ThemePreference) => void;
   onChatTextSizeChange: (value: ChatTextSize) => void;
+  onShowImageThumbnailsChange: (value: boolean) => void;
   onClose: () => void;
 };
 
@@ -39,8 +41,10 @@ export function SettingsModal({
   open,
   themePreference,
   chatTextSize,
+  showImageThumbnails,
   onThemePreferenceChange,
   onChatTextSizeChange,
+  onShowImageThumbnailsChange,
   onClose,
 }: SettingsModalProps) {
   return (
@@ -93,6 +97,24 @@ export function SettingsModal({
             ))}
           </div>
           <p className="settings-hint">Applies across messages, inputs, panels, and modals. Use Command +/- or Ctrl +/- to adjust without opening Settings. Command/Ctrl+0 resets.</p>
+        </fieldset>
+        <fieldset className="settings-fieldset settings-attachments-fieldset">
+          <legend>Attachments</legend>
+          <label className="settings-toggle-row">
+            <span className="settings-toggle-copy">
+              <Image size={17} />
+              <span>
+                <strong>Show image thumbnails</strong>
+                <small>Display uploaded images inline before opening them.</small>
+              </span>
+            </span>
+            <input
+              type="checkbox"
+              checked={showImageThumbnails}
+              onChange={(event) => onShowImageThumbnailsChange(event.currentTarget.checked)}
+            />
+          </label>
+          <p className="settings-hint">When disabled, images appear as compact attachment rows and still open in preview when clicked.</p>
         </fieldset>
       </section>
     </Modal>

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -104,6 +104,7 @@ type ThreadPanelProps = {
   shareBaseUrl: string | null;
   savedMessageIds: Set<string>;
   focusedMessageId: string | null;
+  showImageThumbnails: boolean;
   onToggleMessageSaved: (message: Message, saved: boolean) => void;
   onResizeStart: (event: ReactPointerEvent<HTMLButtonElement>) => void;
 };
@@ -145,6 +146,7 @@ export function ThreadPanel({
   shareBaseUrl,
   savedMessageIds,
   focusedMessageId,
+  showImageThumbnails,
   onToggleMessageSaved,
   onResizeStart,
 }: ThreadPanelProps) {
@@ -646,7 +648,7 @@ export function ThreadPanel({
                           </>
                         );
                       })()}
-                      <MessageAttachments attachments={activeRoot.attachments} />
+                      <MessageAttachments attachments={activeRoot.attachments} showImageThumbnails={showImageThumbnails} />
                       <MessageArtifacts artifacts={activeRoot.artifacts} onOpenArtifact={openArtifact} />
                       {activeRoot.delivery_state === "sending" && (
                         <div className="message-stream-state sending">Sending...</div>
@@ -919,7 +921,7 @@ export function ThreadPanel({
                           </>
                         );
                       })()}
-                      <MessageAttachments attachments={reply.attachments} />
+                      <MessageAttachments attachments={reply.attachments} showImageThumbnails={showImageThumbnails} />
                       <MessageArtifacts artifacts={reply.artifacts} onOpenArtifact={openArtifact} />
                       {reply.delivery_state === "sending" && (
                         <div className="message-stream-state sending">Sending...</div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -160,6 +160,7 @@ const AGENT_DRAWER_WIDTH_STORAGE_KEY = "lantor.agentDrawerWidth";
 const SIDEBAR_WIDTH_STORAGE_KEY = "lantor.sidebarWidth";
 const THEME_PREFERENCE_STORAGE_KEY = "lantor.themePreference";
 const CHAT_TEXT_SIZE_STORAGE_KEY = "lantor.chatTextSize";
+const SHOW_IMAGE_THUMBNAILS_STORAGE_KEY = "lantor.showImageThumbnails";
 const MOBILE_EDGE_SWIPE_START_PX = 24;
 const MOBILE_EDGE_SWIPE_OPEN_PX = 72;
 const MOBILE_EDGE_SWIPE_MAX_VERTICAL_PX = 48;
@@ -504,6 +505,10 @@ function getStoredChatTextSize(): ChatTextSize {
   return CHAT_TEXT_SIZE_OPTIONS.includes(stored as ChatTextSize) ? stored as ChatTextSize : "default";
 }
 
+function getStoredShowImageThumbnails() {
+  return window.localStorage.getItem(SHOW_IMAGE_THUMBNAILS_STORAGE_KEY) !== "false";
+}
+
 async function attachmentUploads(attachments: DraftAttachment[]) {
   return Promise.all(attachments.map(async (attachment) => {
     const buffer = await attachment.file.arrayBuffer();
@@ -679,6 +684,7 @@ function App() {
   const [showSettingsModal, setShowSettingsModal] = useState(false);
   const [themePreference, setThemePreference] = useState<ThemePreference>(() => getStoredThemePreference());
   const [chatTextSize, setChatTextSize] = useState<ChatTextSize>(() => getStoredChatTextSize());
+  const [showImageThumbnails, setShowImageThumbnails] = useState(() => getStoredShowImageThumbnails());
   const [showMobileSidebar, setShowMobileSidebar] = useState(() => isMobileViewport());
   const [mobileSidebarFocus, setMobileSidebarFocus] = useState<"home" | "dms">("home");
   const [mobileSidebarDragPx, setMobileSidebarDragPx] = useState(0);
@@ -1490,6 +1496,10 @@ function App() {
   useEffect(() => {
     window.localStorage.setItem(CHAT_TEXT_SIZE_STORAGE_KEY, chatTextSize);
   }, [chatTextSize]);
+
+  useEffect(() => {
+    window.localStorage.setItem(SHOW_IMAGE_THUMBNAILS_STORAGE_KEY, String(showImageThumbnails));
+  }, [showImageThumbnails]);
 
   useEffect(() => {
     setDismissedActivityFeedItems(data?.dismissed_inbox_items ?? {});
@@ -3720,8 +3730,10 @@ function App() {
         open={showSettingsModal}
         themePreference={themePreference}
         chatTextSize={chatTextSize}
+        showImageThumbnails={showImageThumbnails}
         onThemePreferenceChange={setThemePreference}
         onChatTextSizeChange={setChatTextSize}
+        onShowImageThumbnailsChange={setShowImageThumbnails}
         onClose={() => setShowSettingsModal(false)}
       />
 
@@ -3773,6 +3785,7 @@ function App() {
         shareBaseUrl={shareBaseUrl}
         savedMessageIds={savedMessageIds}
         focusedMessageId={focusedMessageId}
+        showImageThumbnails={showImageThumbnails}
         onToggleMessageSaved={setMessageSaved}
       />
 
@@ -3835,6 +3848,7 @@ function App() {
           shareBaseUrl={shareBaseUrl}
           savedMessageIds={savedMessageIds}
           focusedMessageId={focusedMessageId}
+          showImageThumbnails={showImageThumbnails}
           onToggleMessageSaved={setMessageSaved}
           onResizeStart={startThreadResize}
         />

--- a/src/styles.css
+++ b/src/styles.css
@@ -2170,9 +2170,9 @@ button,
   gap: 8px;
   width: min(100%, 520px);
   max-width: 100%;
-  min-height: 46px;
-  margin-top: 10px;
-  padding: 6px 10px;
+  min-height: 38px;
+  margin-top: 4px;
+  padding: 4px 8px;
   border: 1px solid transparent;
   border-radius: 10px;
   background: transparent;
@@ -2955,6 +2955,19 @@ mark {
   cursor: zoom-in;
 }
 
+.message-attachment.image.compact-image {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  min-height: 48px;
+  padding: 8px;
+  background: var(--bg-control-flat);
+  text-align: left;
+}
+
+.message-attachment.image.compact-image:hover {
+  background: var(--bg-control-hover);
+}
+
 .message-attachment.image img {
   display: block;
   width: 100%;
@@ -2966,6 +2979,10 @@ mark {
 
 .message-attachment.image:hover img {
   filter: saturate(1.04) contrast(1.02);
+}
+
+.message-attachment.image.compact-image:hover img {
+  filter: none;
 }
 
 .message-attachment.pending {
@@ -3732,13 +3749,15 @@ mark {
 :root[data-theme="dark"] .activity-run-card,
 :root[data-theme="dark"] .task-board-summary > div,
 :root[data-theme="dark"] .theme-choice-grid button,
-:root[data-theme="dark"] .chat-text-size-grid button {
+:root[data-theme="dark"] .chat-text-size-grid button,
+:root[data-theme="dark"] .settings-toggle-row {
   border-color: var(--border-subtle);
   background: var(--bg-panel);
   color: var(--ink-primary);
 }
 
-:root[data-theme="dark"] .theme-choice-grid button.selected {
+:root[data-theme="dark"] .theme-choice-grid button.selected,
+:root[data-theme="dark"] .chat-text-size-grid button.selected {
   border-color: var(--accent);
   background: var(--bg-selected-soft);
   box-shadow: inset 0 0 0 1px var(--accent);
@@ -3746,7 +3765,9 @@ mark {
 }
 
 :root[data-theme="dark"] .theme-choice-grid button.selected strong,
-:root[data-theme="dark"] .theme-choice-grid button.selected small {
+:root[data-theme="dark"] .theme-choice-grid button.selected small,
+:root[data-theme="dark"] .chat-text-size-grid button.selected strong,
+:root[data-theme="dark"] .chat-text-size-grid button.selected small {
   color: var(--accent);
 }
 
@@ -3784,7 +3805,8 @@ mark {
 :root[data-theme="dark"] .activity-run-head h5,
 :root[data-theme="dark"] .settings-section-head h4,
 :root[data-theme="dark"] .theme-choice-grid strong,
-:root[data-theme="dark"] .chat-text-size-grid strong {
+:root[data-theme="dark"] .chat-text-size-grid strong,
+:root[data-theme="dark"] .settings-toggle-copy strong {
   color: var(--ink-primary);
 }
 
@@ -5710,6 +5732,7 @@ body.resizing-column * {
 }
 
 .settings-fieldset legend {
+  margin-bottom: 8px;
   padding: 0;
   color: var(--muted);
   font-size: var(--type-size-meta);
@@ -5760,13 +5783,7 @@ body.resizing-column * {
   text-align: center;
 }
 
-.theme-choice-grid button.selected {
-  border-color: var(--accent);
-  background: var(--bg-selected-accent);
-  box-shadow: var(--shadow-selected-accent);
-  color: var(--accent);
-}
-
+.theme-choice-grid button.selected,
 .chat-text-size-grid button.selected {
   border-color: var(--accent);
   background: var(--bg-selected-accent);
@@ -5774,12 +5791,8 @@ body.resizing-column * {
   color: var(--accent);
 }
 
-:root[data-theme="dark"] .theme-choice-grid button.selected {
-  border-color: rgba(105, 170, 252, 0.72);
-  color: var(--accent);
-}
-
-.theme-choice-grid button.selected::after {
+.theme-choice-grid button.selected::after,
+.chat-text-size-grid button.selected::after {
   position: absolute;
   top: 8px;
   right: 8px;
@@ -5831,6 +5844,56 @@ body.resizing-column * {
   color: var(--muted);
   font-size: var(--type-size-meta);
   line-height: 1.4;
+}
+
+.settings-attachments-fieldset {
+  margin-top: 8px;
+}
+
+.settings-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  min-width: 0;
+  padding: 11px 12px;
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  background: var(--panel-strong);
+}
+
+.settings-toggle-copy {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  color: var(--muted);
+}
+
+.settings-toggle-copy > span {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.settings-toggle-copy strong {
+  color: var(--ink);
+  font-size: var(--type-size-body);
+  font-weight: var(--type-weight-semibold);
+}
+
+.settings-toggle-copy small {
+  color: var(--muted);
+  font-size: var(--type-size-caption);
+  line-height: 1.3;
+}
+
+.settings-toggle-row input {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  accent-color: var(--accent);
 }
 
 .modal-form {


### PR DESCRIPTION
## Summary\n- Add a Settings toggle for showing image thumbnails in message attachments.\n- Render image attachments as compact rows when thumbnails are disabled, while preserving click-to-preview.\n- Tighten reply-summary spacing and align Settings selected styles/spacing.\n\n## Verification\n- npm run build\n- npm run lint:css-tokens