### PR TITLE
Add spacing below settings field labels

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -5724,7 +5724,7 @@ body.resizing-column * {
 
 .settings-fieldset {
   display: grid;
-  gap: 9px;
+  gap: 12px;
   min-width: 0;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Summary
- increase Settings fieldset gap so Theme/Text Size labels are not tight against their option cards
- keep selected card treatment consistent with current main

## Verification
- npm run build
- npm run lint:css-tokens
- git diff --check