### PR TITLE
Disable composer writing suggestions

### DIFF
--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -14,7 +14,7 @@ import {
   Trash2,
   UserPlus,
 } from "lucide-react";
-import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type FocusEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type WheelEvent as ReactWheelEvent } from "react";
+import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type FocusEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type TextareaHTMLAttributes, type WheelEvent as ReactWheelEvent } from "react";
 import { useAutoGrowTextarea } from "../hooks/useAutoGrowTextarea";
 import { useMentionPicker } from "../hooks/useMentionPicker";
 import { useMobileViewport } from "../hooks/useMobileViewport";
@@ -35,6 +35,10 @@ import { MessageAttachments } from "./MessageAttachments";
 import { MessageArtifacts } from "./MessageArtifacts";
 import { MessageMarkdown } from "./MessageMarkdown";
 import { TaskAssigneePicker } from "./TaskAssigneePicker";
+
+type WritingSuggestionsTextareaAttrs = TextareaHTMLAttributes<HTMLTextAreaElement> & { "writingsuggestions": "false" };
+
+const disableWritingSuggestionsAttrs: WritingSuggestionsTextareaAttrs = { writingsuggestions: "false" };
 
 type ConversationProps = {
   channel: Channel | null;
@@ -1547,6 +1551,7 @@ function ConversationComposer({
         autoCapitalize="none"
         autoComplete="off"
         autoCorrect="off"
+        {...disableWritingSuggestionsAttrs}
         spellCheck={false}
         onChange={(event) => {
           updateText(event.target.value);

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -1,5 +1,5 @@
 import { ArrowDown, ArrowLeft, Bookmark, CheckCircle2, Crosshair, Hash, MessageSquare, Paperclip, RotateCcw, Send, X } from "lucide-react";
-import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type WheelEvent as ReactWheelEvent } from "react";
+import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type TextareaHTMLAttributes, type WheelEvent as ReactWheelEvent } from "react";
 import { useAutoGrowTextarea } from "../hooks/useAutoGrowTextarea";
 import { useMentionPicker } from "../hooks/useMentionPicker";
 import { useMobileViewport } from "../hooks/useMobileViewport";
@@ -20,6 +20,10 @@ import { MessageAttachments } from "./MessageAttachments";
 import { MessageArtifacts } from "./MessageArtifacts";
 import { MessageMarkdown } from "./MessageMarkdown";
 import { TaskAssigneePicker } from "./TaskAssigneePicker";
+
+type WritingSuggestionsTextareaAttrs = TextareaHTMLAttributes<HTMLTextAreaElement> & { "writingsuggestions": "false" };
+
+const disableWritingSuggestionsAttrs: WritingSuggestionsTextareaAttrs = { writingsuggestions: "false" };
 
 function taskStatusLabel(status: string) {
   return status.replace("_", " ");
@@ -1209,6 +1213,7 @@ function ThreadReplyComposer({
         autoCapitalize="none"
         autoComplete="off"
         autoCorrect="off"
+        {...disableWritingSuggestionsAttrs}
         spellCheck={false}
         onChange={(event) => {
           updateText(event.target.value);


### PR DESCRIPTION
## Summary
- Disable browser writing suggestions on the channel composer textarea
- Disable browser writing suggestions on the thread reply textarea

## Verification
- git diff --check
- npm run lint:css-tokens
- npm run build

Note: validation was run from a clean worktree at `/private/tmp/lantor-composer-writing-suggestions` based on latest `origin/main`.