### PR TITLE
Polish attachment tile layout

### DIFF
--- a/scripts/styles-raw-color-baseline.json
+++ b/scripts/styles-raw-color-baseline.json
@@ -693,18 +693,6 @@
       "n": 0
     },
     {
-      "selector": ".message-attachment.image",
-      "prop": "background",
-      "literal": "#eef0f4",
-      "n": 0
-    },
-    {
-      "selector": ".message-attachment.image img",
-      "prop": "background",
-      "literal": "#eef0f4",
-      "n": 0
-    },
-    {
       "selector": ".message-card:hover .message-long-preview.collapsed::after, .message-card.focused .message-long-preview.collapsed::after, .message-card.tap-focused .message-long-preview.collapsed::after, .message-card[data-jump-focused=\"true\"] .message-long-preview.collapsed::after",
       "prop": "background",
       "literal": "rgba(248, 248, 248, 0.98)",

--- a/src/components/MessageAttachments.tsx
+++ b/src/components/MessageAttachments.tsx
@@ -74,7 +74,7 @@ export function MessageAttachments({ attachments, showImageThumbnails }: Message
                 type="button"
                 className={`message-attachment image ${showImageThumbnails ? "" : "compact-image"} ${attachment.local_url ? "pending" : ""}`}
                 aria-label={`Preview ${attachment.original_name}`}
-                title={attachment.original_name}
+                data-attachment-name={attachment.original_name}
                 onPointerDown={isolateAttachmentEvent}
                 onClick={(event) => {
                   event.stopPropagation();
@@ -87,8 +87,9 @@ export function MessageAttachments({ attachments, showImageThumbnails }: Message
                   <>
                     <span className="attachment-icon"><Image size={18} /></span>
                     <span className="attachment-meta">
-                      <span><Image size={13} /> {attachment.original_name}</span>
-                      <small>{attachment.mime_type || "image"} · {formatBytes(attachment.size_bytes)}</small>
+                      <span className="attachment-name">{attachment.original_name}</span>
+                      <small className="attachment-type">{attachment.mime_type || "image"}</small>
+                      <small className="attachment-size">{formatBytes(attachment.size_bytes)}</small>
                     </span>
                   </>
                 )}
@@ -102,7 +103,8 @@ export function MessageAttachments({ attachments, showImageThumbnails }: Message
               href={src}
               target="_blank"
               rel="noreferrer"
-              title={attachment.original_name}
+              aria-label={`Open ${attachment.original_name}`}
+              data-attachment-name={attachment.original_name}
               onPointerDown={isolateAttachmentEvent}
               onClick={(event) => {
                 event.stopPropagation();
@@ -111,8 +113,9 @@ export function MessageAttachments({ attachments, showImageThumbnails }: Message
             >
               <span className="attachment-icon"><FileText size={18} /></span>
               <span className="attachment-meta">
-                <span><FileText size={13} /> {attachment.original_name}</span>
-                <small>{attachment.mime_type || "file"} · {formatBytes(attachment.size_bytes)}</small>
+                <span className="attachment-name">{attachment.original_name}</span>
+                <small className="attachment-type">{attachment.mime_type || "file"}</small>
+                <small className="attachment-size">{formatBytes(attachment.size_bytes)}</small>
               </span>
             </a>
           );

--- a/src/styles.css
+++ b/src/styles.css
@@ -2921,17 +2921,21 @@ mark {
 
 .message-attachments {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(132px, 260px));
+  grid-template-columns: repeat(auto-fit, 112px);
   gap: 8px;
   margin-top: 8px;
 }
 
 .message-attachment {
-  display: grid;
-  grid-template-columns: 34px minmax(0, 1fr);
+  position: relative;
+  display: flex;
+  aspect-ratio: 1;
+  flex-direction: column;
   align-items: center;
-  gap: 9px;
-  min-height: 48px;
+  justify-content: center;
+  gap: 7px;
+  min-width: 0;
+  min-height: 0;
   padding: 8px;
   border: 1px solid var(--line);
   border-radius: 13px;
@@ -2949,19 +2953,17 @@ mark {
   display: block;
   grid-template-columns: none;
   min-height: 0;
-  overflow: hidden;
-  padding: 0;
-  background: #eef0f4;
+  overflow: visible;
+  padding: 3px;
+  background: var(--bg-control-flat);
   cursor: zoom-in;
 }
 
 .message-attachment.image.compact-image {
-  display: grid;
-  grid-template-columns: 34px minmax(0, 1fr);
-  min-height: 48px;
+  display: flex;
   padding: 8px;
   background: var(--bg-control-flat);
-  text-align: left;
+  text-align: center;
 }
 
 .message-attachment.image.compact-image:hover {
@@ -2971,10 +2973,11 @@ mark {
 .message-attachment.image img {
   display: block;
   width: 100%;
-  height: 132px;
-  border-radius: 0;
+  aspect-ratio: 1;
+  height: auto;
+  border-radius: 9px;
   object-fit: cover;
-  background: #eef0f4;
+  background: var(--bg-control-flat);
 }
 
 .message-attachment.image:hover img {
@@ -2987,6 +2990,39 @@ mark {
 
 .message-attachment.pending {
   opacity: 0.78;
+}
+
+.message-attachment[data-attachment-name]::after {
+  position: absolute;
+  right: auto;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  z-index: 20;
+  width: max-content;
+  max-width: min(320px, 70vw);
+  padding: 6px 8px;
+  border: 1px solid var(--border-emphasis);
+  border-radius: 8px;
+  background: var(--surface-tooltip);
+  box-shadow: var(--state-selected-shadow);
+  color: var(--ink-on-tooltip);
+  content: attr(data-attachment-name);
+  font-size: var(--type-size-caption);
+  font-weight: var(--type-weight-medium);
+  line-height: 1.35;
+  opacity: 0;
+  overflow-wrap: anywhere;
+  pointer-events: none;
+  text-align: left;
+  transform: translate(-50%, 3px);
+  transition: opacity 120ms ease, transform 120ms ease;
+  white-space: normal;
+}
+
+.message-attachment[data-attachment-name]:hover::after,
+.message-attachment[data-attachment-name]:focus-visible::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 .attachment-icon {
@@ -3107,14 +3143,14 @@ mark {
 
 .attachment-meta {
   display: grid;
+  width: 100%;
   min-width: 0;
-  gap: 2px;
+  gap: 1px;
+  text-align: left;
 }
 
-.attachment-meta span {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
+.attachment-name {
+  display: block;
   min-width: 0;
   overflow: hidden;
   color: var(--ink);
@@ -3130,6 +3166,16 @@ mark {
   font-size: var(--type-size-caption);
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.attachment-size {
+  overflow: visible;
+  text-align: center;
+  text-overflow: clip;
+}
+
+.attachment-type {
+  text-align: center;
 }
 
 .attachment-lightbox {
@@ -9427,12 +9473,8 @@ body.resizing-column * {
   }
 
   .message-attachments {
-    grid-template-columns: minmax(0, min(58vw, 220px));
+    grid-template-columns: repeat(auto-fit, 96px);
     justify-content: start;
-  }
-
-  .message-attachment.image img {
-    height: 124px;
   }
 
   .task-board {


### PR DESCRIPTION
## Summary
- make attachment tiles square for both thumbnails and compact attachment rows
- split compact metadata into filename, type, and size rows with centered type/size
- replace native filename tooltips with Lantor-styled hover/focus tooltips

## Verification
- npm run build
- npm run lint:css-tokens