### PR TITLE
Add lightbox image zoom

### DIFF
--- a/src/components/DraftAttachmentsPreview.tsx
+++ b/src/components/DraftAttachmentsPreview.tsx
@@ -1,5 +1,5 @@
 import { type MouseEvent, type PointerEvent, useEffect, useState } from "react";
-import { FileText, X } from "lucide-react";
+import { FileText, X, ZoomIn, ZoomOut } from "lucide-react";
 import { DraftAttachment } from "../types";
 
 type DraftAttachmentsPreviewProps = {
@@ -88,20 +88,37 @@ function DraftAttachmentPreviewItem({ attachment, onRemove, onOpenImage }: Draft
 
 export function DraftAttachmentsPreview({ attachments, onRemove }: DraftAttachmentsPreviewProps) {
   const [imagePreview, setImagePreview] = useState<ImagePreview | null>(null);
+  const [imagePreviewZoomed, setImagePreviewZoomed] = useState(false);
 
   function closeImagePreview(event: MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
     event.stopPropagation();
     setImagePreview(null);
+    setImagePreviewZoomed(false);
+  }
+
+  function openImagePreview(preview: ImagePreview) {
+    setImagePreview(preview);
+    setImagePreviewZoomed(false);
+  }
+
+  function toggleImagePreviewZoom(event: MouseEvent<HTMLElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    setImagePreviewZoomed((zoomed) => !zoomed);
   }
 
   useEffect(() => {
     if (!imagePreview) return;
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") setImagePreview(null);
+      if (event.key === "Escape") {
+        setImagePreview(null);
+        setImagePreviewZoomed(false);
+      }
     }
     function handleHistoryNavigation() {
       setImagePreview(null);
+      setImagePreviewZoomed(false);
     }
     window.addEventListener("keydown", handleKeyDown);
     window.addEventListener("popstate", handleHistoryNavigation);
@@ -121,7 +138,7 @@ export function DraftAttachmentsPreview({ attachments, onRemove }: DraftAttachme
             key={attachment.id}
             attachment={attachment}
             onRemove={onRemove}
-            onOpenImage={setImagePreview}
+            onOpenImage={openImagePreview}
           />
         ))}
       </div>
@@ -150,8 +167,26 @@ export function DraftAttachmentsPreview({ attachments, onRemove }: DraftAttachme
           >
             <X size={18} />
           </button>
-          <div className="attachment-lightbox-content">
-            <img src={imagePreview.src} alt={imagePreview.alt} />
+          <button
+            type="button"
+            className="attachment-lightbox-zoom"
+            aria-label={imagePreviewZoomed ? "Fit image to screen" : "View image at full size"}
+            aria-pressed={imagePreviewZoomed}
+            onPointerDown={isolateDraftAttachmentEvent}
+            onClick={toggleImagePreviewZoom}
+          >
+            {imagePreviewZoomed ? <ZoomOut size={18} /> : <ZoomIn size={18} />}
+          </button>
+          <div className={`attachment-lightbox-content ${imagePreviewZoomed ? "zoomed" : ""}`}>
+            <button
+              type="button"
+              className="attachment-lightbox-image-button"
+              aria-label={imagePreviewZoomed ? "Fit image to screen" : "View image at full size"}
+              onPointerDown={isolateDraftAttachmentEvent}
+              onClick={toggleImagePreviewZoom}
+            >
+              <img src={imagePreview.src} alt={imagePreview.alt} />
+            </button>
           </div>
         </div>
       )}

--- a/src/components/MessageAttachments.tsx
+++ b/src/components/MessageAttachments.tsx
@@ -1,5 +1,5 @@
 import { type MouseEvent, type PointerEvent, useEffect, useState } from "react";
-import { FileText, Image, X } from "lucide-react";
+import { FileText, Image, X, ZoomIn, ZoomOut } from "lucide-react";
 import { attachmentAssetUrl, isTauriRuntime, openExternalUrl } from "../apiClient";
 import { MessageAttachment } from "../types";
 
@@ -36,20 +36,37 @@ function isolateAttachmentEvent(event: MouseEvent<HTMLElement> | PointerEvent<HT
 
 export function MessageAttachments({ attachments, showImageThumbnails }: MessageAttachmentsProps) {
   const [imagePreview, setImagePreview] = useState<ImagePreview | null>(null);
+  const [imagePreviewZoomed, setImagePreviewZoomed] = useState(false);
 
   function closeImagePreview(event: MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
     event.stopPropagation();
     setImagePreview(null);
+    setImagePreviewZoomed(false);
+  }
+
+  function openImagePreview(preview: ImagePreview) {
+    setImagePreview(preview);
+    setImagePreviewZoomed(false);
+  }
+
+  function toggleImagePreviewZoom(event: MouseEvent<HTMLElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    setImagePreviewZoomed((zoomed) => !zoomed);
   }
 
   useEffect(() => {
     if (!imagePreview) return;
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") setImagePreview(null);
+      if (event.key === "Escape") {
+        setImagePreview(null);
+        setImagePreviewZoomed(false);
+      }
     }
     function handleHistoryNavigation() {
       setImagePreview(null);
+      setImagePreviewZoomed(false);
     }
     window.addEventListener("keydown", handleKeyDown);
     window.addEventListener("popstate", handleHistoryNavigation);
@@ -78,7 +95,7 @@ export function MessageAttachments({ attachments, showImageThumbnails }: Message
                 onPointerDown={isolateAttachmentEvent}
                 onClick={(event) => {
                   event.stopPropagation();
-                  setImagePreview({ src, alt: attachment.original_name });
+                  openImagePreview({ src, alt: attachment.original_name });
                 }}
               >
                 {showImageThumbnails ? (
@@ -143,8 +160,26 @@ export function MessageAttachments({ attachments, showImageThumbnails }: Message
           >
             <X size={18} />
           </button>
-          <div className="attachment-lightbox-content">
-            <img src={imagePreview.src} alt={imagePreview.alt} />
+          <button
+            type="button"
+            className="attachment-lightbox-zoom"
+            aria-label={imagePreviewZoomed ? "Fit image to screen" : "View image at full size"}
+            aria-pressed={imagePreviewZoomed}
+            onPointerDown={isolateAttachmentEvent}
+            onClick={toggleImagePreviewZoom}
+          >
+            {imagePreviewZoomed ? <ZoomOut size={18} /> : <ZoomIn size={18} />}
+          </button>
+          <div className={`attachment-lightbox-content ${imagePreviewZoomed ? "zoomed" : ""}`}>
+            <button
+              type="button"
+              className="attachment-lightbox-image-button"
+              aria-label={imagePreviewZoomed ? "Fit image to screen" : "View image at full size"}
+              onPointerDown={isolateAttachmentEvent}
+              onClick={toggleImagePreviewZoom}
+            >
+              <img src={imagePreview.src} alt={imagePreview.alt} />
+            </button>
           </div>
         </div>
       )}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3154,9 +3154,30 @@ mark {
   position: relative;
   z-index: 1;
   display: grid;
+  overflow: auto;
   max-width: min(92vw, 1120px);
   max-height: calc(100dvh - 104px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
   place-items: center;
+}
+
+.attachment-lightbox-content.zoomed {
+  width: calc(100vw - 32px);
+  max-width: none;
+  place-items: start center;
+  padding: 16px;
+}
+
+.attachment-lightbox-image-button {
+  display: block;
+  min-width: 0;
+  padding: 0;
+  border-radius: 18px;
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.attachment-lightbox-content.zoomed .attachment-lightbox-image-button {
+  cursor: zoom-out;
 }
 
 .attachment-lightbox-content img {
@@ -3166,6 +3187,11 @@ mark {
   border-radius: 18px;
   box-shadow: 0 28px 80px rgba(0, 0, 0, 0.34);
   object-fit: contain;
+}
+
+.attachment-lightbox-content.zoomed .attachment-lightbox-image-button img {
+  max-width: none;
+  max-height: none;
 }
 
 .attachment-lightbox-close {
@@ -3181,6 +3207,21 @@ mark {
   background: rgba(255, 255, 255, 0.92);
   color: #111827;
   box-shadow: 0 10px 26px rgba(0, 0, 0, 0.2);
+}
+
+.attachment-lightbox-zoom {
+  position: absolute;
+  top: calc(56px + env(safe-area-inset-top));
+  right: 14px;
+  z-index: 2;
+  display: inline-grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 999px;
+  background: var(--surface-floating);
+  color: var(--ink-primary);
+  box-shadow: var(--state-selected-shadow);
 }
 
 .message-stream-state {


### PR DESCRIPTION
## Summary
- add fit/full-size zoom state to message attachment lightboxes
- add the same zoom behavior for draft attachment previews
- allow zoomed images to render at original size with scrollable lightbox content

## Verification
- npm run build
- npm run lint:css-tokens