### PR TITLE
Make modals dismissible

### DIFF
--- a/src/components/ActivityFeedModal.tsx
+++ b/src/components/ActivityFeedModal.tsx
@@ -221,9 +221,6 @@ export function ActivityFeedModal({
     <div className="search-backdrop" onClick={onClose}>
       <section className="activity-feed-panel activity-panel" onClick={(event) => event.stopPropagation()}>
         <header className="activity-feed-head">
-          <button className="activity-feed-back" onClick={onClose} aria-label="Close activity">
-            <X size={18} />
-          </button>
           <div>
             <h2>Activity</h2>
             <p>{displayItems.length} active · {unreadCount} unread</p>
@@ -244,6 +241,9 @@ export function ActivityFeedModal({
               Dismiss all
             </button>
           </div>
+          <button className="activity-feed-back" onClick={onClose} aria-label="Close activity">
+            <X size={18} />
+          </button>
         </header>
 
         <div className="activity-feed-filters">

--- a/src/components/AgentFormModal.tsx
+++ b/src/components/AgentFormModal.tsx
@@ -201,8 +201,6 @@ export function AgentFormModal({
       title={title}
       onClose={onCancel}
       width={700}
-      closeOnBackdrop={false}
-      closeOnEscape={false}
     >
       <div className="modal-form agent-modal-form">
         {createMode ? (

--- a/src/components/ChannelSettingsModal.tsx
+++ b/src/components/ChannelSettingsModal.tsx
@@ -28,8 +28,6 @@ export function ChannelSettingsModal({
       title={channel ? `#${channel.name} Settings` : "Channel Settings"}
       onClose={onCancel}
       width={560}
-      closeOnBackdrop={false}
-      closeOnEscape={false}
     >
       {channel && (
         <div className="modal-form">

--- a/src/components/CreateChannelModal.tsx
+++ b/src/components/CreateChannelModal.tsx
@@ -55,8 +55,6 @@ export function CreateChannelModal({
       title="Create Channel"
       onClose={submitting ? () => undefined : onCancel}
       width={560}
-      closeOnBackdrop={false}
-      closeOnEscape={false}
     >
       <div className="modal-form">
         <label>

--- a/src/components/OwnerProfileModal.tsx
+++ b/src/components/OwnerProfileModal.tsx
@@ -57,8 +57,6 @@ export function OwnerProfileModal({
       title="Edit Profile"
       onClose={onCancel}
       width={560}
-      closeOnBackdrop={false}
-      closeOnEscape={false}
     >
       <div className="modal-form owner-profile-form">
         <div className="owner-profile-preview">

--- a/src/components/ReminderModal.tsx
+++ b/src/components/ReminderModal.tsx
@@ -91,8 +91,6 @@ export function ReminderModal({
       title="Reminders"
       onClose={onClose}
       width={880}
-      closeOnBackdrop={false}
-      closeOnEscape={false}
     >
       <div className="reminder-modal">
         <section className="reminder-create">

--- a/src/components/SavedMessagesModal.tsx
+++ b/src/components/SavedMessagesModal.tsx
@@ -38,13 +38,13 @@ export function SavedMessagesModal({
     <div className="search-backdrop" onClick={onClose}>
       <section className="activity-feed-panel saved-panel" onClick={(event) => event.stopPropagation()}>
         <header className="activity-feed-head">
-          <button className="activity-feed-back" onClick={onClose} aria-label="Close saved messages">
-            <X size={18} />
-          </button>
           <div>
             <h2>Saved</h2>
             <p>{items.length} saved {items.length === 1 ? "message" : "messages"}</p>
           </div>
+          <button className="activity-feed-back" onClick={onClose} aria-label="Close saved messages">
+            <X size={18} />
+          </button>
         </header>
 
         <div className="activity-feed-body">

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -134,6 +134,9 @@ export function SearchModal({
               <X size={18} />
             </button>
           )}
+          <button className="search-clear search-modal-close" onClick={onClose} aria-label="Close search">
+            <X size={18} />
+          </button>
         </header>
 
         <div className="search-filters">

--- a/src/styles.css
+++ b/src/styles.css
@@ -7957,7 +7957,7 @@ body.resizing-column * {
 
 .search-panel-head {
   display: grid;
-  grid-template-columns: 52px minmax(0, 1fr) auto;
+  grid-template-columns: 52px minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 12px;
   padding: 18px 20px;
@@ -8644,7 +8644,7 @@ body.resizing-column * {
 
 .activity-feed-head {
   display: grid;
-  grid-template-columns: 48px minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 14px;
   padding: 18px 20px;
@@ -10037,7 +10037,7 @@ body.resizing-column * {
 
   .search-panel-head {
     order: 4;
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) auto auto;
     gap: 8px;
     min-height: 64px;
     padding: 10px 12px calc(92px + env(safe-area-inset-bottom));
@@ -10130,7 +10130,7 @@ body.resizing-column * {
   }
 
   .activity-feed-head {
-    grid-template-columns: 42px minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) auto auto;
     gap: 10px;
     min-height: 64px;
     padding: calc(10px + env(safe-area-inset-top)) 12px 10px;


### PR DESCRIPTION
## Summary
- allow form modals to use the shared backdrop and Escape dismissal behavior
- add a visible close button to the search modal header
- update search header layout so clear and close controls can coexist

## Verification
- npm run build
- npm run lint:css-tokens