### PR TITLE
Add thread expand and fold controls

### DIFF
--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowLeft, Bookmark, CheckCircle2, Crosshair, Hash, MessageSquare, Paperclip, RotateCcw, Send, X } from "lucide-react";
+import { ArrowDown, ArrowLeft, Bookmark, CheckCircle2, Crosshair, Hash, Maximize2, MessageSquare, Minimize2, Paperclip, RotateCcw, Send, X } from "lucide-react";
 import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type TextareaHTMLAttributes, type WheelEvent as ReactWheelEvent } from "react";
 import { useAutoGrowTextarea } from "../hooks/useAutoGrowTextarea";
 import { useMentionPicker } from "../hooks/useMentionPicker";
@@ -166,6 +166,17 @@ export function ThreadPanel({
       : `Thread in #${channel.name}`
     : `${APP_DISPLAY_NAME} thread`;
   const lastReply = replies[replies.length - 1] ?? null;
+  const collapsibleThreadMessageIds = useMemo(() => {
+    const messages = activeRoot ? [activeRoot, ...replies] : replies;
+    return messages
+      .filter((message) => message.delivery_state !== "streaming" && shouldCollapseThreadMessage(message.body))
+      .map((message) => message.id);
+  }, [activeRoot, replies]);
+  const hasCollapsibleThreadMessages = collapsibleThreadMessageIds.length > 0;
+  const areAllThreadMessagesExpanded = hasCollapsibleThreadMessages
+    && collapsibleThreadMessageIds.every((messageId) => expandedThreadMessageIds.has(messageId));
+  const areAllThreadMessagesFolded = hasCollapsibleThreadMessages
+    && collapsibleThreadMessageIds.every((messageId) => !expandedThreadMessageIds.has(messageId));
 
   function isThreadScrollAtBottom(element: HTMLDivElement) {
     return threadScrollDistanceFromBottom(element) < 32;
@@ -420,6 +431,20 @@ export function ThreadPanel({
     });
   }
 
+  function expandAllThreadMessages() {
+    if (!hasCollapsibleThreadMessages || areAllThreadMessagesExpanded) return;
+    stopFollowingThread();
+    setPendingCollapsedThreadMessageId(null);
+    setExpandedThreadMessageIds(new Set(collapsibleThreadMessageIds));
+  }
+
+  function foldAllThreadMessages() {
+    if (!hasCollapsibleThreadMessages || areAllThreadMessagesFolded) return;
+    stopFollowingThread();
+    setPendingCollapsedThreadMessageId(null);
+    setExpandedThreadMessageIds(new Set());
+  }
+
   const activeTaskAssignee = activeTask
     ? agents.find((agent) => agent.id === activeTask.assignee_id) ?? null
     : null;
@@ -471,6 +496,28 @@ export function ThreadPanel({
           </h2>
         </div>
         <span className="thread-header-actions">
+          <button
+            type="button"
+            className="thread-expand-all"
+            onClick={expandAllThreadMessages}
+            aria-disabled={!hasCollapsibleThreadMessages || areAllThreadMessagesExpanded}
+            data-tooltip="Expand all messages in this thread"
+            title="Expand all messages in this thread"
+            aria-label="Expand all messages in this thread"
+          >
+            <Maximize2 size={18} />
+          </button>
+          <button
+            type="button"
+            className="thread-fold-all"
+            onClick={foldAllThreadMessages}
+            aria-disabled={!hasCollapsibleThreadMessages || areAllThreadMessagesFolded}
+            data-tooltip="Fold all messages in this thread"
+            title="Fold all messages in this thread"
+            aria-label="Fold all messages in this thread"
+          >
+            <Minimize2 size={18} />
+          </button>
           <button
             type="button"
             className="thread-locate-root"

--- a/src/styles.css
+++ b/src/styles.css
@@ -1896,7 +1896,12 @@ button,
   position: relative;
 }
 
-.thread-header-actions button[data-tooltip]:not(:disabled)::after {
+.thread-header-actions button[aria-disabled="true"] {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.thread-header-actions button[data-tooltip]::after {
   position: absolute;
   top: calc(100% + 8px);
   right: 0;
@@ -1919,7 +1924,7 @@ button,
   white-space: nowrap;
 }
 
-.thread-header-actions button[data-tooltip]:not(:disabled)::before {
+.thread-header-actions button[data-tooltip]::before {
   position: absolute;
   top: calc(100% + 3px);
   right: 15px;
@@ -1936,16 +1941,16 @@ button,
     transform 60ms ease;
 }
 
-.thread-header-actions button[data-tooltip]:not(:disabled):hover::after,
-.thread-header-actions button[data-tooltip]:not(:disabled):focus-visible::after,
-.thread-header-actions button[data-tooltip]:not(:disabled):hover::before,
-.thread-header-actions button[data-tooltip]:not(:disabled):focus-visible::before {
+.thread-header-actions button[data-tooltip]:hover::after,
+.thread-header-actions button[data-tooltip]:focus-visible::after,
+.thread-header-actions button[data-tooltip]:hover::before,
+.thread-header-actions button[data-tooltip]:focus-visible::before {
   opacity: 1;
   transform: translateY(0);
 }
 
-.thread-header-actions button[data-tooltip]:not(:disabled):hover::before,
-.thread-header-actions button[data-tooltip]:not(:disabled):focus-visible::before {
+.thread-header-actions button[data-tooltip]:hover::before,
+.thread-header-actions button[data-tooltip]:focus-visible::before {
   transform: translateY(0) rotate(45deg);
 }
 


### PR DESCRIPTION
## Summary
- add thread header controls to expand or fold all collapsible messages in the active thread
- use outward/inward arrow icons and keep tooltips visible for inactive controls

## Validation
- npm run build