### PR TITLE
Add thread SVG export and attachment downloads

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -79,7 +79,7 @@ use lifecycle_commands::{
     install_supervisor_service, start_agent, stop_agent, uninstall_supervisor_service,
 };
 use runtime::supervisor::run_supervisor;
-use system_commands::{check_runtime, open_external_url};
+use system_commands::{check_runtime, download_attachment, open_external_url};
 use ui_notifications::{spawn_ui_events_pruner, spawn_ui_refresh_listener};
 
 const WINDOW_STATE_FILE: &str = "window-state.json";
@@ -357,6 +357,7 @@ pub fn run() {
             mark_all_inbox_read,
             mark_channel_read,
             open_dm_with_agent,
+            download_attachment,
             open_external_url,
             retry_agent_work,
             send_message,

--- a/src-tauri/src/system_commands.rs
+++ b/src-tauri/src/system_commands.rs
@@ -1,5 +1,6 @@
 use std::{
-    path::Path,
+    fs,
+    path::{Path, PathBuf},
     process::{Command as StdCommand, Stdio},
 };
 
@@ -8,6 +9,7 @@ use crate::{
     db::expand_home_path,
     models::RuntimeCheck,
 };
+use tauri::Manager;
 
 #[derive(Debug, PartialEq, Eq)]
 enum OpenLinkTarget {
@@ -285,6 +287,78 @@ pub(crate) async fn open_external_url(url: String) -> CommandResult<()> {
     tauri::async_runtime::spawn_blocking(move || open_link_target(&target))
         .await
         .map_err(to_string)?
+}
+
+fn safe_download_filename(value: &str) -> String {
+    let name = Path::new(value)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("attachment")
+        .trim();
+    let sanitized: String = name
+        .chars()
+        .map(|character| match character {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            character if character.is_control() => '_',
+            character => character,
+        })
+        .collect();
+    let sanitized = sanitized.trim_matches(['.', ' ']);
+    if sanitized.is_empty() {
+        "attachment".to_owned()
+    } else {
+        sanitized.to_owned()
+    }
+}
+
+fn unique_download_path(downloads_dir: &Path, filename: &str) -> PathBuf {
+    let initial = downloads_dir.join(filename);
+    if !initial.exists() {
+        return initial;
+    }
+
+    let source = Path::new(filename);
+    let stem = source
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("attachment");
+    let extension = source.extension().and_then(|value| value.to_str());
+    for index in 1..1000 {
+        let candidate_name = match extension {
+            Some(extension) if !extension.is_empty() => format!("{stem} ({index}).{extension}"),
+            _ => format!("{stem} ({index})"),
+        };
+        let candidate = downloads_dir.join(candidate_name);
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    downloads_dir.join(format!("{stem} ({})", uuid::Uuid::new_v4()))
+}
+
+#[tauri::command]
+pub(crate) async fn download_attachment(
+    app: tauri::AppHandle,
+    storage_path: String,
+    original_name: String,
+) -> CommandResult<String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let source = PathBuf::from(expand_home_path(&storage_path));
+        if !source.is_file() {
+            return Err(format!(
+                "attachment file does not exist: {}",
+                source.display()
+            ));
+        }
+        let downloads_dir = app.path().download_dir().map_err(to_string)?;
+        fs::create_dir_all(&downloads_dir).map_err(to_string)?;
+        let filename = safe_download_filename(&original_name);
+        let target = unique_download_path(&downloads_dir, &filename);
+        fs::copy(&source, &target).map_err(to_string)?;
+        Ok(target.to_string_lossy().to_string())
+    })
+    .await
+    .map_err(to_string)?
 }
 
 #[tauri::command]

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -21,6 +21,13 @@ export async function openExternalUrl(url: string): Promise<void> {
   window.open(url, "_blank", "noopener,noreferrer");
 }
 
+export async function downloadAttachment(storagePath: string, originalName: string): Promise<string> {
+  if (!isTauriRuntime()) {
+    throw new Error("downloadAttachment is only available in the desktop app");
+  }
+  return tauriInvoke<string>("download_attachment", { storagePath, originalName });
+}
+
 function apiPath(command: string) {
   return `/api/${command}`;
 }

--- a/src/components/MessageAttachments.tsx
+++ b/src/components/MessageAttachments.tsx
@@ -1,6 +1,6 @@
 import { type MouseEvent, type PointerEvent, useEffect, useState } from "react";
-import { FileText, Image, X, ZoomIn, ZoomOut } from "lucide-react";
-import { attachmentAssetUrl, isTauriRuntime, openExternalUrl } from "../apiClient";
+import { Download, FileText, Image, X, ZoomIn, ZoomOut } from "lucide-react";
+import { attachmentAssetUrl, downloadAttachment, isTauriRuntime, openExternalUrl } from "../apiClient";
 import { MessageAttachment } from "../types";
 
 type MessageAttachmentsProps = {
@@ -11,6 +11,7 @@ type MessageAttachmentsProps = {
 type ImagePreview = {
   src: string;
   alt: string;
+  attachment: MessageAttachment;
 };
 
 function formatBytes(value: number) {
@@ -28,6 +29,35 @@ async function openStoredAttachment(event: MouseEvent<HTMLAnchorElement>, attach
   } catch (error) {
     console.error("Failed to open attachment", error);
   }
+}
+
+async function downloadStoredAttachment(event: MouseEvent<HTMLElement>, attachment: MessageAttachment) {
+  event.preventDefault();
+  event.stopPropagation();
+
+  if (!attachment.local_url && isTauriRuntime()) {
+    try {
+      await downloadAttachment(attachment.storage_path, attachment.original_name);
+    } catch (error) {
+      console.error("Failed to download attachment", error);
+    }
+    return;
+  }
+
+  triggerBrowserDownload(
+    attachment.local_url ?? attachmentAssetUrl(attachment.storage_path, attachment.id),
+    attachment.original_name,
+  );
+}
+
+function triggerBrowserDownload(url: string, filename: string) {
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.rel = "noreferrer";
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
 }
 
 function isolateAttachmentEvent(event: MouseEvent<HTMLElement> | PointerEvent<HTMLElement>) {
@@ -86,55 +116,87 @@ export function MessageAttachments({ attachments, showImageThumbnails }: Message
           const isImage = attachment.mime_type.startsWith("image/");
           if (isImage) {
             return (
-              <button
+              <div
                 key={attachment.id}
-                type="button"
                 className={`message-attachment image ${showImageThumbnails ? "" : "compact-image"} ${attachment.local_url ? "pending" : ""}`}
-                aria-label={`Preview ${attachment.original_name}`}
                 data-attachment-name={attachment.original_name}
                 onPointerDown={isolateAttachmentEvent}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  openImagePreview({ src, alt: attachment.original_name });
-                }}
               >
-                {showImageThumbnails ? (
-                  <img src={src} alt="" loading="lazy" />
-                ) : (
-                  <>
-                    <span className="attachment-icon"><Image size={18} /></span>
-                    <span className="attachment-meta">
-                      <span className="attachment-name">{attachment.original_name}</span>
-                      <small className="attachment-type">{attachment.mime_type || "image"}</small>
-                      <small className="attachment-size">{formatBytes(attachment.size_bytes)}</small>
-                    </span>
-                  </>
-                )}
-              </button>
+                <button
+                  type="button"
+                  className="attachment-preview-trigger"
+                  aria-label={`Preview ${attachment.original_name}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    openImagePreview({ src, alt: attachment.original_name, attachment });
+                  }}
+                >
+                  {showImageThumbnails ? (
+                    <img src={src} alt="" loading="lazy" />
+                  ) : (
+                    <>
+                      <span className="attachment-icon"><Image size={18} /></span>
+                      <span className="attachment-meta">
+                        <span className="attachment-name">{attachment.original_name}</span>
+                        <small className="attachment-type">{attachment.mime_type || "image"}</small>
+                        <small className="attachment-size">{formatBytes(attachment.size_bytes)}</small>
+                      </span>
+                    </>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  className="attachment-download"
+                  aria-label={`Download ${attachment.original_name}`}
+                  title={`Download ${attachment.original_name}`}
+                  onPointerDown={isolateAttachmentEvent}
+                  onClick={(event) => {
+                    void downloadStoredAttachment(event, attachment);
+                  }}
+                >
+                  <Download size={15} />
+                </button>
+              </div>
             );
           }
           return (
-            <a
+            <div
               key={attachment.id}
               className={`message-attachment ${attachment.local_url ? "pending" : ""}`}
-              href={src}
-              target="_blank"
-              rel="noreferrer"
-              aria-label={`Open ${attachment.original_name}`}
               data-attachment-name={attachment.original_name}
               onPointerDown={isolateAttachmentEvent}
-              onClick={(event) => {
-                event.stopPropagation();
-                void openStoredAttachment(event, attachment);
-              }}
             >
-              <span className="attachment-icon"><FileText size={18} /></span>
-              <span className="attachment-meta">
-                <span className="attachment-name">{attachment.original_name}</span>
-                <small className="attachment-type">{attachment.mime_type || "file"}</small>
-                <small className="attachment-size">{formatBytes(attachment.size_bytes)}</small>
-              </span>
-            </a>
+              <a
+                className="attachment-open"
+                href={src}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={`Open ${attachment.original_name}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  void openStoredAttachment(event, attachment);
+                }}
+              >
+                <span className="attachment-icon"><FileText size={18} /></span>
+                <span className="attachment-meta">
+                  <span className="attachment-name">{attachment.original_name}</span>
+                  <small className="attachment-type">{attachment.mime_type || "file"}</small>
+                  <small className="attachment-size">{formatBytes(attachment.size_bytes)}</small>
+                </span>
+              </a>
+              <button
+                type="button"
+                className="attachment-download"
+                aria-label={`Download ${attachment.original_name}`}
+                title={`Download ${attachment.original_name}`}
+                onPointerDown={isolateAttachmentEvent}
+                onClick={(event) => {
+                  void downloadStoredAttachment(event, attachment);
+                }}
+              >
+                <Download size={15} />
+              </button>
+            </div>
           );
         })}
       </div>
@@ -172,6 +234,18 @@ export function MessageAttachments({ attachments, showImageThumbnails }: Message
             onClick={toggleImagePreviewZoom}
           >
             {imagePreviewZoomed ? <ZoomOut size={18} /> : <ZoomIn size={18} />}
+          </button>
+          <button
+            type="button"
+            className="attachment-lightbox-download"
+            aria-label={`Download ${imagePreview.alt}`}
+            title={`Download ${imagePreview.alt}`}
+            onPointerDown={isolateAttachmentEvent}
+            onClick={(event) => {
+              void downloadStoredAttachment(event, imagePreview.attachment);
+            }}
+          >
+            <Download size={18} />
           </button>
           <div className={`attachment-lightbox-content ${imagePreviewZoomed ? "zoomed" : ""}`}>
             <button

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowLeft, Bookmark, CheckCircle2, Crosshair, Hash, Maximize2, MessageSquare, Minimize2, Paperclip, RotateCcw, Send, X } from "lucide-react";
+import { ArrowDown, ArrowLeft, Bookmark, CheckCircle2, Crosshair, FileImage, Hash, Maximize2, MessageSquare, Minimize2, Paperclip, RotateCcw, Send, X } from "lucide-react";
 import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type TextareaHTMLAttributes, type WheelEvent as ReactWheelEvent } from "react";
 import { useAutoGrowTextarea } from "../hooks/useAutoGrowTextarea";
 import { useMentionPicker } from "../hooks/useMentionPicker";
@@ -10,6 +10,7 @@ import { copyText } from "../clipboard";
 import { isCompactFollowupMessage, wasEdited } from "../message-grouping";
 import { DESKTOP_MESSAGE_PREVIEW_CHARS, DESKTOP_MESSAGE_PREVIEW_LINES } from "../message-preview";
 import { messageShareLink, messageToMarkdown } from "../message-share";
+import { downloadThreadPanelSvg } from "../thread-svg-export";
 import { Agent, AgentActivity, AgentRun, AgentWorkItem, Artifact, Channel, DraftAttachment, Message, OwnerProfile, TASK_STATUSES, Task } from "../types";
 import { agentForMessageSender, deletedAgentForMessageSender, formatClockTime, formatDateDivider, formatTime, isSameCalendarDay, ownerAsAvatarAgent, visibleAgentDescription, visibleChannelDescription } from "../ui-utils";
 import { ActivityProgressDock } from "./ActivityProgressDock";
@@ -58,6 +59,12 @@ function shouldCollapseThreadMessage(body: string) {
   const text = body.trim();
   if (!text) return false;
   return text.split("\n").length > DESKTOP_MESSAGE_PREVIEW_LINES || text.length > DESKTOP_MESSAGE_PREVIEW_CHARS;
+}
+
+function waitForNextFrame() {
+  return new Promise<void>((resolve) => {
+    window.requestAnimationFrame(() => resolve());
+  });
 }
 
 type ThreadPanelProps = {
@@ -143,6 +150,7 @@ export function ThreadPanel({
   const [tapFocusedMessageId, setTapFocusedMessageId] = useState<string | null>(null);
   const [expandedThreadMessageIds, setExpandedThreadMessageIds] = useState<Set<string>>(() => new Set());
   const [pendingCollapsedThreadMessageId, setPendingCollapsedThreadMessageId] = useState<string | null>(null);
+  const threadPanelRef = useRef<HTMLElement | null>(null);
   const threadScrollRef = useRef<HTMLDivElement | null>(null);
   const threadBottomAnchorRef = useRef<HTMLDivElement | null>(null);
   const threadMessageRefs = useRef(new Map<string, HTMLElement>());
@@ -445,6 +453,24 @@ export function ThreadPanel({
     setExpandedThreadMessageIds(new Set());
   }
 
+  async function exportThreadVectorImage() {
+    const threadPanel = threadPanelRef.current;
+    if (!activeRoot || !threadPanel) return;
+    const previousExpandedMessageIds = new Set(expandedThreadMessageIds);
+    const shouldTemporarilyExpand = collapsibleThreadMessageIds.some((messageId) => !previousExpandedMessageIds.has(messageId));
+    if (shouldTemporarilyExpand) {
+      setPendingCollapsedThreadMessageId(null);
+      setExpandedThreadMessageIds(new Set(collapsibleThreadMessageIds));
+      await waitForNextFrame();
+      await waitForNextFrame();
+    }
+    try {
+      await downloadThreadPanelSvg(threadPanel, surfaceLabel);
+    } finally {
+      if (shouldTemporarilyExpand) setExpandedThreadMessageIds(previousExpandedMessageIds);
+    }
+  }
+
   const activeTaskAssignee = activeTask
     ? agents.find((agent) => agent.id === activeTask.assignee_id) ?? null
     : null;
@@ -472,7 +498,7 @@ export function ThreadPanel({
   const showTaskReviewActions = Boolean(activeTask && activeTask.status === "in_review" && latestFinishedTaskWorkItem?.status === "done");
 
   return (
-    <aside className="thread">
+    <aside className="thread" ref={threadPanelRef}>
       <button
         className="thread-resize-handle"
         aria-label="Resize thread panel"
@@ -496,6 +522,17 @@ export function ThreadPanel({
           </h2>
         </div>
         <span className="thread-header-actions">
+          <button
+            type="button"
+            className="thread-export-svg"
+            onClick={exportThreadVectorImage}
+            aria-disabled={!activeRoot}
+            data-tooltip="Export thread as SVG"
+            title="Export thread as SVG"
+            aria-label="Export thread as SVG"
+          >
+            <FileImage size={18} />
+          </button>
           <button
             type="button"
             className="thread-expand-all"

--- a/src/styles.css
+++ b/src/styles.css
@@ -2933,20 +2933,17 @@ mark {
 
 .message-attachment {
   position: relative;
-  display: flex;
+  display: grid;
   aspect-ratio: 1;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
   min-width: 0;
   min-height: 0;
-  padding: 8px;
+  padding: 0;
   border: 1px solid var(--line);
   border-radius: 13px;
   background: rgba(255, 255, 255, 0.72);
   color: var(--ink);
   text-decoration: none;
+  overflow: visible;
 }
 
 .message-attachment:hover {
@@ -2955,7 +2952,6 @@ mark {
 }
 
 .message-attachment.image {
-  display: block;
   grid-template-columns: none;
   min-height: 0;
   overflow: visible;
@@ -2965,10 +2961,40 @@ mark {
 }
 
 .message-attachment.image.compact-image {
-  display: flex;
   padding: 8px;
   background: var(--bg-control-flat);
   text-align: center;
+}
+
+.attachment-open,
+.attachment-preview-trigger {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 8px;
+  border-radius: 12px;
+  background: transparent;
+  color: inherit;
+  text-decoration: none;
+}
+
+.attachment-preview-trigger {
+  height: 100%;
+  cursor: zoom-in;
+}
+
+.message-attachment.image:not(.compact-image) .attachment-preview-trigger {
+  display: block;
+  padding: 0;
+}
+
+.message-attachment.image.compact-image .attachment-preview-trigger {
+  padding: 0;
 }
 
 .message-attachment.image.compact-image:hover {
@@ -2991,6 +3017,38 @@ mark {
 
 .message-attachment.image.compact-image:hover img {
   filter: none;
+}
+
+.attachment-download {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 2;
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface-floating);
+  color: var(--ink-primary);
+  box-shadow: var(--state-selected-shadow);
+  opacity: 0.94;
+  transform: none;
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.message-attachment:hover .attachment-download,
+.message-attachment:focus-within .attachment-download {
+  opacity: 1;
+  transform: none;
+}
+
+.attachment-download:hover,
+.attachment-download:focus-visible {
+  border-color: rgba(10, 132, 255, 0.32);
+  color: var(--accent);
+  outline: none;
 }
 
 .message-attachment.pending {
@@ -3245,9 +3303,10 @@ mark {
   max-height: none;
 }
 
-.attachment-lightbox-close {
+.attachment-lightbox-close,
+.attachment-lightbox-download,
+.attachment-lightbox-zoom {
   position: absolute;
-  top: calc(14px + env(safe-area-inset-top));
   right: 14px;
   z-index: 2;
   display: inline-grid;
@@ -3260,16 +3319,19 @@ mark {
   box-shadow: 0 10px 26px rgba(0, 0, 0, 0.2);
 }
 
+.attachment-lightbox-close {
+  top: calc(14px + env(safe-area-inset-top));
+}
+
 .attachment-lightbox-zoom {
-  position: absolute;
   top: calc(56px + env(safe-area-inset-top));
-  right: 14px;
-  z-index: 2;
-  display: inline-grid;
-  width: 34px;
-  height: 34px;
-  place-items: center;
-  border-radius: 999px;
+  background: var(--surface-floating);
+  color: var(--ink-primary);
+  box-shadow: var(--state-selected-shadow);
+}
+
+.attachment-lightbox-download {
+  top: calc(98px + env(safe-area-inset-top));
   background: var(--surface-floating);
   color: var(--ink-primary);
   box-shadow: var(--state-selected-shadow);

--- a/src/thread-svg-export.ts
+++ b/src/thread-svg-export.ts
@@ -1,0 +1,274 @@
+const XHTML_NS = "http://www.w3.org/1999/xhtml";
+const CANVAS_PADDING_X = 48;
+const CANVAS_PADDING_Y = 36;
+const CONTENT_BOTTOM_SPACER_HEIGHT = 16;
+
+function escapeXml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function fileSafeName(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80) || "thread";
+}
+
+function collectDocumentCss() {
+  const chunks: string[] = [];
+  for (const sheet of Array.from(document.styleSheets)) {
+    try {
+      for (const rule of Array.from(sheet.cssRules)) {
+        chunks.push(rule.cssText);
+      }
+    } catch {
+      // Ignore cross-origin sheets. Lantor's own Vite CSS is same-origin.
+    }
+  }
+  return chunks.join("\n");
+}
+
+function makeScrollableContentVisible(clone: HTMLElement, panelWidth: number) {
+  clone.style.width = `${panelWidth}px`;
+  clone.style.minWidth = `${panelWidth}px`;
+  clone.style.maxWidth = `${panelWidth}px`;
+  clone.style.margin = "0";
+  clone.style.position = "relative";
+  clone.style.inset = "auto";
+  clone.style.transform = "none";
+  clone.style.display = "block";
+  clone.style.height = "auto";
+  clone.style.maxHeight = "none";
+  clone.style.minHeight = "0";
+  clone.style.overflow = "visible";
+
+  const selectors = [
+    ".thread-focus",
+    ".thread-scroll-shell",
+    ".thread-scroll",
+    ".reply-list",
+    ".task-execution-timeline",
+  ];
+  for (const selector of selectors) {
+    clone.querySelectorAll<HTMLElement>(selector).forEach((element) => {
+      element.style.height = "auto";
+      element.style.maxHeight = "none";
+      element.style.minHeight = "0";
+      element.style.overflow = "visible";
+    });
+  }
+}
+
+function removeTransientUi(clone: HTMLElement) {
+  const selectors = [
+    ".thread-resize-handle",
+    ".thread-back-to-bottom",
+    ".thread-progress-layer",
+    ".message-hover-actions",
+    ".mobile-message-save-tag",
+    ".message-expand-button",
+    ".reply-composer",
+  ];
+  for (const selector of selectors) {
+    clone.querySelectorAll(selector).forEach((element) => element.remove());
+  }
+}
+
+function addExportBottomSpacer(clone: HTMLElement) {
+  const spacer = document.createElement("div");
+  spacer.setAttribute("aria-hidden", "true");
+  spacer.setAttribute("data-thread-export-spacer", "true");
+  spacer.style.height = `${CONTENT_BOTTOM_SPACER_HEIGHT}px`;
+  spacer.style.minHeight = `${CONTENT_BOTTOM_SPACER_HEIGHT}px`;
+  spacer.style.pointerEvents = "none";
+  const target = clone.querySelector<HTMLElement>(".thread-scroll") ?? clone;
+  target.append(spacer);
+}
+
+function serializeThreadElement(source: HTMLElement) {
+  const panelWidth = Math.max(360, Math.ceil(source.getBoundingClientRect().width));
+  const clone = source.cloneNode(true) as HTMLElement;
+  makeScrollableContentVisible(clone, panelWidth);
+  removeTransientUi(clone);
+  addExportBottomSpacer(clone);
+  clone.setAttribute("data-exported-thread", "true");
+  return { clone, panelWidth };
+}
+
+async function waitForRenderableAssets(source: HTMLElement) {
+  const fontReady = "fonts" in document
+    ? document.fonts.ready.catch(() => undefined)
+    : Promise.resolve();
+  const imageReady = Array.from(source.querySelectorAll("img")).map(async (image) => {
+    if (image.complete && image.naturalWidth > 0) return;
+    try {
+      await image.decode();
+    } catch {
+      // Broken or cross-origin images should not block export.
+    }
+  });
+  await Promise.all([fontReady, ...imageReady]);
+}
+
+function buildDocumentExportOverrides(panelWidth: number) {
+  return `
+      html,
+      body {
+        margin: 0;
+        width: ${panelWidth}px;
+        min-width: ${panelWidth}px;
+        overflow: visible;
+        background: var(--bg-panel);
+      }
+    `;
+}
+
+function buildThreadExportOverrides(panelWidth: number) {
+  return `
+      .thread[data-exported-thread="true"] {
+        position: relative !important;
+        inset: auto !important;
+        grid-column: auto !important;
+        grid-row: auto !important;
+        width: ${panelWidth}px !important;
+        min-width: ${panelWidth}px !important;
+        max-width: ${panelWidth}px !important;
+        height: auto !important;
+        min-height: 0 !important;
+        margin: 0 !important;
+        overflow: visible !important;
+        container-type: normal !important;
+        transform: none !important;
+      }
+
+      .thread[data-exported-thread="true"] .thread-focus,
+      .thread[data-exported-thread="true"] .thread-scroll-shell,
+      .thread[data-exported-thread="true"] .thread-scroll,
+      .thread[data-exported-thread="true"] .reply-list,
+      .thread[data-exported-thread="true"] .task-execution-timeline {
+        display: block !important;
+        height: auto !important;
+        max-height: none !important;
+        min-height: 0 !important;
+        overflow: visible !important;
+      }
+
+      .thread[data-exported-thread="true"] .thread-progress-layer,
+      .thread[data-exported-thread="true"] .thread-back-to-bottom,
+      .thread[data-exported-thread="true"] .thread-resize-handle,
+      .thread[data-exported-thread="true"] .message-hover-actions,
+      .thread[data-exported-thread="true"] .mobile-message-save-tag,
+      .thread[data-exported-thread="true"] .message-expand-button,
+      .thread[data-exported-thread="true"] .reply-composer {
+        display: none !important;
+      }
+    `;
+}
+
+function buildExportStyles(panelWidth: number, options: { includeDocumentRules: boolean }) {
+  return [
+    collectDocumentCss(),
+    options.includeDocumentRules ? buildDocumentExportOverrides(panelWidth) : "",
+    buildThreadExportOverrides(panelWidth),
+  ].join("\n");
+}
+
+function exportedDocumentMarkup(clone: HTMLElement, panelWidth: number) {
+  const wrapper = document.createElement("div");
+  wrapper.setAttribute("xmlns", XHTML_NS);
+  wrapper.style.width = `${panelWidth}px`;
+  wrapper.style.minWidth = `${panelWidth}px`;
+  wrapper.style.maxWidth = `${panelWidth}px`;
+  wrapper.style.margin = "0";
+  wrapper.style.overflow = "visible";
+  const style = document.createElement("style");
+  style.textContent = buildExportStyles(panelWidth, { includeDocumentRules: true });
+  wrapper.append(style, clone);
+  return new XMLSerializer().serializeToString(wrapper);
+}
+
+function measureExportHeight(clone: HTMLElement, panelWidth: number) {
+  const measuringHost = document.createElement("div");
+  measuringHost.style.position = "fixed";
+  measuringHost.style.left = "-100000px";
+  measuringHost.style.top = "0";
+  measuringHost.style.width = `${panelWidth}px`;
+  measuringHost.style.minWidth = `${panelWidth}px`;
+  measuringHost.style.overflow = "visible";
+  measuringHost.style.pointerEvents = "none";
+  const style = document.createElement("style");
+  style.textContent = buildExportStyles(panelWidth, { includeDocumentRules: false });
+  measuringHost.append(style, clone.cloneNode(true));
+  document.body.appendChild(measuringHost);
+  const exportedThread = measuringHost.querySelector<HTMLElement>(".thread[data-exported-thread='true']");
+  const threadRect = exportedThread?.getBoundingClientRect();
+  let contentBottom = threadRect?.bottom || 0;
+  if (exportedThread && threadRect) {
+    exportedThread.querySelectorAll<HTMLElement>("*").forEach((element) => {
+      const styles = getComputedStyle(element);
+      if (styles.display === "none" || styles.visibility === "hidden") return;
+      const rect = element.getBoundingClientRect();
+      contentBottom = Math.max(contentBottom, rect.bottom);
+    });
+  }
+  const measuredHeight = threadRect
+    ? Math.max(exportedThread?.scrollHeight || 0, exportedThread?.offsetHeight || 0, contentBottom - threadRect.top)
+    : 0;
+  const height = Math.max(240, Math.ceil(measuredHeight));
+  measuringHost.remove();
+  return height;
+}
+
+function svgCanvasFill() {
+  const styles = getComputedStyle(document.body);
+  return styles.backgroundColor && styles.backgroundColor !== "rgba(0, 0, 0, 0)"
+    ? styles.backgroundColor
+    : getComputedStyle(document.documentElement).backgroundColor || "transparent";
+}
+
+function assertValidSvg(svg: string) {
+  const parsed = new DOMParser().parseFromString(svg, "image/svg+xml");
+  const parserError = parsed.querySelector("parsererror");
+  if (parserError) {
+    throw new Error(`Thread SVG export produced invalid XML: ${parserError.textContent || "parsererror"}`);
+  }
+}
+
+function downloadSvg(svg: string, surfaceLabel: string) {
+  assertValidSvg(svg);
+  const blob = new Blob([svg], { type: "image/svg+xml;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `${fileSafeName(surfaceLabel)}.svg`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+export async function downloadThreadPanelSvg(source: HTMLElement, surfaceLabel: string) {
+  await waitForRenderableAssets(source);
+  const { clone, panelWidth } = serializeThreadElement(source);
+  const panelHeight = measureExportHeight(clone, panelWidth);
+  const serializedThread = exportedDocumentMarkup(clone, panelWidth);
+  const canvasWidth = panelWidth + CANVAS_PADDING_X * 2;
+  const canvasHeight = panelHeight + CANVAS_PADDING_Y * 2;
+  const canvasFill = escapeXml(svgCanvasFill());
+
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${canvasWidth}" height="${canvasHeight}" viewBox="0 0 ${canvasWidth} ${canvasHeight}" role="img" aria-label="${escapeXml(surfaceLabel)}" style="display:block;margin-inline:auto;">
+  <rect width="100%" height="100%" fill="${canvasFill}"/>
+  <foreignObject x="${CANVAS_PADDING_X}" y="${CANVAS_PADDING_Y}" width="${panelWidth}" height="${panelHeight}">
+    ${serializedThread}
+  </foreignObject>
+</svg>
+`;
+  downloadSvg(svg, surfaceLabel);
+}


### PR DESCRIPTION
## Summary
- add a thread header action to export the current thread as an SVG that clones the rendered thread panel, expands collapsed messages for export, centers the panel on a padded canvas, and removes transient UI/reply composer controls
- harden SVG export by serializing XML safely, validating the SVG before download, waiting for fonts/images before measuring, using a real bottom spacer, and avoiding global html/body style injection during measurement
- add download controls for message attachments on attachment cards and image lightboxes
- add a Tauri `download_attachment` command that copies stored attachments to the user Downloads directory so desktop downloads do not rely on `<a download>` for asset URLs

## Verification
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`

## Notes
- Created from a clean worktree based on `origin/main`; unrelated local changes from `martin/modal-dismiss-controls` were not included.
- `cargo check` emits the existing `inbox_wake_context` dead-code warning.
