### PR TITLE
Add desktop attachment download feedback

### DIFF
--- a/scripts/styles-raw-color-baseline.json
+++ b/scripts/styles-raw-color-baseline.json
@@ -273,24 +273,6 @@
       "n": 0
     },
     {
-      "selector": ".attachment-lightbox-close",
-      "prop": "background",
-      "literal": "rgba(255, 255, 255, 0.92)",
-      "n": 0
-    },
-    {
-      "selector": ".attachment-lightbox-close",
-      "prop": "box-shadow",
-      "literal": "rgba(0, 0, 0, 0.2)",
-      "n": 0
-    },
-    {
-      "selector": ".attachment-lightbox-close",
-      "prop": "color",
-      "literal": "#111827",
-      "n": 0
-    },
-    {
       "selector": ".attachment-lightbox-content img",
       "prop": "box-shadow",
       "literal": "rgba(0, 0, 0, 0.34)",

--- a/src/components/MessageAttachments.tsx
+++ b/src/components/MessageAttachments.tsx
@@ -14,10 +14,25 @@ type ImagePreview = {
   attachment: MessageAttachment;
 };
 
+type DownloadNotice = {
+  id: number;
+  kind: "success" | "error";
+  message: string;
+};
+
 function formatBytes(value: number) {
   if (value < 1024) return `${value} B`;
   if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
   return `${(value / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function filenameFromPath(path: string, fallback: string) {
+  const normalized = path.replace(/\\/g, "/");
+  return normalized.split("/").pop() || fallback;
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error || "Unknown error");
 }
 
 async function openStoredAttachment(event: MouseEvent<HTMLAnchorElement>, attachment: MessageAttachment) {
@@ -31,15 +46,27 @@ async function openStoredAttachment(event: MouseEvent<HTMLAnchorElement>, attach
   }
 }
 
-async function downloadStoredAttachment(event: MouseEvent<HTMLElement>, attachment: MessageAttachment) {
+async function downloadStoredAttachment(
+  event: MouseEvent<HTMLElement>,
+  attachment: MessageAttachment,
+  onNotice: (notice: Omit<DownloadNotice, "id">) => void,
+) {
   event.preventDefault();
   event.stopPropagation();
 
   if (!attachment.local_url && isTauriRuntime()) {
     try {
-      await downloadAttachment(attachment.storage_path, attachment.original_name);
+      const targetPath = await downloadAttachment(attachment.storage_path, attachment.original_name);
+      onNotice({
+        kind: "success",
+        message: `Saved to Downloads: ${filenameFromPath(targetPath, attachment.original_name)}`,
+      });
     } catch (error) {
       console.error("Failed to download attachment", error);
+      onNotice({
+        kind: "error",
+        message: `Download failed: ${errorMessage(error)}`,
+      });
     }
     return;
   }
@@ -67,6 +94,14 @@ function isolateAttachmentEvent(event: MouseEvent<HTMLElement> | PointerEvent<HT
 export function MessageAttachments({ attachments, showImageThumbnails }: MessageAttachmentsProps) {
   const [imagePreview, setImagePreview] = useState<ImagePreview | null>(null);
   const [imagePreviewZoomed, setImagePreviewZoomed] = useState(false);
+  const [downloadNotice, setDownloadNotice] = useState<DownloadNotice | null>(null);
+
+  function showDownloadNotice(notice: Omit<DownloadNotice, "id">) {
+    setDownloadNotice({
+      ...notice,
+      id: Date.now(),
+    });
+  }
 
   function closeImagePreview(event: MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
@@ -105,6 +140,14 @@ export function MessageAttachments({ attachments, showImageThumbnails }: Message
       window.removeEventListener("popstate", handleHistoryNavigation);
     };
   }, [imagePreview]);
+
+  useEffect(() => {
+    if (!downloadNotice) return;
+    const timeout = window.setTimeout(() => {
+      setDownloadNotice((current) => current?.id === downloadNotice.id ? null : current);
+    }, downloadNotice.kind === "error" ? 6000 : 3600);
+    return () => window.clearTimeout(timeout);
+  }, [downloadNotice]);
 
   if (attachments.length === 0) return null;
 
@@ -151,7 +194,7 @@ export function MessageAttachments({ attachments, showImageThumbnails }: Message
                   title={`Download ${attachment.original_name}`}
                   onPointerDown={isolateAttachmentEvent}
                   onClick={(event) => {
-                    void downloadStoredAttachment(event, attachment);
+                    void downloadStoredAttachment(event, attachment, showDownloadNotice);
                   }}
                 >
                   <Download size={15} />
@@ -191,7 +234,7 @@ export function MessageAttachments({ attachments, showImageThumbnails }: Message
                 title={`Download ${attachment.original_name}`}
                 onPointerDown={isolateAttachmentEvent}
                 onClick={(event) => {
-                  void downloadStoredAttachment(event, attachment);
+                  void downloadStoredAttachment(event, attachment, showDownloadNotice);
                 }}
               >
                 <Download size={15} />
@@ -242,7 +285,7 @@ export function MessageAttachments({ attachments, showImageThumbnails }: Message
             title={`Download ${imagePreview.alt}`}
             onPointerDown={isolateAttachmentEvent}
             onClick={(event) => {
-              void downloadStoredAttachment(event, imagePreview.attachment);
+              void downloadStoredAttachment(event, imagePreview.attachment, showDownloadNotice);
             }}
           >
             <Download size={18} />
@@ -258,6 +301,12 @@ export function MessageAttachments({ attachments, showImageThumbnails }: Message
               <img src={imagePreview.src} alt={imagePreview.alt} />
             </button>
           </div>
+        </div>
+      )}
+      {downloadNotice && (
+        <div className={`app-toast attachment-download-toast ${downloadNotice.kind}`} role={downloadNotice.kind === "error" ? "alert" : "status"}>
+          <span>{downloadNotice.message}</span>
+          <button type="button" onClick={() => setDownloadNotice(null)} aria-label="Dismiss download notification">Dismiss</button>
         </div>
       )}
     </>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3046,7 +3046,7 @@ mark {
 
 .attachment-download:hover,
 .attachment-download:focus-visible {
-  border-color: rgba(10, 132, 255, 0.32);
+  border-color: var(--accent-soft-hover-border);
   color: var(--accent);
   outline: none;
 }
@@ -3314,9 +3314,9 @@ mark {
   height: 34px;
   place-items: center;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.92);
-  color: #111827;
-  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.2);
+  background: var(--surface-floating);
+  color: var(--ink-primary);
+  box-shadow: var(--state-selected-shadow);
 }
 
 .attachment-lightbox-close {
@@ -3325,16 +3325,10 @@ mark {
 
 .attachment-lightbox-zoom {
   top: calc(56px + env(safe-area-inset-top));
-  background: var(--surface-floating);
-  color: var(--ink-primary);
-  box-shadow: var(--state-selected-shadow);
 }
 
 .attachment-lightbox-download {
   top: calc(98px + env(safe-area-inset-top));
-  background: var(--surface-floating);
-  color: var(--ink-primary);
-  box-shadow: var(--state-selected-shadow);
 }
 
 .message-stream-state {
@@ -6469,6 +6463,23 @@ body.resizing-column * {
   color: #4f5560;
   font-size: var(--type-size-meta);
   font-weight: var(--type-weight-semibold);
+}
+
+.app-toast.success {
+  border-color: var(--status-success-border);
+  background: color-mix(in srgb, var(--status-success-soft) 72%, var(--surface-floating));
+  color: var(--status-success);
+}
+
+.app-toast.error {
+  border-color: var(--status-danger-border);
+  background: color-mix(in srgb, var(--status-danger-soft) 72%, var(--surface-floating));
+  color: var(--status-danger);
+}
+
+.attachment-download-toast {
+  bottom: 80px;
+  z-index: 1300;
 }
 
 .agent-detail {


### PR DESCRIPTION
## Summary
- show success feedback after desktop attachment downloads finish copying to Downloads
- show failure feedback with the command error when desktop downloads fail
- keep browser/blob downloads on native browser download UI without duplicate toast
- tokenized the attachment/lightbox download styles and refreshed the raw-color baseline after removing stale fingerprints

## Verification
- npm run build
- npm run lint:css-tokens
- Playwright web smoke test: opened a message with attachments, clicked a download button, confirmed native browser download started and no attachment toast appeared in the web path