### PR TITLE
Prototype animated startup splash

### DIFF
--- a/public/splashscreen.html
+++ b/public/splashscreen.html
@@ -1,0 +1,355 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lantor</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --surface: #f0f3f7;
+        --surface-floating: #fbfcfd;
+        --ink: #20242b;
+        --muted: #68717d;
+        --line: rgba(32, 36, 44, 0.1);
+        --line-strong: rgba(32, 36, 44, 0.16);
+        --accent: #0a84ff;
+        --accent-soft: rgba(10, 132, 255, 0.1);
+        --accent-border: rgba(10, 132, 255, 0.28);
+        --selected:
+          linear-gradient(180deg, rgba(10, 132, 255, 0.13), rgba(10, 132, 255, 0.07)),
+          rgba(240, 243, 247, 0.92);
+        --shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.82),
+          0 1px 2px rgba(20, 23, 31, 0.05);
+        --shadow-active:
+          inset 0 0 0 1px rgba(10, 132, 255, 0.24),
+          0 1px 2px rgba(20, 23, 31, 0.05);
+        font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --surface: #222a35;
+          --surface-floating: #303844;
+          --ink: #f4f6fa;
+          --muted: #b3bdcc;
+          --line: rgba(226, 232, 240, 0.18);
+          --line-strong: rgba(226, 232, 240, 0.3);
+          --accent: #69aafc;
+          --accent-soft: rgba(105, 170, 252, 0.14);
+          --accent-border: rgba(105, 170, 252, 0.28);
+          --selected:
+            linear-gradient(180deg, rgba(105, 170, 252, 0.17), rgba(105, 170, 252, 0.09)),
+            rgba(43, 51, 63, 0.95);
+          --shadow:
+            inset 0 1px 0 rgba(255, 255, 255, 0.08),
+            0 1px 2px rgba(0, 0, 0, 0.18);
+          --shadow-active:
+            inset 0 0 0 1px rgba(105, 170, 252, 0.28),
+            0 1px 2px rgba(0, 0, 0, 0.18);
+        }
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        display: grid;
+        min-height: 100vh;
+        margin: 0;
+        place-items: center;
+        overflow: hidden;
+        background:
+          linear-gradient(var(--line) 1px, transparent 1px),
+          linear-gradient(90deg, var(--line) 1px, transparent 1px),
+          var(--surface);
+        background-size: 42px 42px;
+        color: var(--ink);
+      }
+
+      .shell {
+        display: grid;
+        width: 440px;
+        min-height: 430px;
+        place-items: center;
+        align-content: center;
+        gap: 22px;
+        padding: 34px;
+        text-align: center;
+      }
+
+      .constellation {
+        position: relative;
+        display: grid;
+        width: 240px;
+        aspect-ratio: 1;
+        place-items: center;
+      }
+
+      .orbit,
+      .core {
+        position: absolute;
+        inset: 0;
+        display: grid;
+        place-items: center;
+      }
+
+      .orbit {
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        animation: orbit 2400ms ease-in-out infinite;
+      }
+
+      .core {
+        inset: 58px;
+        border: 1px solid var(--line-strong);
+        border-radius: 28px;
+        background: var(--surface-floating);
+        box-shadow: var(--shadow);
+        animation: core 1800ms ease-in-out infinite;
+      }
+
+      .mark {
+        display: grid;
+        width: 70px;
+        height: 70px;
+        place-items: center;
+        border-radius: 22px;
+        background: var(--selected);
+        color: var(--accent);
+        font-size: 34px;
+        font-weight: 700;
+      }
+
+      .node {
+        position: absolute;
+        z-index: 2;
+        display: grid;
+        width: 34px;
+        height: 34px;
+        place-items: center;
+        border: 1px solid var(--line-strong);
+        border-radius: 999px;
+        background: var(--surface-floating);
+        box-shadow: var(--shadow);
+        color: var(--ink);
+        font-size: 12px;
+        font-weight: 700;
+        animation: node 2400ms ease-in-out infinite;
+      }
+
+      .node-d {
+        top: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+      }
+
+      .node-b {
+        top: 88px;
+        right: 6px;
+        animation-delay: 180ms;
+      }
+
+      .node-a {
+        right: 44px;
+        bottom: 24px;
+        animation-delay: 360ms;
+      }
+
+      .node-m {
+        bottom: 56px;
+        left: 8px;
+        animation-delay: 540ms;
+      }
+
+      .link {
+        position: absolute;
+        z-index: 1;
+        height: 1px;
+        border-radius: 999px;
+        background: linear-gradient(90deg, transparent, var(--accent), transparent);
+        opacity: 0;
+        transform-origin: left center;
+        animation: link 2400ms ease-in-out infinite;
+      }
+
+      .link-one {
+        top: 78px;
+        left: 110px;
+        width: 96px;
+        transform: rotate(30deg);
+      }
+
+      .link-two {
+        top: 150px;
+        left: 132px;
+        width: 74px;
+        transform: rotate(112deg);
+        animation-delay: 300ms;
+      }
+
+      .link-three {
+        top: 160px;
+        left: 54px;
+        width: 100px;
+        transform: rotate(-32deg);
+        animation-delay: 600ms;
+      }
+
+      .copy {
+        display: grid;
+        width: 100%;
+        min-height: 62px;
+        gap: 8px;
+        place-items: center;
+      }
+
+      strong {
+        font-size: 28px;
+        line-height: 1;
+      }
+
+      .status {
+        position: relative;
+        width: 260px;
+        min-height: 20px;
+        color: var(--muted);
+        font-size: 14px;
+        font-weight: 500;
+        line-height: 1.4;
+        white-space: nowrap;
+      }
+
+      .status span {
+        position: absolute;
+        inset: 0;
+        opacity: 0;
+        transform: translateY(8px);
+        animation: status 3600ms ease-in-out infinite;
+      }
+
+      .status span:nth-child(2) {
+        animation-delay: 1200ms;
+      }
+
+      .status span:nth-child(3) {
+        animation-delay: 2400ms;
+      }
+
+      @keyframes orbit {
+        0%,
+        100% {
+          border-color: var(--line);
+          box-shadow: none;
+        }
+        50% {
+          border-color: var(--accent-border);
+          box-shadow: 0 0 0 8px var(--accent-soft);
+        }
+      }
+
+      @keyframes core {
+        0%,
+        100% {
+          transform: scale(1);
+          box-shadow: var(--shadow);
+        }
+        50% {
+          transform: scale(1.035);
+          box-shadow: var(--shadow-active);
+        }
+      }
+
+      @keyframes node {
+        0%,
+        100% {
+          border-color: var(--line-strong);
+          color: var(--ink);
+        }
+        45% {
+          border-color: var(--accent-border);
+          color: var(--accent);
+        }
+      }
+
+      @keyframes link {
+        0%,
+        20%,
+        100% {
+          opacity: 0;
+          clip-path: inset(0 100% 0 0);
+        }
+        45%,
+        68% {
+          opacity: 0.74;
+          clip-path: inset(0 0 0 0);
+        }
+      }
+
+      @keyframes status {
+        0%,
+        100% {
+          opacity: 0;
+          transform: translateY(8px);
+        }
+        10%,
+        30% {
+          opacity: 1;
+          transform: translateY(0);
+        }
+        42% {
+          opacity: 0;
+          transform: translateY(-8px);
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .orbit,
+        .core,
+        .node,
+        .link,
+        .status span {
+          animation: none;
+        }
+
+        .status span:first-child {
+          opacity: 1;
+          transform: none;
+        }
+
+        .link {
+          opacity: 0.42;
+          clip-path: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell" aria-label="Starting Lantor">
+      <div class="constellation" aria-hidden="true">
+        <div class="orbit">
+          <span class="node node-d">D</span>
+          <span class="node node-b">B</span>
+          <span class="node node-a">A</span>
+          <span class="node node-m">M</span>
+          <span class="link link-one"></span>
+          <span class="link link-two"></span>
+          <span class="link link-three"></span>
+        </div>
+        <div class="core">
+          <span class="mark">L</span>
+        </div>
+      </div>
+      <div class="copy">
+        <strong>Lantor</strong>
+        <div class="status">
+          <span>Waking agents...</span>
+          <span>Restoring workspace...</span>
+          <span>Syncing threads...</span>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/scripts/styles-raw-color-baseline.json
+++ b/scripts/styles-raw-color-baseline.json
@@ -285,36 +285,6 @@
       "n": 0
     },
     {
-      "selector": ".boot",
-      "prop": "color",
-      "literal": "#777",
-      "n": 0
-    },
-    {
-      "selector": ".boot-panel button",
-      "prop": "background",
-      "literal": "#1d4ed8",
-      "n": 0
-    },
-    {
-      "selector": ".boot-panel button",
-      "prop": "color",
-      "literal": "#fff",
-      "n": 0
-    },
-    {
-      "selector": ".boot-panel p",
-      "prop": "color",
-      "literal": "#b42318",
-      "n": 0
-    },
-    {
-      "selector": ".boot-panel strong",
-      "prop": "color",
-      "literal": "#23252b",
-      "n": 0
-    },
-    {
       "selector": ".channel-actions-menu",
       "prop": "box-shadow",
       "literal": "rgba(20, 22, 28, 0.18)",

--- a/src-tauri/src/agent_inbox_wake.rs
+++ b/src-tauri/src/agent_inbox_wake.rs
@@ -463,6 +463,7 @@ fn inbox_wake_work_item_title(items: &[InboxWakeItem]) -> String {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn inbox_wake_context(
     items: &[InboxWakeItem],
     other_active: &[InboxWakeSummary],

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -79,7 +79,9 @@ use lifecycle_commands::{
     install_supervisor_service, start_agent, stop_agent, uninstall_supervisor_service,
 };
 use runtime::supervisor::run_supervisor;
-use system_commands::{check_runtime, download_attachment, open_external_url};
+use system_commands::{
+    check_runtime, complete_startup_splash, download_attachment, open_external_url,
+};
 use ui_notifications::{spawn_ui_events_pruner, spawn_ui_refresh_listener};
 
 const WINDOW_STATE_FILE: &str = "window-state.json";
@@ -357,6 +359,7 @@ pub fn run() {
             mark_all_inbox_read,
             mark_channel_read,
             open_dm_with_agent,
+            complete_startup_splash,
             download_attachment,
             open_external_url,
             retry_agent_work,

--- a/src-tauri/src/system_commands.rs
+++ b/src-tauri/src/system_commands.rs
@@ -362,6 +362,18 @@ pub(crate) async fn download_attachment(
 }
 
 #[tauri::command]
+pub(crate) async fn complete_startup_splash(app: tauri::AppHandle) -> CommandResult<()> {
+    if let Some(window) = app.get_webview_window("main") {
+        window.show().map_err(to_string)?;
+        let _ = window.set_focus();
+    }
+    if let Some(splashscreen) = app.get_webview_window("splashscreen") {
+        splashscreen.close().map_err(to_string)?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
 pub(crate) async fn check_runtime(runtime: String) -> CommandResult<RuntimeCheck> {
     check_runtime_in_env(runtime).await
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,6 +12,7 @@
   "app": {
     "windows": [
       {
+        "label": "main",
         "title": "Lantor",
         "width": 1440,
         "height": 920,
@@ -19,6 +20,20 @@
         "minHeight": 760,
         "center": true,
         "resizable": true,
+        "visible": false,
+        "dragDropEnabled": false
+      },
+      {
+        "label": "splashscreen",
+        "title": "Lantor",
+        "url": "splashscreen.html",
+        "width": 520,
+        "height": 520,
+        "center": true,
+        "decorations": false,
+        "resizable": false,
+        "skipTaskbar": true,
+        "visible": true,
         "dragDropEnabled": false
       }
     ],

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -28,6 +28,11 @@ export async function downloadAttachment(storagePath: string, originalName: stri
   return tauriInvoke<string>("download_attachment", { storagePath, originalName });
 }
 
+export async function completeStartupSplash(): Promise<void> {
+  if (!isTauriRuntime()) return;
+  await tauriInvoke("complete_startup_splash");
+}
+
 function apiPath(command: string) {
   return `/api/${command}`;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -144,6 +144,7 @@ const MIN_COMPACT_SIDEBAR_VISIBLE_WIDTH = 220;
 const MOBILE_BREAKPOINT = 760;
 const UI_REFRESH_DEBOUNCE_MS = 80;
 const EPHEMERAL_FLUSH_FALLBACK_MS = 80;
+const MIN_BOOT_SPLASH_MS = 1400;
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 const ACTIVITY_HISTORY_LIMIT_PER_AGENT = 80;
 // Issue #82: run states that must bypass the ephemeral coalescing buffer
@@ -688,6 +689,8 @@ function buildAgentPerformance(activities: AgentActivity[], runs: AgentRun[]): A
 }
 
 function App() {
+  const [bootStartedAt] = useState(() => performance.now());
+  const [bootReady, setBootReady] = useState(false);
   const [data, setData] = useState<Bootstrap | null>(null);
   const [activeChannelId, setActiveChannelId] = useState<string>("");
   const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
@@ -1360,6 +1363,14 @@ function App() {
       console.error(err);
     });
   }, []);
+
+  useEffect(() => {
+    if (!data || bootReady) return;
+    const elapsed = performance.now() - bootStartedAt;
+    const delay = Math.max(0, MIN_BOOT_SPLASH_MS - elapsed);
+    const timer = window.setTimeout(() => setBootReady(true), delay);
+    return () => window.clearTimeout(timer);
+  }, [bootReady, bootStartedAt, data]);
 
   useEffect(() => {
     if (!data || showOwnerProfileModal) return;
@@ -3635,7 +3646,7 @@ function App() {
     await mutate("uninstall_supervisor_service");
   }
 
-  if (!data) {
+  if (!data || !bootReady) {
     return (
       <BootSplash
         appError={appError}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,7 +14,7 @@ import {
 } from "react";
 import { createRoot } from "react-dom/client";
 import { Bookmark, Home, Inbox, Search } from "lucide-react";
-import { apiInvoke, isTauriRuntime, subscribeBackendEvents } from "./apiClient";
+import { apiInvoke, completeStartupSplash, isTauriRuntime, subscribeBackendEvents } from "./apiClient";
 import { APP_DISPLAY_NAME } from "./branding";
 import { AgentDetailDrawer } from "./components/AgentDetailDrawer";
 import type { AgentPerformance } from "./components/AgentDetailDrawer";
@@ -691,6 +691,7 @@ function buildAgentPerformance(activities: AgentActivity[], runs: AgentRun[]): A
 function App() {
   const [bootStartedAt] = useState(() => performance.now());
   const [bootReady, setBootReady] = useState(false);
+  const startupSplashCompletedRef = useRef(false);
   const [data, setData] = useState<Bootstrap | null>(null);
   const [activeChannelId, setActiveChannelId] = useState<string>("");
   const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
@@ -1365,12 +1366,20 @@ function App() {
   }, []);
 
   useEffect(() => {
-    if (!data || bootReady) return;
+    if ((!data && !appError) || bootReady) return;
     const elapsed = performance.now() - bootStartedAt;
     const delay = Math.max(0, MIN_BOOT_SPLASH_MS - elapsed);
     const timer = window.setTimeout(() => setBootReady(true), delay);
     return () => window.clearTimeout(timer);
-  }, [bootReady, bootStartedAt, data]);
+  }, [appError, bootReady, bootStartedAt, data]);
+
+  useEffect(() => {
+    if (!bootReady || (!data && !appError) || startupSplashCompletedRef.current) return;
+    startupSplashCompletedRef.current = true;
+    completeStartupSplash().catch((err) => {
+      console.error("Failed to complete startup splash", err);
+    });
+  }, [appError, bootReady, data]);
 
   useEffect(() => {
     if (!data || showOwnerProfileModal) return;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -334,6 +334,51 @@ function errorMessage(err: unknown, fallback: string) {
   return fallback;
 }
 
+function BootSplash({ appError, onRetry }: { appError: string | null; onRetry: () => void }) {
+  const statuses = [
+    "Waking agents...",
+    "Restoring workspace...",
+    "Syncing threads...",
+  ];
+
+  return (
+    <div className="boot" aria-live="polite">
+      <div className="boot-panel">
+        <div className="boot-constellation" aria-hidden="true">
+          <div className="boot-orbit">
+            <span className="boot-node node-dylan">D</span>
+            <span className="boot-node node-bugen">B</span>
+            <span className="boot-node node-admin">A</span>
+            <span className="boot-node node-owner">M</span>
+            <span className="boot-link link-one" />
+            <span className="boot-link link-two" />
+            <span className="boot-link link-three" />
+          </div>
+          <div className="boot-core">
+            <span className="boot-core-mark">L</span>
+          </div>
+        </div>
+        <div className="boot-copy">
+          <strong>{APP_DISPLAY_NAME}</strong>
+          <div className="boot-status" aria-label={statuses.join(" ")}>
+            {statuses.map((status, index) => (
+              <span key={status} style={{ "--status-index": index } as CSSProperties}>{status}</span>
+            ))}
+          </div>
+        </div>
+        {appError ? (
+          <div className="boot-error" role="alert">
+            <p>{appError}</p>
+            <button type="button" onClick={onRetry}>
+              Retry
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 class AppErrorBoundary extends Component<{ children: ReactNode }, AppErrorBoundaryState> {
   state: AppErrorBoundaryState = { error: null, info: null };
 
@@ -3592,19 +3637,10 @@ function App() {
 
   if (!data) {
     return (
-      <div className="boot">
-        <div className="boot-panel">
-          <strong>Opening {APP_DISPLAY_NAME}...</strong>
-          {appError ? (
-            <>
-              <p>{appError}</p>
-              <button type="button" onClick={() => refreshWithError(`Failed to load ${APP_DISPLAY_NAME} state`)}>
-                Retry
-              </button>
-            </>
-          ) : null}
-        </div>
-      </div>
+      <BootSplash
+        appError={appError}
+        onRetry={() => refreshWithError(`Failed to load ${APP_DISPLAY_NAME} state`)}
+      />
     );
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -88,28 +88,199 @@ button,
 }
 
 .boot {
+  position: relative;
   display: grid;
   min-height: 100vh;
   place-items: center;
-  color: #777;
+  overflow: hidden;
+  background:
+    linear-gradient(var(--border-subtle) 1px, transparent 1px),
+    linear-gradient(90deg, var(--border-subtle) 1px, transparent 1px),
+    var(--surface-app);
+  background-size: 42px 42px;
+  color: var(--ink);
 }
 
 .boot-panel {
   display: grid;
-  gap: 10px;
-  max-width: 520px;
-  padding: 20px;
+  width: min(440px, calc(100vw - 48px));
+  min-height: 430px;
+  place-items: center;
+  align-content: center;
+  gap: 22px;
+  padding: 34px;
   text-align: center;
 }
 
+.boot-constellation {
+  position: relative;
+  display: grid;
+  width: 240px;
+  aspect-ratio: 1;
+  place-items: center;
+}
+
+.boot-orbit,
+.boot-core {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+}
+
+.boot-orbit {
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  animation: bootOrbit 2400ms ease-in-out infinite;
+}
+
+.boot-core {
+  inset: 58px;
+  border: 1px solid var(--border-emphasis);
+  border-radius: 28px;
+  background: var(--surface-floating);
+  box-shadow: var(--state-selected-shadow);
+  animation: bootCore 1800ms ease-in-out infinite;
+}
+
+.boot-core-mark {
+  display: grid;
+  width: 70px;
+  height: 70px;
+  place-items: center;
+  border-radius: 22px;
+  background: var(--state-selected-emphasis);
+  color: var(--accent);
+  font-size: 34px;
+  font-weight: var(--type-weight-bold);
+  letter-spacing: 0;
+}
+
+.boot-node {
+  position: absolute;
+  z-index: 2;
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: 1px solid var(--border-emphasis);
+  border-radius: 999px;
+  background: var(--surface-floating);
+  box-shadow: var(--state-selected-shadow);
+  color: var(--ink-primary);
+  font-size: var(--type-size-meta);
+  font-weight: var(--type-weight-bold);
+  animation: bootNode 2400ms ease-in-out infinite;
+}
+
+.node-dylan {
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.node-bugen {
+  top: 88px;
+  right: 6px;
+  animation-delay: 180ms;
+}
+
+.node-admin {
+  bottom: 24px;
+  right: 44px;
+  animation-delay: 360ms;
+}
+
+.node-owner {
+  bottom: 56px;
+  left: 8px;
+  animation-delay: 540ms;
+}
+
+.boot-link {
+  position: absolute;
+  z-index: 1;
+  height: 1px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+  opacity: 0;
+  transform-origin: left center;
+  animation: bootLink 2400ms ease-in-out infinite;
+}
+
+.link-one {
+  top: 78px;
+  left: 110px;
+  width: 96px;
+  transform: rotate(30deg);
+}
+
+.link-two {
+  top: 150px;
+  left: 132px;
+  width: 74px;
+  transform: rotate(112deg);
+  animation-delay: 300ms;
+}
+
+.link-three {
+  top: 160px;
+  left: 54px;
+  width: 100px;
+  transform: rotate(-32deg);
+  animation-delay: 600ms;
+}
+
+.boot-copy {
+  display: grid;
+  width: 100%;
+  gap: 8px;
+  min-height: 62px;
+  place-items: center;
+}
+
 .boot-panel strong {
-  color: #23252b;
-  font-size: var(--type-size-message);
+  color: var(--ink-primary);
+  font-size: 28px;
+  font-weight: var(--type-weight-bold);
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.boot-status {
+  position: relative;
+  width: min(260px, calc(100vw - 80px));
+  min-height: 20px;
+  color: var(--ink-muted);
+  font-size: var(--type-size-body);
+  font-weight: var(--type-weight-medium);
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.boot-status span {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transform: translateY(8px);
+  animation: bootStatus 3600ms ease-in-out infinite;
+  animation-delay: calc(var(--status-index) * 1200ms);
+}
+
+.boot-error {
+  display: grid;
+  gap: 10px;
+  width: 100%;
+  max-width: 360px;
+  padding: 12px;
+  border: 1px solid var(--status-danger-border);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--status-danger-soft) 72%, var(--surface-floating));
 }
 
 .boot-panel p {
   margin: 0;
-  color: #b42318;
+  color: var(--status-danger);
   font-size: var(--type-size-body);
   line-height: 1.5;
 }
@@ -118,10 +289,97 @@ button,
   justify-self: center;
   padding: 8px 14px;
   border-radius: 8px;
-  background: #1d4ed8;
-  color: #fff;
+  background: var(--accent);
+  color: var(--ink-on-accent);
   font-size: var(--type-size-body);
   font-weight: var(--type-weight-semibold);
+}
+
+@keyframes bootOrbit {
+  0%,
+  100% {
+    border-color: var(--border-subtle);
+    box-shadow: none;
+  }
+  50% {
+    border-color: var(--accent-soft-border);
+    box-shadow: 0 0 0 8px var(--accent-soft);
+  }
+}
+
+@keyframes bootCore {
+  0%,
+  100% {
+    transform: scale(1);
+    box-shadow: var(--state-selected-shadow);
+  }
+  50% {
+    transform: scale(1.035);
+    box-shadow: var(--state-selected-emphasis-shadow);
+  }
+}
+
+@keyframes bootNode {
+  0%,
+  100% {
+    color: var(--ink-primary);
+    border-color: var(--border-emphasis);
+  }
+  45% {
+    color: var(--accent);
+    border-color: var(--accent-soft-hover-border);
+  }
+}
+
+@keyframes bootLink {
+  0%,
+  20%,
+  100% {
+    opacity: 0;
+    clip-path: inset(0 100% 0 0);
+  }
+  45%,
+  68% {
+    opacity: 0.74;
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+@keyframes bootStatus {
+  0%,
+  100% {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  10%,
+  30% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  42% {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .boot-orbit,
+  .boot-core,
+  .boot-node,
+  .boot-link,
+  .boot-status span {
+    animation: none;
+  }
+
+  .boot-status span:first-child {
+    opacity: 1;
+    transform: none;
+  }
+
+  .boot-link {
+    opacity: 0.42;
+    clip-path: none;
+  }
 }
 
 :root,


### PR DESCRIPTION
## Summary
- replace the plain `Opening Lantor...` boot state with an animated agent constellation splash
- add a native Tauri `splashscreen` window so desktop startup shows the animation before the main window is ready
- keep the React boot screen visible for at least 1.4s so fast web/bootstrap loads do not skip the splash
- cycle startup status copy: `Waking agents...`, `Restoring workspace...`, `Syncing threads...`
- add reduced-motion fallback
- fix the existing clippy dead-code warning in `agent_inbox_wake.rs`
- refresh the raw-color baseline after removing the old boot literals

## Notes
- The shared LottieFiles link requires login, so this uses native CSS motion inspired by the selected direction rather than embedding that Lottie JSON.
- Web preview remains a React boot-screen; desktop gets an additional native Tauri splash window.

## Verification
- npm run build
- npm run lint:css-tokens
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path src-tauri/Cargo.toml
- Playwright smoke test: local preview shows splash first, then enters the app