### PR TITLE
Preserve thread message expansion state while navigating

### DIFF
--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -116,7 +116,7 @@ type ThreadMessageExpansionState = {
 };
 
 const THREAD_MESSAGE_EXPANSION_TTL_MS = 24 * 60 * 60 * 1000;
-const THREAD_MESSAGE_EXPANSION_MAX_ENTRIES = 100;
+const THREAD_MESSAGE_EXPANSION_MAX_ENTRIES = 50;
 
 function pruneThreadMessageExpansionState(
   entries: Map<string, ThreadMessageExpansionState>,

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -116,6 +116,18 @@ type ThreadMessageExpansionState = {
 };
 
 const THREAD_MESSAGE_EXPANSION_TTL_MS = 24 * 60 * 60 * 1000;
+const THREAD_MESSAGE_EXPANSION_MAX_ENTRIES = 100;
+
+function pruneThreadMessageExpansionState(
+  entries: Map<string, ThreadMessageExpansionState>,
+  now: number,
+) {
+  const freshEntries = Array.from(entries.entries())
+    .filter(([, entry]) => now - entry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS)
+    .sort((left, right) => right[1].lastTouchedAt - left[1].lastTouchedAt)
+    .slice(0, THREAD_MESSAGE_EXPANSION_MAX_ENTRIES);
+  return new Map(freshEntries);
+}
 
 export function ThreadPanel({
   channel,
@@ -349,21 +361,14 @@ export function ThreadPanel({
   useEffect(() => {
     const now = Date.now();
     setExpandedThreadMessageStateByThread((current) => {
-      let changed = false;
-      const next = new Map<string, ThreadMessageExpansionState>();
-      current.forEach((entry, threadId) => {
-        if (now - entry.lastTouchedAt > THREAD_MESSAGE_EXPANSION_TTL_MS) {
-          changed = true;
-          return;
+      const touched = new Map(current);
+      if (activeThreadExpansionKey) {
+        const entry = touched.get(activeThreadExpansionKey);
+        if (entry && now - entry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS) {
+          touched.set(activeThreadExpansionKey, { messageIds: entry.messageIds, lastTouchedAt: now });
         }
-        if (threadId === activeThreadExpansionKey) {
-          changed = true;
-          next.set(threadId, { messageIds: entry.messageIds, lastTouchedAt: now });
-          return;
-        }
-        next.set(threadId, entry);
-      });
-      return changed ? next : current;
+      }
+      return pruneThreadMessageExpansionState(touched, now);
     });
   }, [activeThreadExpansionKey]);
 
@@ -464,12 +469,9 @@ export function ThreadPanel({
     if (!activeThreadExpansionKey) return;
     setExpandedThreadMessageStateByThread((current) => {
       const now = Date.now();
-      const next = new Map<string, ThreadMessageExpansionState>();
-      current.forEach((entry, threadId) => {
-        if (now - entry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS) next.set(threadId, entry);
-      });
+      const next = pruneThreadMessageExpansionState(current, now);
       next.set(activeThreadExpansionKey, { messageIds: nextMessageIds, lastTouchedAt: now });
-      return next;
+      return pruneThreadMessageExpansionState(next, now);
     });
   }
 
@@ -482,12 +484,9 @@ export function ThreadPanel({
         ? currentEntry.messageIds
         : new Set<string>();
       const nextMessageIds = updater(currentMessageIds);
-      const next = new Map<string, ThreadMessageExpansionState>();
-      current.forEach((entry, threadId) => {
-        if (now - entry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS) next.set(threadId, entry);
-      });
+      const next = pruneThreadMessageExpansionState(current, now);
       next.set(activeThreadExpansionKey, { messageIds: nextMessageIds, lastTouchedAt: now });
-      return next;
+      return pruneThreadMessageExpansionState(next, now);
     });
   }
 

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -116,6 +116,53 @@ type ThreadMessageExpansionState = {
 };
 
 const THREAD_MESSAGE_EXPANSION_TTL_MS = 24 * 60 * 60 * 1000;
+const THREAD_MESSAGE_EXPANSION_STORAGE_KEY = "lantor.threadMessageExpansion.v1";
+
+function isFreshThreadMessageExpansionState(entry: ThreadMessageExpansionState, now: number) {
+  return now - entry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS;
+}
+
+function readThreadMessageExpansionStateFromStorage() {
+  const next = new Map<string, ThreadMessageExpansionState>();
+  if (typeof window === "undefined") return next;
+  try {
+    const rawValue = window.localStorage.getItem(THREAD_MESSAGE_EXPANSION_STORAGE_KEY);
+    if (!rawValue) return next;
+    const parsedValue = JSON.parse(rawValue) as unknown;
+    if (!parsedValue || typeof parsedValue !== "object" || Array.isArray(parsedValue)) return next;
+    const now = Date.now();
+    Object.entries(parsedValue).forEach(([threadId, value]) => {
+      if (!value || typeof value !== "object" || Array.isArray(value)) return;
+      const { messageIds, lastTouchedAt } = value as { messageIds?: unknown; lastTouchedAt?: unknown };
+      if (!Array.isArray(messageIds) || typeof lastTouchedAt !== "number") return;
+      const entry = {
+        messageIds: new Set(messageIds.filter((messageId): messageId is string => typeof messageId === "string")),
+        lastTouchedAt,
+      };
+      if (isFreshThreadMessageExpansionState(entry, now)) next.set(threadId, entry);
+    });
+  } catch {
+    return next;
+  }
+  return next;
+}
+
+function writeThreadMessageExpansionStateToStorage(entries: Map<string, ThreadMessageExpansionState>) {
+  if (typeof window === "undefined") return;
+  try {
+    const value: Record<string, { messageIds: string[]; lastTouchedAt: number }> = {};
+    entries.forEach((entry, threadId) => {
+      value[threadId] = { messageIds: Array.from(entry.messageIds), lastTouchedAt: entry.lastTouchedAt };
+    });
+    if (Object.keys(value).length === 0) {
+      window.localStorage.removeItem(THREAD_MESSAGE_EXPANSION_STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(THREAD_MESSAGE_EXPANSION_STORAGE_KEY, JSON.stringify(value));
+  } catch {
+    // Ignore storage failures; the in-memory state still works for the current session.
+  }
+}
 
 export function ThreadPanel({
   channel,
@@ -155,7 +202,9 @@ export function ThreadPanel({
   const [showBackToBottom, setShowBackToBottom] = useState(false);
   const [messageMenu, setMessageMenu] = useState<MessageMenuState>(null);
   const [tapFocusedMessageId, setTapFocusedMessageId] = useState<string | null>(null);
-  const [expandedThreadMessageStateByThread, setExpandedThreadMessageStateByThread] = useState<Map<string, ThreadMessageExpansionState>>(() => new Map());
+  const [expandedThreadMessageStateByThread, setExpandedThreadMessageStateByThread] = useState<Map<string, ThreadMessageExpansionState>>(
+    readThreadMessageExpansionStateFromStorage,
+  );
   const [pendingCollapsedThreadMessageId, setPendingCollapsedThreadMessageId] = useState<string | null>(null);
   const threadPanelRef = useRef<HTMLElement | null>(null);
   const threadScrollRef = useRef<HTMLDivElement | null>(null);
@@ -179,7 +228,7 @@ export function ThreadPanel({
   const expandedThreadMessageIds = useMemo(() => {
     if (!activeThreadExpansionKey) return new Set<string>();
     const entry = expandedThreadMessageStateByThread.get(activeThreadExpansionKey);
-    if (!entry || Date.now() - entry.lastTouchedAt > THREAD_MESSAGE_EXPANSION_TTL_MS) return new Set<string>();
+    if (!entry || !isFreshThreadMessageExpansionState(entry, Date.now())) return new Set<string>();
     return entry.messageIds;
   }, [activeThreadExpansionKey, expandedThreadMessageStateByThread]);
   const surfaceLabel = channel
@@ -352,7 +401,7 @@ export function ThreadPanel({
       let changed = false;
       const next = new Map<string, ThreadMessageExpansionState>();
       current.forEach((entry, threadId) => {
-        if (now - entry.lastTouchedAt > THREAD_MESSAGE_EXPANSION_TTL_MS) {
+        if (!isFreshThreadMessageExpansionState(entry, now)) {
           changed = true;
           return;
         }
@@ -366,6 +415,10 @@ export function ThreadPanel({
       return changed ? next : current;
     });
   }, [activeThreadExpansionKey]);
+
+  useEffect(() => {
+    writeThreadMessageExpansionStateToStorage(expandedThreadMessageStateByThread);
+  }, [expandedThreadMessageStateByThread]);
 
   useEffect(() => {
     if (!pendingCollapsedThreadMessageId) return;
@@ -466,7 +519,7 @@ export function ThreadPanel({
       const now = Date.now();
       const next = new Map<string, ThreadMessageExpansionState>();
       current.forEach((entry, threadId) => {
-        if (now - entry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS) next.set(threadId, entry);
+        if (isFreshThreadMessageExpansionState(entry, now)) next.set(threadId, entry);
       });
       next.set(activeThreadExpansionKey, { messageIds: nextMessageIds, lastTouchedAt: now });
       return next;
@@ -478,13 +531,13 @@ export function ThreadPanel({
     setExpandedThreadMessageStateByThread((current) => {
       const now = Date.now();
       const currentEntry = current.get(activeThreadExpansionKey);
-      const currentMessageIds = currentEntry && now - currentEntry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS
+      const currentMessageIds = currentEntry && isFreshThreadMessageExpansionState(currentEntry, now)
         ? currentEntry.messageIds
         : new Set<string>();
       const nextMessageIds = updater(currentMessageIds);
       const next = new Map<string, ThreadMessageExpansionState>();
       current.forEach((entry, threadId) => {
-        if (now - entry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS) next.set(threadId, entry);
+        if (isFreshThreadMessageExpansionState(entry, now)) next.set(threadId, entry);
       });
       next.set(activeThreadExpansionKey, { messageIds: nextMessageIds, lastTouchedAt: now });
       return next;

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -110,6 +110,13 @@ type MessageMenuState = {
   message: Message;
 } | null;
 
+type ThreadMessageExpansionState = {
+  messageIds: Set<string>;
+  lastTouchedAt: number;
+};
+
+const THREAD_MESSAGE_EXPANSION_TTL_MS = 24 * 60 * 60 * 1000;
+
 export function ThreadPanel({
   channel,
   channels,
@@ -148,7 +155,7 @@ export function ThreadPanel({
   const [showBackToBottom, setShowBackToBottom] = useState(false);
   const [messageMenu, setMessageMenu] = useState<MessageMenuState>(null);
   const [tapFocusedMessageId, setTapFocusedMessageId] = useState<string | null>(null);
-  const [expandedThreadMessageIds, setExpandedThreadMessageIds] = useState<Set<string>>(() => new Set());
+  const [expandedThreadMessageStateByThread, setExpandedThreadMessageStateByThread] = useState<Map<string, ThreadMessageExpansionState>>(() => new Map());
   const [pendingCollapsedThreadMessageId, setPendingCollapsedThreadMessageId] = useState<string | null>(null);
   const threadPanelRef = useRef<HTMLElement | null>(null);
   const threadScrollRef = useRef<HTMLDivElement | null>(null);
@@ -168,6 +175,13 @@ export function ThreadPanel({
   const rootAgent = activeRoot ? agentForMessageSender(activeRoot, agents) : null;
   const deletedRootAgent = activeRoot && !rootAgent ? deletedAgentForMessageSender(activeRoot) : null;
   const rootSaved = activeRoot ? savedMessageIds.has(activeRoot.id) : false;
+  const activeThreadExpansionKey = activeRoot?.id ?? null;
+  const expandedThreadMessageIds = useMemo(() => {
+    if (!activeThreadExpansionKey) return new Set<string>();
+    const entry = expandedThreadMessageStateByThread.get(activeThreadExpansionKey);
+    if (!entry || Date.now() - entry.lastTouchedAt > THREAD_MESSAGE_EXPANSION_TTL_MS) return new Set<string>();
+    return entry.messageIds;
+  }, [activeThreadExpansionKey, expandedThreadMessageStateByThread]);
   const surfaceLabel = channel
     ? isDm
       ? `Thread in DM with @${dmAgent?.handle || "agent"}`
@@ -329,9 +343,29 @@ export function ThreadPanel({
   useEffect(() => {
     setMessageMenu(null);
     setTapFocusedMessageId(null);
-    setExpandedThreadMessageIds(new Set());
     setPendingCollapsedThreadMessageId(null);
   }, [activeRoot?.id]);
+
+  useEffect(() => {
+    const now = Date.now();
+    setExpandedThreadMessageStateByThread((current) => {
+      let changed = false;
+      const next = new Map<string, ThreadMessageExpansionState>();
+      current.forEach((entry, threadId) => {
+        if (now - entry.lastTouchedAt > THREAD_MESSAGE_EXPANSION_TTL_MS) {
+          changed = true;
+          return;
+        }
+        if (threadId === activeThreadExpansionKey) {
+          changed = true;
+          next.set(threadId, { messageIds: entry.messageIds, lastTouchedAt: now });
+          return;
+        }
+        next.set(threadId, entry);
+      });
+      return changed ? next : current;
+    });
+  }, [activeThreadExpansionKey]);
 
   useEffect(() => {
     if (!pendingCollapsedThreadMessageId) return;
@@ -426,12 +460,43 @@ export function ThreadPanel({
     setMessageMenu(null);
   }
 
+  function setActiveThreadExpandedMessageIds(nextMessageIds: Set<string>) {
+    if (!activeThreadExpansionKey) return;
+    setExpandedThreadMessageStateByThread((current) => {
+      const now = Date.now();
+      const next = new Map<string, ThreadMessageExpansionState>();
+      current.forEach((entry, threadId) => {
+        if (now - entry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS) next.set(threadId, entry);
+      });
+      next.set(activeThreadExpansionKey, { messageIds: nextMessageIds, lastTouchedAt: now });
+      return next;
+    });
+  }
+
+  function updateActiveThreadExpandedMessageIds(updater: (current: Set<string>) => Set<string>) {
+    if (!activeThreadExpansionKey) return;
+    setExpandedThreadMessageStateByThread((current) => {
+      const now = Date.now();
+      const currentEntry = current.get(activeThreadExpansionKey);
+      const currentMessageIds = currentEntry && now - currentEntry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS
+        ? currentEntry.messageIds
+        : new Set<string>();
+      const nextMessageIds = updater(currentMessageIds);
+      const next = new Map<string, ThreadMessageExpansionState>();
+      current.forEach((entry, threadId) => {
+        if (now - entry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS) next.set(threadId, entry);
+      });
+      next.set(activeThreadExpansionKey, { messageIds: nextMessageIds, lastTouchedAt: now });
+      return next;
+    });
+  }
+
   function toggleThreadMessageExpanded(messageId: string) {
     if (expandedThreadMessageIds.has(messageId)) {
       stopFollowingThread();
       setPendingCollapsedThreadMessageId(messageId);
     }
-    setExpandedThreadMessageIds((current) => {
+    updateActiveThreadExpandedMessageIds((current) => {
       const next = new Set(current);
       if (next.has(messageId)) next.delete(messageId);
       else next.add(messageId);
@@ -443,14 +508,14 @@ export function ThreadPanel({
     if (!hasCollapsibleThreadMessages || areAllThreadMessagesExpanded) return;
     stopFollowingThread();
     setPendingCollapsedThreadMessageId(null);
-    setExpandedThreadMessageIds(new Set(collapsibleThreadMessageIds));
+    setActiveThreadExpandedMessageIds(new Set(collapsibleThreadMessageIds));
   }
 
   function foldAllThreadMessages() {
     if (!hasCollapsibleThreadMessages || areAllThreadMessagesFolded) return;
     stopFollowingThread();
     setPendingCollapsedThreadMessageId(null);
-    setExpandedThreadMessageIds(new Set());
+    setActiveThreadExpandedMessageIds(new Set());
   }
 
   async function exportThreadVectorImage() {
@@ -460,14 +525,14 @@ export function ThreadPanel({
     const shouldTemporarilyExpand = collapsibleThreadMessageIds.some((messageId) => !previousExpandedMessageIds.has(messageId));
     if (shouldTemporarilyExpand) {
       setPendingCollapsedThreadMessageId(null);
-      setExpandedThreadMessageIds(new Set(collapsibleThreadMessageIds));
+      setActiveThreadExpandedMessageIds(new Set(collapsibleThreadMessageIds));
       await waitForNextFrame();
       await waitForNextFrame();
     }
     try {
       await downloadThreadPanelSvg(threadPanel, surfaceLabel);
     } finally {
-      if (shouldTemporarilyExpand) setExpandedThreadMessageIds(previousExpandedMessageIds);
+      if (shouldTemporarilyExpand) setActiveThreadExpandedMessageIds(previousExpandedMessageIds);
     }
   }
 

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -116,53 +116,6 @@ type ThreadMessageExpansionState = {
 };
 
 const THREAD_MESSAGE_EXPANSION_TTL_MS = 24 * 60 * 60 * 1000;
-const THREAD_MESSAGE_EXPANSION_STORAGE_KEY = "lantor.threadMessageExpansion.v1";
-
-function isFreshThreadMessageExpansionState(entry: ThreadMessageExpansionState, now: number) {
-  return now - entry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS;
-}
-
-function readThreadMessageExpansionStateFromStorage() {
-  const next = new Map<string, ThreadMessageExpansionState>();
-  if (typeof window === "undefined") return next;
-  try {
-    const rawValue = window.localStorage.getItem(THREAD_MESSAGE_EXPANSION_STORAGE_KEY);
-    if (!rawValue) return next;
-    const parsedValue = JSON.parse(rawValue) as unknown;
-    if (!parsedValue || typeof parsedValue !== "object" || Array.isArray(parsedValue)) return next;
-    const now = Date.now();
-    Object.entries(parsedValue).forEach(([threadId, value]) => {
-      if (!value || typeof value !== "object" || Array.isArray(value)) return;
-      const { messageIds, lastTouchedAt } = value as { messageIds?: unknown; lastTouchedAt?: unknown };
-      if (!Array.isArray(messageIds) || typeof lastTouchedAt !== "number") return;
-      const entry = {
-        messageIds: new Set(messageIds.filter((messageId): messageId is string => typeof messageId === "string")),
-        lastTouchedAt,
-      };
-      if (isFreshThreadMessageExpansionState(entry, now)) next.set(threadId, entry);
-    });
-  } catch {
-    return next;
-  }
-  return next;
-}
-
-function writeThreadMessageExpansionStateToStorage(entries: Map<string, ThreadMessageExpansionState>) {
-  if (typeof window === "undefined") return;
-  try {
-    const value: Record<string, { messageIds: string[]; lastTouchedAt: number }> = {};
-    entries.forEach((entry, threadId) => {
-      value[threadId] = { messageIds: Array.from(entry.messageIds), lastTouchedAt: entry.lastTouchedAt };
-    });
-    if (Object.keys(value).length === 0) {
-      window.localStorage.removeItem(THREAD_MESSAGE_EXPANSION_STORAGE_KEY);
-      return;
-    }
-    window.localStorage.setItem(THREAD_MESSAGE_EXPANSION_STORAGE_KEY, JSON.stringify(value));
-  } catch {
-    // Ignore storage failures; the in-memory state still works for the current session.
-  }
-}
 
 export function ThreadPanel({
   channel,
@@ -202,9 +155,7 @@ export function ThreadPanel({
   const [showBackToBottom, setShowBackToBottom] = useState(false);
   const [messageMenu, setMessageMenu] = useState<MessageMenuState>(null);
   const [tapFocusedMessageId, setTapFocusedMessageId] = useState<string | null>(null);
-  const [expandedThreadMessageStateByThread, setExpandedThreadMessageStateByThread] = useState<Map<string, ThreadMessageExpansionState>>(
-    readThreadMessageExpansionStateFromStorage,
-  );
+  const [expandedThreadMessageStateByThread, setExpandedThreadMessageStateByThread] = useState<Map<string, ThreadMessageExpansionState>>(() => new Map());
   const [pendingCollapsedThreadMessageId, setPendingCollapsedThreadMessageId] = useState<string | null>(null);
   const threadPanelRef = useRef<HTMLElement | null>(null);
   const threadScrollRef = useRef<HTMLDivElement | null>(null);
@@ -228,7 +179,7 @@ export function ThreadPanel({
   const expandedThreadMessageIds = useMemo(() => {
     if (!activeThreadExpansionKey) return new Set<string>();
     const entry = expandedThreadMessageStateByThread.get(activeThreadExpansionKey);
-    if (!entry || !isFreshThreadMessageExpansionState(entry, Date.now())) return new Set<string>();
+    if (!entry || Date.now() - entry.lastTouchedAt > THREAD_MESSAGE_EXPANSION_TTL_MS) return new Set<string>();
     return entry.messageIds;
   }, [activeThreadExpansionKey, expandedThreadMessageStateByThread]);
   const surfaceLabel = channel
@@ -401,7 +352,7 @@ export function ThreadPanel({
       let changed = false;
       const next = new Map<string, ThreadMessageExpansionState>();
       current.forEach((entry, threadId) => {
-        if (!isFreshThreadMessageExpansionState(entry, now)) {
+        if (now - entry.lastTouchedAt > THREAD_MESSAGE_EXPANSION_TTL_MS) {
           changed = true;
           return;
         }
@@ -415,10 +366,6 @@ export function ThreadPanel({
       return changed ? next : current;
     });
   }, [activeThreadExpansionKey]);
-
-  useEffect(() => {
-    writeThreadMessageExpansionStateToStorage(expandedThreadMessageStateByThread);
-  }, [expandedThreadMessageStateByThread]);
 
   useEffect(() => {
     if (!pendingCollapsedThreadMessageId) return;
@@ -519,7 +466,7 @@ export function ThreadPanel({
       const now = Date.now();
       const next = new Map<string, ThreadMessageExpansionState>();
       current.forEach((entry, threadId) => {
-        if (isFreshThreadMessageExpansionState(entry, now)) next.set(threadId, entry);
+        if (now - entry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS) next.set(threadId, entry);
       });
       next.set(activeThreadExpansionKey, { messageIds: nextMessageIds, lastTouchedAt: now });
       return next;
@@ -531,13 +478,13 @@ export function ThreadPanel({
     setExpandedThreadMessageStateByThread((current) => {
       const now = Date.now();
       const currentEntry = current.get(activeThreadExpansionKey);
-      const currentMessageIds = currentEntry && isFreshThreadMessageExpansionState(currentEntry, now)
+      const currentMessageIds = currentEntry && now - currentEntry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS
         ? currentEntry.messageIds
         : new Set<string>();
       const nextMessageIds = updater(currentMessageIds);
       const next = new Map<string, ThreadMessageExpansionState>();
       current.forEach((entry, threadId) => {
-        if (isFreshThreadMessageExpansionState(entry, now)) next.set(threadId, entry);
+        if (now - entry.lastTouchedAt <= THREAD_MESSAGE_EXPANSION_TTL_MS) next.set(threadId, entry);
       });
       next.set(activeThreadExpansionKey, { messageIds: nextMessageIds, lastTouchedAt: now });
       return next;


### PR DESCRIPTION
## Summary
- keep expanded/collapsed message IDs in a per-thread React state map
- preserve that state while switching between threads in the same app session
- do not write this UI state to the backend, localStorage, or sessionStorage, so a browser refresh clears it
- prune expansion state entries that have not been touched for more than 24 hours during the same session
- cap the state map to the 100 most recently touched threads with an LRU strategy
- keep expand all, fold all, and SVG export temporary expansion scoped to the active thread

## Verification
- npm run build