### PR TITLE
Remove startup splash letter nodes

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -347,10 +347,6 @@ function BootSplash({ appError, onRetry }: { appError: string | null; onRetry: (
       <div className="boot-panel">
         <div className="boot-constellation" aria-hidden="true">
           <div className="boot-orbit">
-            <span className="boot-node node-dylan">D</span>
-            <span className="boot-node node-bugen">B</span>
-            <span className="boot-node node-admin">A</span>
-            <span className="boot-node node-owner">M</span>
             <span className="boot-link link-one" />
             <span className="boot-link link-two" />
             <span className="boot-link link-three" />

--- a/src/styles.css
+++ b/src/styles.css
@@ -156,47 +156,6 @@ button,
   letter-spacing: 0;
 }
 
-.boot-node {
-  position: absolute;
-  z-index: 2;
-  display: grid;
-  width: 34px;
-  height: 34px;
-  place-items: center;
-  border: 1px solid var(--border-emphasis);
-  border-radius: 999px;
-  background: var(--surface-floating);
-  box-shadow: var(--state-selected-shadow);
-  color: var(--ink-primary);
-  font-size: var(--type-size-meta);
-  font-weight: var(--type-weight-bold);
-  animation: bootNode 2400ms ease-in-out infinite;
-}
-
-.node-dylan {
-  top: 12px;
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-.node-bugen {
-  top: 88px;
-  right: 6px;
-  animation-delay: 180ms;
-}
-
-.node-admin {
-  bottom: 24px;
-  right: 44px;
-  animation-delay: 360ms;
-}
-
-.node-owner {
-  bottom: 56px;
-  left: 8px;
-  animation-delay: 540ms;
-}
-
 .boot-link {
   position: absolute;
   z-index: 1;
@@ -319,18 +278,6 @@ button,
   }
 }
 
-@keyframes bootNode {
-  0%,
-  100% {
-    color: var(--ink-primary);
-    border-color: var(--border-emphasis);
-  }
-  45% {
-    color: var(--accent);
-    border-color: var(--accent-soft-hover-border);
-  }
-}
-
 @keyframes bootLink {
   0%,
   20%,
@@ -365,7 +312,6 @@ button,
 @media (prefers-reduced-motion: reduce) {
   .boot-orbit,
   .boot-core,
-  .boot-node,
   .boot-link,
   .boot-status span {
     animation: none;


### PR DESCRIPTION
## Summary
- remove the five startup splash letter-node elements
- keep the orbit ring, connection lines, and centered animated `L` mark
- delete unused letter-node styles and keyframes

## Verification
- npm run build
- npm run lint:css-tokens
- DOM check: `.boot-orbit` = 1, `.boot-link` = 3, `.boot-node` = 0, center mark = `L`
