### PR TITLE
Keep splash orbit without letter nodes

### DIFF
--- a/public/splashscreen.html
+++ b/public/splashscreen.html
@@ -140,28 +140,34 @@
         animation: node 2400ms ease-in-out infinite;
       }
 
-      .node-d {
+      .node-a {
         top: 12px;
         left: 50%;
         transform: translateX(-50%);
       }
 
-      .node-b {
-        top: 88px;
+      .node-n {
+        top: 74px;
         right: 6px;
         animation-delay: 180ms;
       }
 
-      .node-a {
-        right: 44px;
-        bottom: 24px;
+      .node-t {
+        right: 36px;
+        bottom: 22px;
         animation-delay: 360ms;
       }
 
-      .node-m {
-        bottom: 56px;
-        left: 8px;
+      .node-o {
+        bottom: 22px;
+        left: 36px;
         animation-delay: 540ms;
+      }
+
+      .node-r {
+        top: 74px;
+        left: 6px;
+        animation-delay: 720ms;
       }
 
       .link {
@@ -196,6 +202,14 @@
         width: 100px;
         transform: rotate(-32deg);
         animation-delay: 600ms;
+      }
+
+      .link-four {
+        top: 78px;
+        left: 40px;
+        width: 88px;
+        transform: rotate(-30deg);
+        animation-delay: 900ms;
       }
 
       .copy {
@@ -330,13 +344,15 @@
     <main class="shell" aria-label="Starting Lantor">
       <div class="constellation" aria-hidden="true">
         <div class="orbit">
-          <span class="node node-d">D</span>
-          <span class="node node-b">B</span>
           <span class="node node-a">A</span>
-          <span class="node node-m">M</span>
+          <span class="node node-n">N</span>
+          <span class="node node-t">T</span>
+          <span class="node node-o">O</span>
+          <span class="node node-r">R</span>
           <span class="link link-one"></span>
           <span class="link link-two"></span>
           <span class="link link-three"></span>
+          <span class="link link-four"></span>
         </div>
         <div class="core">
           <span class="mark">L</span>

--- a/public/splashscreen.html
+++ b/public/splashscreen.html
@@ -83,27 +83,19 @@
       .constellation {
         position: relative;
         display: grid;
-        width: 240px;
+        width: 124px;
         aspect-ratio: 1;
         place-items: center;
       }
 
-      .orbit,
       .core {
-        position: absolute;
-        inset: 0;
         display: grid;
         place-items: center;
       }
 
-      .orbit {
-        border: 1px solid var(--line);
-        border-radius: 999px;
-        animation: orbit 2400ms ease-in-out infinite;
-      }
-
       .core {
-        inset: 58px;
+        width: 124px;
+        aspect-ratio: 1;
         border: 1px solid var(--line-strong);
         border-radius: 28px;
         background: var(--surface-floating);
@@ -121,95 +113,6 @@
         color: var(--accent);
         font-size: 34px;
         font-weight: 700;
-      }
-
-      .node {
-        position: absolute;
-        z-index: 2;
-        display: grid;
-        width: 34px;
-        height: 34px;
-        place-items: center;
-        border: 1px solid var(--line-strong);
-        border-radius: 999px;
-        background: var(--surface-floating);
-        box-shadow: var(--shadow);
-        color: var(--ink);
-        font-size: 12px;
-        font-weight: 700;
-        animation: node 2400ms ease-in-out infinite;
-      }
-
-      .node-a {
-        top: 12px;
-        left: 50%;
-        transform: translateX(-50%);
-      }
-
-      .node-n {
-        top: 74px;
-        right: 6px;
-        animation-delay: 180ms;
-      }
-
-      .node-t {
-        right: 36px;
-        bottom: 22px;
-        animation-delay: 360ms;
-      }
-
-      .node-o {
-        bottom: 22px;
-        left: 36px;
-        animation-delay: 540ms;
-      }
-
-      .node-r {
-        top: 74px;
-        left: 6px;
-        animation-delay: 720ms;
-      }
-
-      .link {
-        position: absolute;
-        z-index: 1;
-        height: 1px;
-        border-radius: 999px;
-        background: linear-gradient(90deg, transparent, var(--accent), transparent);
-        opacity: 0;
-        transform-origin: left center;
-        animation: link 2400ms ease-in-out infinite;
-      }
-
-      .link-one {
-        top: 78px;
-        left: 110px;
-        width: 96px;
-        transform: rotate(30deg);
-      }
-
-      .link-two {
-        top: 150px;
-        left: 132px;
-        width: 74px;
-        transform: rotate(112deg);
-        animation-delay: 300ms;
-      }
-
-      .link-three {
-        top: 160px;
-        left: 54px;
-        width: 100px;
-        transform: rotate(-32deg);
-        animation-delay: 600ms;
-      }
-
-      .link-four {
-        top: 78px;
-        left: 40px;
-        width: 88px;
-        transform: rotate(-30deg);
-        animation-delay: 900ms;
       }
 
       .copy {
@@ -252,18 +155,6 @@
         animation-delay: 2400ms;
       }
 
-      @keyframes orbit {
-        0%,
-        100% {
-          border-color: var(--line);
-          box-shadow: none;
-        }
-        50% {
-          border-color: var(--accent-border);
-          box-shadow: 0 0 0 8px var(--accent-soft);
-        }
-      }
-
       @keyframes core {
         0%,
         100% {
@@ -273,32 +164,6 @@
         50% {
           transform: scale(1.035);
           box-shadow: var(--shadow-active);
-        }
-      }
-
-      @keyframes node {
-        0%,
-        100% {
-          border-color: var(--line-strong);
-          color: var(--ink);
-        }
-        45% {
-          border-color: var(--accent-border);
-          color: var(--accent);
-        }
-      }
-
-      @keyframes link {
-        0%,
-        20%,
-        100% {
-          opacity: 0;
-          clip-path: inset(0 100% 0 0);
-        }
-        45%,
-        68% {
-          opacity: 0.74;
-          clip-path: inset(0 0 0 0);
         }
       }
 
@@ -320,10 +185,7 @@
       }
 
       @media (prefers-reduced-motion: reduce) {
-        .orbit,
         .core,
-        .node,
-        .link,
         .status span {
           animation: none;
         }
@@ -333,27 +195,12 @@
           transform: none;
         }
 
-        .link {
-          opacity: 0.42;
-          clip-path: none;
-        }
       }
     </style>
   </head>
   <body>
     <main class="shell" aria-label="Starting Lantor">
       <div class="constellation" aria-hidden="true">
-        <div class="orbit">
-          <span class="node node-a"></span>
-          <span class="node node-n"></span>
-          <span class="node node-t"></span>
-          <span class="node node-o"></span>
-          <span class="node node-r"></span>
-          <span class="link link-one"></span>
-          <span class="link link-two"></span>
-          <span class="link link-three"></span>
-          <span class="link link-four"></span>
-        </div>
         <div class="core">
           <span class="mark">L</span>
         </div>

--- a/public/splashscreen.html
+++ b/public/splashscreen.html
@@ -83,19 +83,27 @@
       .constellation {
         position: relative;
         display: grid;
-        width: 124px;
+        width: 240px;
         aspect-ratio: 1;
         place-items: center;
       }
 
+      .orbit,
       .core {
+        position: absolute;
+        inset: 0;
         display: grid;
         place-items: center;
       }
 
+      .orbit {
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        animation: orbit 2400ms ease-in-out infinite;
+      }
+
       .core {
-        width: 124px;
-        aspect-ratio: 1;
+        inset: 58px;
         border: 1px solid var(--line-strong);
         border-radius: 28px;
         background: var(--surface-floating);
@@ -113,6 +121,48 @@
         color: var(--accent);
         font-size: 34px;
         font-weight: 700;
+      }
+
+      .link {
+        position: absolute;
+        z-index: 1;
+        height: 1px;
+        border-radius: 999px;
+        background: linear-gradient(90deg, transparent, var(--accent), transparent);
+        opacity: 0;
+        transform-origin: left center;
+        animation: link 2400ms ease-in-out infinite;
+      }
+
+      .link-one {
+        top: 78px;
+        left: 110px;
+        width: 96px;
+        transform: rotate(30deg);
+      }
+
+      .link-two {
+        top: 150px;
+        left: 132px;
+        width: 74px;
+        transform: rotate(112deg);
+        animation-delay: 300ms;
+      }
+
+      .link-three {
+        top: 160px;
+        left: 54px;
+        width: 100px;
+        transform: rotate(-32deg);
+        animation-delay: 600ms;
+      }
+
+      .link-four {
+        top: 78px;
+        left: 40px;
+        width: 88px;
+        transform: rotate(-30deg);
+        animation-delay: 900ms;
       }
 
       .copy {
@@ -155,6 +205,18 @@
         animation-delay: 2400ms;
       }
 
+      @keyframes orbit {
+        0%,
+        100% {
+          border-color: var(--line);
+          box-shadow: none;
+        }
+        50% {
+          border-color: var(--accent-border);
+          box-shadow: 0 0 0 8px var(--accent-soft);
+        }
+      }
+
       @keyframes core {
         0%,
         100% {
@@ -164,6 +226,20 @@
         50% {
           transform: scale(1.035);
           box-shadow: var(--shadow-active);
+        }
+      }
+
+      @keyframes link {
+        0%,
+        20%,
+        100% {
+          opacity: 0;
+          clip-path: inset(0 100% 0 0);
+        }
+        45%,
+        68% {
+          opacity: 0.74;
+          clip-path: inset(0 0 0 0);
         }
       }
 
@@ -185,7 +261,9 @@
       }
 
       @media (prefers-reduced-motion: reduce) {
+        .orbit,
         .core,
+        .link,
         .status span {
           animation: none;
         }
@@ -195,12 +273,22 @@
           transform: none;
         }
 
+        .link {
+          opacity: 0.42;
+          clip-path: none;
+        }
       }
     </style>
   </head>
   <body>
     <main class="shell" aria-label="Starting Lantor">
       <div class="constellation" aria-hidden="true">
+        <div class="orbit">
+          <span class="link link-one"></span>
+          <span class="link link-two"></span>
+          <span class="link link-three"></span>
+          <span class="link link-four"></span>
+        </div>
         <div class="core">
           <span class="mark">L</span>
         </div>

--- a/public/splashscreen.html
+++ b/public/splashscreen.html
@@ -344,11 +344,11 @@
     <main class="shell" aria-label="Starting Lantor">
       <div class="constellation" aria-hidden="true">
         <div class="orbit">
-          <span class="node node-a">A</span>
-          <span class="node node-n">N</span>
-          <span class="node node-t">T</span>
-          <span class="node node-o">O</span>
-          <span class="node node-r">R</span>
+          <span class="node node-a"></span>
+          <span class="node node-n"></span>
+          <span class="node node-t"></span>
+          <span class="node node-o"></span>
+          <span class="node node-r"></span>
           <span class="link link-one"></span>
           <span class="link link-two"></span>
           <span class="link link-three"></span>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -347,11 +347,11 @@ function BootSplash({ appError, onRetry }: { appError: string | null; onRetry: (
       <div className="boot-panel">
         <div className="boot-constellation" aria-hidden="true">
           <div className="boot-orbit">
-            <span className="boot-node node-lantor-a">A</span>
-            <span className="boot-node node-lantor-n">N</span>
-            <span className="boot-node node-lantor-t">T</span>
-            <span className="boot-node node-lantor-o">O</span>
-            <span className="boot-node node-lantor-r">R</span>
+            <span className="boot-node node-lantor-a" />
+            <span className="boot-node node-lantor-n" />
+            <span className="boot-node node-lantor-t" />
+            <span className="boot-node node-lantor-o" />
+            <span className="boot-node node-lantor-r" />
             <span className="boot-link link-one" />
             <span className="boot-link link-two" />
             <span className="boot-link link-three" />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -346,6 +346,12 @@ function BootSplash({ appError, onRetry }: { appError: string | null; onRetry: (
     <div className="boot" aria-live="polite">
       <div className="boot-panel">
         <div className="boot-constellation" aria-hidden="true">
+          <div className="boot-orbit">
+            <span className="boot-link link-one" />
+            <span className="boot-link link-two" />
+            <span className="boot-link link-three" />
+            <span className="boot-link link-four" />
+          </div>
           <div className="boot-core">
             <span className="boot-core-mark">L</span>
           </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -346,17 +346,6 @@ function BootSplash({ appError, onRetry }: { appError: string | null; onRetry: (
     <div className="boot" aria-live="polite">
       <div className="boot-panel">
         <div className="boot-constellation" aria-hidden="true">
-          <div className="boot-orbit">
-            <span className="boot-node node-lantor-a" />
-            <span className="boot-node node-lantor-n" />
-            <span className="boot-node node-lantor-t" />
-            <span className="boot-node node-lantor-o" />
-            <span className="boot-node node-lantor-r" />
-            <span className="boot-link link-one" />
-            <span className="boot-link link-two" />
-            <span className="boot-link link-three" />
-            <span className="boot-link link-four" />
-          </div>
           <div className="boot-core">
             <span className="boot-core-mark">L</span>
           </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -347,13 +347,15 @@ function BootSplash({ appError, onRetry }: { appError: string | null; onRetry: (
       <div className="boot-panel">
         <div className="boot-constellation" aria-hidden="true">
           <div className="boot-orbit">
-            <span className="boot-node node-dylan">D</span>
-            <span className="boot-node node-bugen">B</span>
-            <span className="boot-node node-admin">A</span>
-            <span className="boot-node node-owner">M</span>
+            <span className="boot-node node-lantor-a">A</span>
+            <span className="boot-node node-lantor-n">N</span>
+            <span className="boot-node node-lantor-t">T</span>
+            <span className="boot-node node-lantor-o">O</span>
+            <span className="boot-node node-lantor-r">R</span>
             <span className="boot-link link-one" />
             <span className="boot-link link-two" />
             <span className="boot-link link-three" />
+            <span className="boot-link link-four" />
           </div>
           <div className="boot-core">
             <span className="boot-core-mark">L</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -115,19 +115,27 @@ button,
 .boot-constellation {
   position: relative;
   display: grid;
-  width: 124px;
+  width: 240px;
   aspect-ratio: 1;
   place-items: center;
 }
 
+.boot-orbit,
 .boot-core {
+  position: absolute;
+  inset: 0;
   display: grid;
   place-items: center;
 }
 
+.boot-orbit {
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  animation: bootOrbit 2400ms ease-in-out infinite;
+}
+
 .boot-core {
-  width: 124px;
-  aspect-ratio: 1;
+  inset: 58px;
   border: 1px solid var(--border-emphasis);
   border-radius: 28px;
   background: var(--surface-floating);
@@ -146,6 +154,48 @@ button,
   font-size: 34px;
   font-weight: var(--type-weight-bold);
   letter-spacing: 0;
+}
+
+.boot-link {
+  position: absolute;
+  z-index: 1;
+  height: 1px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+  opacity: 0;
+  transform-origin: left center;
+  animation: bootLink 2400ms ease-in-out infinite;
+}
+
+.link-one {
+  top: 78px;
+  left: 110px;
+  width: 96px;
+  transform: rotate(30deg);
+}
+
+.link-two {
+  top: 150px;
+  left: 132px;
+  width: 74px;
+  transform: rotate(112deg);
+  animation-delay: 300ms;
+}
+
+.link-three {
+  top: 160px;
+  left: 54px;
+  width: 100px;
+  transform: rotate(-32deg);
+  animation-delay: 600ms;
+}
+
+.link-four {
+  top: 78px;
+  left: 40px;
+  width: 88px;
+  transform: rotate(-30deg);
+  animation-delay: 900ms;
 }
 
 .boot-copy {
@@ -212,6 +262,18 @@ button,
   font-weight: var(--type-weight-semibold);
 }
 
+@keyframes bootOrbit {
+  0%,
+  100% {
+    border-color: var(--border-subtle);
+    box-shadow: none;
+  }
+  50% {
+    border-color: var(--accent-soft-border);
+    box-shadow: 0 0 0 8px var(--accent-soft);
+  }
+}
+
 @keyframes bootCore {
   0%,
   100% {
@@ -221,6 +283,20 @@ button,
   50% {
     transform: scale(1.035);
     box-shadow: var(--state-selected-emphasis-shadow);
+  }
+}
+
+@keyframes bootLink {
+  0%,
+  20%,
+  100% {
+    opacity: 0;
+    clip-path: inset(0 100% 0 0);
+  }
+  45%,
+  68% {
+    opacity: 0.74;
+    clip-path: inset(0 0 0 0);
   }
 }
 
@@ -242,7 +318,9 @@ button,
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .boot-orbit,
   .boot-core,
+  .boot-link,
   .boot-status span {
     animation: none;
   }
@@ -252,6 +330,10 @@ button,
     transform: none;
   }
 
+  .boot-link {
+    opacity: 0.42;
+    clip-path: none;
+  }
 }
 
 :root,

--- a/src/styles.css
+++ b/src/styles.css
@@ -115,27 +115,19 @@ button,
 .boot-constellation {
   position: relative;
   display: grid;
-  width: 240px;
+  width: 124px;
   aspect-ratio: 1;
   place-items: center;
 }
 
-.boot-orbit,
 .boot-core {
-  position: absolute;
-  inset: 0;
   display: grid;
   place-items: center;
 }
 
-.boot-orbit {
-  border: 1px solid var(--border-subtle);
-  border-radius: 999px;
-  animation: bootOrbit 2400ms ease-in-out infinite;
-}
-
 .boot-core {
-  inset: 58px;
+  width: 124px;
+  aspect-ratio: 1;
   border: 1px solid var(--border-emphasis);
   border-radius: 28px;
   background: var(--surface-floating);
@@ -154,95 +146,6 @@ button,
   font-size: 34px;
   font-weight: var(--type-weight-bold);
   letter-spacing: 0;
-}
-
-.boot-node {
-  position: absolute;
-  z-index: 2;
-  display: grid;
-  width: 34px;
-  height: 34px;
-  place-items: center;
-  border: 1px solid var(--border-emphasis);
-  border-radius: 999px;
-  background: var(--surface-floating);
-  box-shadow: var(--state-selected-shadow);
-  color: var(--ink-primary);
-  font-size: var(--type-size-meta);
-  font-weight: var(--type-weight-bold);
-  animation: bootNode 2400ms ease-in-out infinite;
-}
-
-.node-lantor-a {
-  top: 12px;
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-.node-lantor-n {
-  top: 74px;
-  right: 6px;
-  animation-delay: 180ms;
-}
-
-.node-lantor-t {
-  bottom: 22px;
-  right: 36px;
-  animation-delay: 360ms;
-}
-
-.node-lantor-o {
-  bottom: 22px;
-  left: 36px;
-  animation-delay: 540ms;
-}
-
-.node-lantor-r {
-  top: 74px;
-  left: 6px;
-  animation-delay: 720ms;
-}
-
-.boot-link {
-  position: absolute;
-  z-index: 1;
-  height: 1px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, transparent, var(--accent), transparent);
-  opacity: 0;
-  transform-origin: left center;
-  animation: bootLink 2400ms ease-in-out infinite;
-}
-
-.link-one {
-  top: 78px;
-  left: 110px;
-  width: 96px;
-  transform: rotate(30deg);
-}
-
-.link-two {
-  top: 150px;
-  left: 132px;
-  width: 74px;
-  transform: rotate(112deg);
-  animation-delay: 300ms;
-}
-
-.link-three {
-  top: 160px;
-  left: 54px;
-  width: 100px;
-  transform: rotate(-32deg);
-  animation-delay: 600ms;
-}
-
-.link-four {
-  top: 78px;
-  left: 40px;
-  width: 88px;
-  transform: rotate(-30deg);
-  animation-delay: 900ms;
 }
 
 .boot-copy {
@@ -309,18 +212,6 @@ button,
   font-weight: var(--type-weight-semibold);
 }
 
-@keyframes bootOrbit {
-  0%,
-  100% {
-    border-color: var(--border-subtle);
-    box-shadow: none;
-  }
-  50% {
-    border-color: var(--accent-soft-border);
-    box-shadow: 0 0 0 8px var(--accent-soft);
-  }
-}
-
 @keyframes bootCore {
   0%,
   100% {
@@ -330,32 +221,6 @@ button,
   50% {
     transform: scale(1.035);
     box-shadow: var(--state-selected-emphasis-shadow);
-  }
-}
-
-@keyframes bootNode {
-  0%,
-  100% {
-    color: var(--ink-primary);
-    border-color: var(--border-emphasis);
-  }
-  45% {
-    color: var(--accent);
-    border-color: var(--accent-soft-hover-border);
-  }
-}
-
-@keyframes bootLink {
-  0%,
-  20%,
-  100% {
-    opacity: 0;
-    clip-path: inset(0 100% 0 0);
-  }
-  45%,
-  68% {
-    opacity: 0.74;
-    clip-path: inset(0 0 0 0);
   }
 }
 
@@ -377,10 +242,7 @@ button,
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .boot-orbit,
   .boot-core,
-  .boot-node,
-  .boot-link,
   .boot-status span {
     animation: none;
   }
@@ -390,10 +252,6 @@ button,
     transform: none;
   }
 
-  .boot-link {
-    opacity: 0.42;
-    clip-path: none;
-  }
 }
 
 :root,

--- a/src/styles.css
+++ b/src/styles.css
@@ -173,28 +173,34 @@ button,
   animation: bootNode 2400ms ease-in-out infinite;
 }
 
-.node-dylan {
+.node-lantor-a {
   top: 12px;
   left: 50%;
   transform: translateX(-50%);
 }
 
-.node-bugen {
-  top: 88px;
+.node-lantor-n {
+  top: 74px;
   right: 6px;
   animation-delay: 180ms;
 }
 
-.node-admin {
-  bottom: 24px;
-  right: 44px;
+.node-lantor-t {
+  bottom: 22px;
+  right: 36px;
   animation-delay: 360ms;
 }
 
-.node-owner {
-  bottom: 56px;
-  left: 8px;
+.node-lantor-o {
+  bottom: 22px;
+  left: 36px;
   animation-delay: 540ms;
+}
+
+.node-lantor-r {
+  top: 74px;
+  left: 6px;
+  animation-delay: 720ms;
 }
 
 .boot-link {
@@ -229,6 +235,14 @@ button,
   width: 100px;
   transform: rotate(-32deg);
   animation-delay: 600ms;
+}
+
+.link-four {
+  top: 78px;
+  left: 40px;
+  width: 88px;
+  transform: rotate(-30deg);
+  animation-delay: 900ms;
 }
 
 .boot-copy {


### PR DESCRIPTION
## Summary
- keep the startup splash center L mark, orbit, and animated connecting lines
- remove the five outer letter/node decorations from both React boot screen and native splash HTML

## Validation
- npm run build
- npm run lint:css-tokens
- git diff --check