### PR TITLE
Keep boot splash visible for at least 3 seconds

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -144,7 +144,7 @@ const MIN_COMPACT_SIDEBAR_VISIBLE_WIDTH = 220;
 const MOBILE_BREAKPOINT = 760;
 const UI_REFRESH_DEBOUNCE_MS = 80;
 const EPHEMERAL_FLUSH_FALLBACK_MS = 80;
-const MIN_BOOT_SPLASH_MS = 1400;
+const MIN_BOOT_SPLASH_MS = 3000;
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 const ACTIVITY_HISTORY_LIMIT_PER_AGENT = 80;
 // Issue #82: run states that must bypass the ephemeral coalescing buffer


### PR DESCRIPTION
## Summary\n- Increase the React boot splash minimum display duration from 1.4s to 3s.\n\n## Test\n- npm run build