### PR TITLE
Show streaming agent replies once content arrives

### DIFF
--- a/src/components/ActivityProgressDock.tsx
+++ b/src/components/ActivityProgressDock.tsx
@@ -21,7 +21,7 @@ import {
 import type { LucideIcon } from "lucide-react";
 import { useState } from "react";
 import type { Agent, AgentActivity, AgentRun, AgentWorkItem, Message } from "../types";
-import { messageRunId } from "../message-grouping";
+import { messageHasVisibleContent, messageRunId } from "../message-grouping";
 import { formatClockTime } from "../ui-utils";
 import { AgentAvatar } from "./AgentAvatar";
 
@@ -350,7 +350,8 @@ export function activeProgressByAgent(
       runId
       && message.sender_role !== "owner"
       && message.sender_role !== "system"
-      && message.delivery_state === "streaming");
+      && message.delivery_state === "streaming"
+      && !messageHasVisibleContent(message));
 
   const activitiesByRun = new Map<string, AgentActivity[]>();
   activities

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -22,7 +22,7 @@ import { isImeComposing } from "../input-utils";
 import { mentionableAgentsForChannel } from "../mentions";
 import { copyText } from "../clipboard";
 import { APP_DISPLAY_NAME } from "../branding";
-import { isCompactFollowupMessage, wasEdited } from "../message-grouping";
+import { isCompactFollowupMessage, messageHasVisibleContent, wasEdited } from "../message-grouping";
 import { DESKTOP_MESSAGE_PREVIEW_CHARS, DESKTOP_MESSAGE_PREVIEW_LINES } from "../message-preview";
 import { messageShareLink, messageToMarkdown } from "../message-share";
 import { Agent, AgentActivity, AgentRun, AgentWorkItem, Artifact, Channel, DraftAttachment, Message, OwnerProfile, TASK_STATUSES, Task, ThreadReplySummary } from "../types";
@@ -1009,7 +1009,7 @@ export function Conversation({
                         <Bookmark size={14} />
                       </button>
                     </div>
-                    {message.delivery_state !== "streaming" && (
+                    {(message.delivery_state !== "streaming" || messageHasVisibleContent(message)) && (
                       <>
                         <div className={isLongChannelMessage && !isChannelMessageExpanded ? "message-long-preview collapsed" : "message-long-preview"}>
                           <MessageMarkdown body={message.body} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${message.id}`} />

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -7,7 +7,7 @@ import { APP_DISPLAY_NAME } from "../branding";
 import { isImeComposing } from "../input-utils";
 import { mentionableAgentsForChannel } from "../mentions";
 import { copyText } from "../clipboard";
-import { isCompactFollowupMessage, wasEdited } from "../message-grouping";
+import { isCompactFollowupMessage, messageHasVisibleContent, wasEdited } from "../message-grouping";
 import { DESKTOP_MESSAGE_PREVIEW_CHARS, DESKTOP_MESSAGE_PREVIEW_LINES } from "../message-preview";
 import { messageShareLink, messageToMarkdown } from "../message-share";
 import { downloadThreadPanelSvg } from "../thread-svg-export";
@@ -756,7 +756,7 @@ export function ThreadPanel({
                           <Bookmark size={14} />
                         </button>
                       </div>
-                      {activeRoot.delivery_state !== "streaming" && (() => {
+                      {(activeRoot.delivery_state !== "streaming" || messageHasVisibleContent(activeRoot)) && (() => {
                         const isLongThreadMessage = shouldCollapseThreadMessage(activeRoot.body);
                         const isThreadMessageExpanded = expandedThreadMessageIds.has(activeRoot.id);
                         return (
@@ -1026,7 +1026,7 @@ export function ThreadPanel({
                           <Bookmark size={14} />
                         </button>
                       </div>
-                      {reply.delivery_state !== "streaming" && (() => {
+                      {(reply.delivery_state !== "streaming" || messageHasVisibleContent(reply)) && (() => {
                         const isLongThreadMessage = shouldCollapseThreadMessage(reply.body);
                         const isThreadMessageExpanded = expandedThreadMessageIds.has(reply.id);
                         return (

--- a/src/message-grouping.ts
+++ b/src/message-grouping.ts
@@ -17,7 +17,7 @@ export function messageHasVisibleContent(message: Message) {
 export function isProgressOnlyMessage(message: Message) {
   if (!messageRunId(message)) return false;
   if (message.sender_role === "owner" || message.sender_role === "system") return false;
-  if (message.delivery_state === "streaming") return true;
+  if (message.delivery_state === "streaming") return !messageHasVisibleContent(message);
   return message.delivery_state === "complete" && !messageHasVisibleContent(message);
 }
 


### PR DESCRIPTION
## Summary
- keep empty streaming placeholders hidden as progress-only messages
- render streaming agent replies in the normal message list once they have visible content
- keep ActivityProgressDock scoped to empty progress-only streaming placeholders so body-bearing replies do not double-render in Dock + thread
- apply the same behavior to root channel messages and thread replies

## Context
This targets the agent streaming handoff flash/settle behavior reported in #lantor. PR #118 addresses owner optimistic-message reconciliation; this is a separate frontend streaming display issue.

## Verification
- npm run build