### PR TITLE
Make save/unsave message optimistic

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -811,6 +811,9 @@ function App() {
   const messageDeltaBufferRef = useRef<Map<string, { append: string; deliveryState: Message["delivery_state"] }>>(new Map());
   const optimisticMessagesRef = useRef<Map<string, Message>>(new Map());
   const optimisticAttachmentUrlsRef = useRef<Map<string, string[]>>(new Map());
+  // Per-message latest-intent sequence for save/unsave, so a late-failing
+  // request cannot roll back over a newer toggle for the same message.
+  const savedToggleSeqRef = useRef<Map<string, number>>(new Map());
   const messageDeltaFlushTimerRef = useRef<number | null>(null);
   // Ephemeral event buffer (issue #82): coalesces high-frequency progress
   // upserts keyed by (kind, id) — latest-wins — and flushes in a single
@@ -3641,25 +3644,44 @@ function App() {
   // backend still emits `saved_message_updated`, which triggers a later refresh
   // that reconciles the optimistic entry with the authoritative row.
   async function toggleMessageSaved(messageId: string, saved: boolean, optimisticEntry?: SavedMessage) {
-    const snapshot = data?.saved_messages ?? null;
+    // Mark this as the latest intent for this message. A request that fails
+    // after a newer toggle landed must NOT roll back, or rapid save→unsave
+    // would be clobbered back to the stale state.
+    const seq = (savedToggleSeqRef.current.get(messageId) ?? 0) + 1;
+    savedToggleSeqRef.current.set(messageId, seq);
+
+    // Optimistically patch only this message's entry. Capture its prior entry
+    // (if any) so a failure can restore exactly this one message rather than
+    // overwriting the whole list (which could drop other in-flight toggles).
+    let priorEntry: SavedMessage | undefined;
     setData((current) => {
       if (!current) return current;
+      priorEntry = current.saved_messages.find((item) => item.message_id === messageId);
+      const without = current.saved_messages.filter((item) => item.message_id !== messageId);
       const next = saved
-        ? current.saved_messages.some((item) => item.message_id === messageId)
-          ? current.saved_messages
-          : optimisticEntry
-            ? [optimisticEntry, ...current.saved_messages]
-            : current.saved_messages
-        : current.saved_messages.filter((item) => item.message_id !== messageId);
+        ? optimisticEntry
+          ? [optimisticEntry, ...without]
+          : priorEntry
+            ? current.saved_messages // already saved, no entry to add — leave as-is
+            : without
+        : without;
       if (next === current.saved_messages) return current;
       return { ...current, saved_messages: next };
     });
+
     try {
       await apiInvoke("set_message_saved", { messageId, saved });
     } catch (err) {
-      // Roll back to the pre-click snapshot and surface the error.
-      setData((current) => (current && snapshot ? { ...current, saved_messages: snapshot } : current));
-      setAppError(errorMessage(err, "set_message_saved failed"));
+      // Only roll back if no newer toggle for this message superseded us.
+      if (savedToggleSeqRef.current.get(messageId) === seq) {
+        setData((current) => {
+          if (!current) return current;
+          const without = current.saved_messages.filter((item) => item.message_id !== messageId);
+          const restored = priorEntry ? [priorEntry, ...without] : without;
+          return { ...current, saved_messages: restored };
+        });
+        setAppError(errorMessage(err, "set_message_saved failed"));
+      }
       console.error(err);
     }
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3636,12 +3636,54 @@ function App() {
     window.addEventListener("pointerup", onPointerUp);
   }
 
+  // Optimistically toggle saved state so the bookmark button responds instantly,
+  // instead of waiting for the backend command + a full bootstrap refresh. The
+  // backend still emits `saved_message_updated`, which triggers a later refresh
+  // that reconciles the optimistic entry with the authoritative row.
+  async function toggleMessageSaved(messageId: string, saved: boolean, optimisticEntry?: SavedMessage) {
+    const snapshot = data?.saved_messages ?? null;
+    setData((current) => {
+      if (!current) return current;
+      const next = saved
+        ? current.saved_messages.some((item) => item.message_id === messageId)
+          ? current.saved_messages
+          : optimisticEntry
+            ? [optimisticEntry, ...current.saved_messages]
+            : current.saved_messages
+        : current.saved_messages.filter((item) => item.message_id !== messageId);
+      if (next === current.saved_messages) return current;
+      return { ...current, saved_messages: next };
+    });
+    try {
+      await apiInvoke("set_message_saved", { messageId, saved });
+    } catch (err) {
+      // Roll back to the pre-click snapshot and surface the error.
+      setData((current) => (current && snapshot ? { ...current, saved_messages: snapshot } : current));
+      setAppError(errorMessage(err, "set_message_saved failed"));
+      console.error(err);
+    }
+  }
+
   async function setMessageSaved(message: Message, saved: boolean) {
-    await mutate("set_message_saved", { messageId: message.id, saved });
+    const optimisticEntry: SavedMessage | undefined = saved
+      ? {
+          id: `optimistic-saved:${message.id}`,
+          message_id: message.id,
+          channel_id: message.channel_id,
+          channel_name: data?.channels.find((channel) => channel.id === message.channel_id)?.name ?? "",
+          thread_root_id: message.thread_root_id,
+          sender_name: message.sender_name,
+          sender_role: message.sender_role,
+          body: message.body,
+          message_created_at: message.created_at,
+          created_at: new Date().toISOString(),
+        }
+      : undefined;
+    await toggleMessageSaved(message.id, saved, optimisticEntry);
   }
 
   async function unsaveSavedMessage(item: SavedMessage) {
-    await mutate("set_message_saved", { messageId: item.message_id, saved: false });
+    await toggleMessageSaved(item.message_id, false);
   }
 
   async function installSupervisorService() {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -814,6 +814,8 @@ function App() {
   // Per-message latest-intent sequence for save/unsave, so a late-failing
   // request cannot roll back over a newer toggle for the same message.
   const savedToggleSeqRef = useRef<Map<string, number>>(new Map());
+  const pendingSavedToggleOverridesRef = useRef<Map<string, { saved: boolean; entry?: SavedMessage; seq: number }>>(new Map());
+  const savedToggleRequestChainsRef = useRef<Map<string, Promise<void>>>(new Map());
   const messageDeltaFlushTimerRef = useRef<number | null>(null);
   // Ephemeral event buffer (issue #82): coalesces high-frequency progress
   // upserts keyed by (kind, id) — latest-wins — and flushes in a single
@@ -909,7 +911,7 @@ function App() {
   async function refresh(includeOptimistic = true, preferredActiveChannelId?: string) {
     const refreshInvalidation = refreshInvalidationRef.current;
     const next = normalizeBootstrap(await apiInvoke<Bootstrap>("bootstrap"));
-    const refreshed = includeOptimistic ? withOptimisticMessages(next) : next;
+    const refreshed = withPendingSavedToggles(includeOptimistic ? withOptimisticMessages(next) : next);
     setData((current) => {
       if (!current || refreshInvalidation === refreshInvalidationRef.current) return refreshed;
       const refreshedMessageIds = new Set(refreshed.messages.map((message) => message.id));
@@ -986,6 +988,24 @@ function App() {
       .filter((message) => !existingIds.has(message.id));
     if (optimisticMessages.length === 0) return next;
     return { ...next, messages: sortedMessages([...next.messages, ...optimisticMessages]) };
+  }
+
+  function savedMessagesWithState(savedMessages: SavedMessage[], messageId: string, saved: boolean, savedEntry?: SavedMessage) {
+    const withoutMessage = savedMessages.filter((item) => item.message_id !== messageId);
+    if (!saved) return withoutMessage.length === savedMessages.length ? savedMessages : withoutMessage;
+    const existing = savedMessages.find((item) => item.message_id === messageId) ?? null;
+    if (!savedEntry && existing) return savedMessages;
+    if (!savedEntry) return savedMessages;
+    return [savedEntry, ...withoutMessage];
+  }
+
+  function withPendingSavedToggles(next: Bootstrap): Bootstrap {
+    if (pendingSavedToggleOverridesRef.current.size === 0) return next;
+    let savedMessages = next.saved_messages;
+    for (const [messageId, override] of pendingSavedToggleOverridesRef.current) {
+      savedMessages = savedMessagesWithState(savedMessages, messageId, override.saved, override.entry);
+    }
+    return savedMessages === next.saved_messages ? next : { ...next, saved_messages: savedMessages };
   }
 
   function flushMessageDeltas() {
@@ -3643,7 +3663,7 @@ function App() {
   // instead of waiting for the backend command + a full bootstrap refresh. The
   // backend still emits `saved_message_updated`, which triggers a later refresh
   // that reconciles the optimistic entry with the authoritative row.
-  async function toggleMessageSaved(messageId: string, saved: boolean, optimisticEntry?: SavedMessage) {
+  function toggleMessageSaved(messageId: string, saved: boolean, optimisticEntry?: SavedMessage) {
     // Mark this as the latest intent for this message. A request that fails
     // after a newer toggle landed must NOT roll back, or rapid save→unsave
     // would be clobbered back to the stale state.
@@ -3657,33 +3677,43 @@ function App() {
     setData((current) => {
       if (!current) return current;
       priorEntry = current.saved_messages.find((item) => item.message_id === messageId);
-      const without = current.saved_messages.filter((item) => item.message_id !== messageId);
-      const next = saved
-        ? optimisticEntry
-          ? [optimisticEntry, ...without]
-          : priorEntry
-            ? current.saved_messages // already saved, no entry to add — leave as-is
-            : without
-        : without;
+      const next = savedMessagesWithState(current.saved_messages, messageId, saved, optimisticEntry ?? priorEntry);
       if (next === current.saved_messages) return current;
       return { ...current, saved_messages: next };
     });
+    pendingSavedToggleOverridesRef.current.set(messageId, {
+      saved,
+      entry: saved ? optimisticEntry ?? priorEntry : undefined,
+      seq,
+    });
 
-    try {
-      await apiInvoke("set_message_saved", { messageId, saved });
-    } catch (err) {
-      // Only roll back if no newer toggle for this message superseded us.
-      if (savedToggleSeqRef.current.get(messageId) === seq) {
-        setData((current) => {
-          if (!current) return current;
-          const without = current.saved_messages.filter((item) => item.message_id !== messageId);
-          const restored = priorEntry ? [priorEntry, ...without] : without;
-          return { ...current, saved_messages: restored };
-        });
-        setAppError(errorMessage(err, "set_message_saved failed"));
-      }
-      console.error(err);
-    }
+    const previousRequest = savedToggleRequestChainsRef.current.get(messageId) ?? Promise.resolve();
+    const request = previousRequest
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          await apiInvoke("set_message_saved", { messageId, saved });
+        } catch (err) {
+          // Only roll back if no newer toggle for this message superseded us.
+          if (savedToggleSeqRef.current.get(messageId) === seq) {
+            setData((current) => current
+              ? { ...current, saved_messages: savedMessagesWithState(current.saved_messages, messageId, Boolean(priorEntry), priorEntry) }
+              : current);
+            setAppError(errorMessage(err, "set_message_saved failed"));
+          }
+          console.error(err);
+        } finally {
+          if (pendingSavedToggleOverridesRef.current.get(messageId)?.seq === seq) {
+            pendingSavedToggleOverridesRef.current.delete(messageId);
+          }
+        }
+      })
+      .finally(() => {
+        if (savedToggleRequestChainsRef.current.get(messageId) === request) {
+          savedToggleRequestChainsRef.current.delete(messageId);
+        }
+      });
+    savedToggleRequestChainsRef.current.set(messageId, request);
   }
 
   async function setMessageSaved(message: Message, saved: boolean) {


### PR DESCRIPTION
## What & why
Saving/unsaving a message felt sluggish (~1s) before the bookmark highlight changed.

**Root cause** (not #145): the button state is derived from `data.saved_messages` (`savedMessageIds`), and the toggle went through `mutate("set_message_saved", ...)`, which awaited the backend command and then `await refresh()` for a full bootstrap before returning. The backend also emits a generic `saved_message_updated` refresh, so the UI waited on backend + full bootstrap work before the bookmark state changed.

## Change
- `setMessageSaved` / `unsaveSavedMessage` no longer go through `mutate()`. They optimistically patch `data.saved_messages` and call `apiInvoke("set_message_saved", ...)` directly, so the bookmark responds instantly.
- Failure rollback is per message, not whole-array: only the affected message entry is restored, and only if that failed request is still the latest intent for that message.
- Rapid save/unsave clicks are serialized per message before hitting the backend, preserving click order in DB writes.
- Pending save/unsave intent is also applied over bootstrap refresh results, so the backend generic refresh cannot briefly flash the bookmark back to an older state while a newer toggle is pending.
- Backend event protocol is unchanged; `saved_message_updated` still reconciles the optimistic entry with the authoritative row.

Scope intentionally stays separate from #145, which only fixes agent streaming-message rendering.

## Testing
- `npm run build` ✅