### PR TITLE
UI: surface supervisor stale/offline so 'queued' isn't mistaken for a stuck agent

### DIFF
--- a/src/components/ActivityProgressDock.tsx
+++ b/src/components/ActivityProgressDock.tsx
@@ -1,5 +1,6 @@
 import {
   AlertCircle,
+  AlertTriangle,
   ArrowRightLeft,
   AtSign,
   Bell,
@@ -33,6 +34,7 @@ type ActivityProgressDockProps = {
   agents: Agent[];
   channelId: string | null;
   threadRootId: string | null;
+  supervisorStale?: boolean;
   onOpenWorkItem?: (item: AgentWorkItem, focusedMessageIdOverride?: string | null) => void;
 };
 
@@ -477,6 +479,7 @@ export function ActivityProgressDock({
   agents,
   channelId,
   threadRootId,
+  supervisorStale = false,
   onOpenWorkItem,
 }: ActivityProgressDockProps) {
   const [historyOpen, setHistoryOpen] = useState(false);
@@ -516,6 +519,10 @@ export function ActivityProgressDock({
     .sort((left, right) => timestamp(right.activity.created_at) - timestamp(left.activity.created_at))
     .slice(0, MAX_PROGRESS_HISTORY_ITEMS);
   const state = providerRetrying ? "provider-retrying" : latestWorking ? "working" : "queued";
+  // While the supervisor heartbeat is stale/offline, queued work won't be
+  // claimed — surface the root cause instead of letting it read as normal queueing.
+  const supervisorBlocked = supervisorStale && (state === "queued" || queuedCount > 0);
+  const supervisorBlockedHint = "backend supervisor unavailable — 排队的 agent 暂停调度，直到 supervisor 恢复。";
 
   const handleJump = () => {
     if (!latestSourceWorkItem || !onOpenWorkItem) return;
@@ -524,7 +531,12 @@ export function ActivityProgressDock({
 
   return (
     <div className="activity-progress-dock" data-source-kind={latestKindMeta.tone}>
-      <div className="activity-progress-summary" data-state={state}>
+      <div
+        className="activity-progress-summary"
+        data-state={state}
+        data-supervisor-stale={supervisorBlocked ? "true" : undefined}
+        title={supervisorBlocked ? supervisorBlockedHint : undefined}
+      >
         <button
           type="button"
           className="activity-progress-summary-main"
@@ -553,6 +565,11 @@ export function ActivityProgressDock({
               <span>{latestTitle}</span>
               {latestDetail && <em>{compact(latestDetail, 80)}</em>}
               {queuedCount > 0 && <em>{queuedCount} queued on this surface</em>}
+              {supervisorBlocked && (
+                <em className="activity-progress-supervisor-hint">
+                  <AlertTriangle size={12} aria-hidden="true" /> supervisor 不可用 · 调度暂停
+                </em>
+              )}
             </small>
           </span>
           {jumpable && (

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -48,6 +48,7 @@ type ConversationProps = {
   agentActivities: AgentActivity[];
   agentRuns: AgentRun[];
   agentWorkItems: AgentWorkItem[];
+  supervisorStale: boolean;
   channelAgents: Agent[];
   activeTab: "chat" | "tasks";
   activeRoot: Message | null;
@@ -209,6 +210,7 @@ export function Conversation({
   agentActivities,
   agentRuns,
   agentWorkItems,
+  supervisorStale,
   channelAgents,
   activeTab,
   activeRoot,
@@ -808,6 +810,7 @@ export function Conversation({
               agents={agents}
               channelId={channel?.id ?? null}
               threadRootId={null}
+              supervisorStale={supervisorStale}
               onOpenWorkItem={openWorkItem}
             />
           </div>

--- a/src/components/SupervisorBanner.tsx
+++ b/src/components/SupervisorBanner.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from "react";
+import { AlertTriangle } from "lucide-react";
+import type { SupervisorStatus } from "../types";
+
+// The backend marks the supervisor "stale" once its heartbeat (`updated_at`) is
+// older than this, and "offline" when there is no supervisor row at all. We
+// mirror the same threshold on the client so the banner can appear even when the
+// backend has stopped pushing fresh bootstrap snapshots (e.g. the supervisor
+// process died mid-window and nothing is emitting `app_state_changed`).
+const STALE_AFTER_MS = 10_000;
+const TICK_MS = 5_000;
+
+export type SupervisorHealth = {
+  /** Scheduling is paused: the supervisor is offline or its heartbeat is stale. */
+  stale: boolean;
+  /** Normalized status: "offline" | "stale" | the raw backend status. */
+  status: string;
+  /** Seconds since the last heartbeat, or null when never seen / offline. */
+  secondsSinceHeartbeat: number | null;
+};
+
+/**
+ * Derive supervisor health from the bootstrap `supervisor` field, re-evaluating
+ * freshness on a timer so a heartbeat that goes stale surfaces without waiting
+ * for the next backend state push.
+ */
+export function useSupervisorHealth(
+  supervisor: SupervisorStatus | null | undefined,
+): SupervisorHealth {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), TICK_MS);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  if (!supervisor) {
+    return { stale: false, status: "unknown", secondsSinceHeartbeat: null };
+  }
+
+  if (supervisor.status === "offline" || !supervisor.updated_at) {
+    return { stale: true, status: "offline", secondsSinceHeartbeat: null };
+  }
+
+  const heartbeatMs = new Date(supervisor.updated_at).getTime();
+  const ageMs = Number.isFinite(heartbeatMs) ? Math.max(0, now - heartbeatMs) : null;
+  // Trust the backend's own verdict, but also re-derive client-side.
+  const stale = supervisor.status === "stale" || (ageMs !== null && ageMs > STALE_AFTER_MS);
+
+  return {
+    stale,
+    status: stale ? "stale" : supervisor.status,
+    secondsSinceHeartbeat: ageMs === null ? null : Math.round(ageMs / 1000),
+  };
+}
+
+/** Short root-cause hint shown on queued work while the supervisor is down. */
+export function supervisorQueuedHint(health: SupervisorHealth): string | null {
+  if (!health.stale) return null;
+  return health.status === "offline"
+    ? "调度进程未在运行：排队的 agent 不会被调度，直到 supervisor 恢复。"
+    : "supervisor 心跳停滞：排队的 agent 暂停调度，直到 supervisor 恢复。";
+}
+
+export function SupervisorBanner({ health }: { health: SupervisorHealth }) {
+  if (!health.stale) return null;
+
+  const offline = health.status === "offline";
+  const detail = offline
+    ? "调度进程未在运行，排队中的 agent 不会被调度。"
+    : health.secondsSinceHeartbeat !== null
+      ? `已 ${health.secondsSinceHeartbeat}s 未收到心跳，排队中的 agent 暂停调度。`
+      : "心跳停滞，排队中的 agent 暂停调度。";
+
+  return (
+    <div className="supervisor-banner" role="alert">
+      <AlertTriangle size={16} className="supervisor-banner-icon" aria-hidden="true" />
+      <div className="supervisor-banner-copy">
+        <strong>backend supervisor unavailable — agent 调度暂停</strong>
+        <span>{detail}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -76,6 +76,7 @@ type ThreadPanelProps = {
   agentActivities: AgentActivity[];
   agentRuns: AgentRun[];
   agentWorkItems: AgentWorkItem[];
+  supervisorStale: boolean;
   activeRoot: Message | null;
   activeTask: Task | null;
   replies: Message[];
@@ -138,6 +139,7 @@ export function ThreadPanel({
   agentActivities,
   agentRuns,
   agentWorkItems,
+  supervisorStale,
   activeRoot,
   activeTask,
   replies,
@@ -646,6 +648,7 @@ export function ThreadPanel({
               agents={agents}
               channelId={activeRoot ? channel?.id ?? null : null}
               threadRootId={activeRoot?.id ?? null}
+              supervisorStale={supervisorStale}
               onOpenWorkItem={openWorkItem}
             />
           </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -31,6 +31,7 @@ import { SavedMessagesModal } from "./components/SavedMessagesModal";
 import { SearchModal } from "./components/SearchModal";
 import { SettingsModal, type ChatTextSize, type ThemePreference } from "./components/SettingsModal";
 import { Sidebar } from "./components/Sidebar";
+import { SupervisorBanner, useSupervisorHealth } from "./components/SupervisorBanner";
 import { ThreadPanel } from "./components/ThreadPanel";
 import { UnreadBadge } from "./components/UnreadBadge";
 import { isProgressOnlyMessage } from "./message-grouping";
@@ -3746,6 +3747,9 @@ function App() {
     await mutate("uninstall_supervisor_service");
   }
 
+  const supervisorHealth = useSupervisorHealth(data?.supervisor);
+  const supervisorStale = supervisorHealth.stale;
+
   if (!data || !bootReady) {
     return (
       <BootSplash
@@ -3758,6 +3762,7 @@ function App() {
   return (
     <main
       className={`app theme-liquid ${selectedAgent || showThread ? "" : "thread-hidden"} ${selectedAgent || activeThreadId ? "right-panel-active" : ""} ${showMobileSidebar ? "mobile-sidebar-open" : ""} ${mobileDragSurface === "sidebar" ? "mobile-sidebar-dragging" : ""} ${mobileDragSurface === "panel" ? "mobile-panel-dragging" : ""} ${mobileComposerFocused ? "mobile-composer-focused" : ""}`}
+      data-supervisor-stale={supervisorStale ? "true" : undefined}
       style={{
         "--sidebar-width": `${sidebarWidth}px`,
         "--thread-width": `${selectedAgent ? agentDrawerWidth : threadPanelWidth}px`,
@@ -3765,6 +3770,7 @@ function App() {
         ...UI_TYPE_SCALE[chatTextSize],
       } as CSSProperties}
     >
+      <SupervisorBanner health={supervisorHealth} />
       <Sidebar
         data={data}
         channel={channel}
@@ -3892,6 +3898,7 @@ function App() {
         agentActivities={data.agent_activities}
         agentRuns={data.agent_runs}
         agentWorkItems={data.agent_work_items}
+        supervisorStale={supervisorStale}
         channelAgents={channelAgents}
         activeTab={activeTab}
         activeRoot={activeRoot}
@@ -3969,6 +3976,7 @@ function App() {
           agentActivities={data.agent_activities}
           agentRuns={data.agent_runs}
           agentWorkItems={data.agent_work_items}
+          supervisorStale={supervisorStale}
           activeRoot={activeRoot}
           activeTask={activeTask}
           replies={replies}

--- a/src/styles.css
+++ b/src/styles.css
@@ -10647,3 +10647,55 @@ body.resizing-column * {
     border-color: var(--modal-mobile-card-border);
   }
 }
+
+/* Supervisor stale/offline banner — scheduling is paused. */
+.app[data-supervisor-stale="true"] {
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.supervisor-banner {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  background: var(--status-warning-soft);
+  border-bottom: 1px solid var(--status-warning-border);
+  color: var(--status-warning);
+  z-index: 5;
+}
+
+.supervisor-banner-icon {
+  flex: 0 0 auto;
+  color: var(--status-warning);
+}
+
+.supervisor-banner-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.supervisor-banner-copy strong {
+  font-size: var(--type-size-meta);
+  font-weight: var(--type-weight-medium);
+  letter-spacing: 0.01em;
+}
+
+.supervisor-banner-copy span {
+  font-size: var(--type-size-caption);
+  color: var(--ink-muted);
+}
+
+.activity-progress-summary[data-supervisor-stale="true"] {
+  border-color: var(--status-warning-border);
+}
+
+.activity-progress-supervisor-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-style: normal;
+  color: var(--status-warning);
+}


### PR DESCRIPTION
## Why
When the supervisor process is down or restarting, work items still showed only their `queued` status. Users couldn't distinguish **normal queueing** from **supervisor isn't scheduling at all**. This was the root cause of a real incident — an 8m21s restart window where no command was claimed and the user thought an agent was stuck.

Closes task #3.

## What
- **`useSupervisorHealth()`** (new `SupervisorBanner.tsx`): derives `stale`/`offline` from the bootstrap `supervisor` field and re-evaluates `updated_at` freshness on a 5s ticker — so a heartbeat that goes stale surfaces even when the backend has stopped pushing fresh bootstrap snapshots (exactly the supervisor-died case).
- **`SupervisorBanner`**: a prominent top-of-app banner shown when stale/offline — `backend supervisor unavailable — agent 调度暂停`, with a detail line (offline vs. Ns since heartbeat). The `.app` grid gets an `auto minmax(0,1fr)` row only when `data-supervisor-stale="true"`.
- **`ActivityProgressDock`**: when the supervisor is stale *and* there is queued work, shows a root-cause hint (`supervisor 不可用 · 调度暂停`) plus a tooltip on the queued summary, instead of letting it read as ordinary queueing.

## Backend
No backend change needed — `runtime::supervisor::load_supervisor_status` already returns `offline` / `stale` (>10s) / `running`. This PR wires the existing `state.supervisor` field (previously **zero** consumers in `src/`) into the UI, and adds a client-side freshness re-derivation for liveness.

## Verification
- `node scripts/check-raw-colors.mjs` -> style token gate ok, none new
- `npm run build` (`tsc && vite build`) -> built, no type errors

## Files
`src/components/SupervisorBanner.tsx` (new), `src/main.tsx`, `src/components/Conversation.tsx`, `src/components/ThreadPanel.tsx`, `src/components/ActivityProgressDock.tsx`, `src/styles.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)