### PR TITLE
fix(runtime): don't poison agent status to sticky error on transient warm-turn failure

### DIFF
--- a/src-tauri/src/runtime/claude.rs
+++ b/src-tauri/src/runtime/claude.rs
@@ -769,3 +769,182 @@ async fn remove_warm_claude_runtime_if_same(
         runtimes.remove(&agent_id);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{process::Stdio, sync::Arc, time::Instant};
+
+    use sqlx::Row;
+    use tokio::{process::Command, sync::Mutex as AsyncMutex};
+    use uuid::Uuid;
+
+    use crate::test_support::{
+        drop_test_schema, insert_test_agent, insert_test_channel, test_pool,
+    };
+
+    use super::{finish_warm_claude_active_turn, ClaudeActiveTurn, WarmClaudeRuntime};
+
+    async fn test_runtime_with_active_turn(
+        run_id: Uuid,
+        work_item_id: Uuid,
+        channel_id: Uuid,
+        stream_key: String,
+    ) -> Result<Arc<WarmClaudeRuntime>, String> {
+        let mut command = Command::new("sleep");
+        command.arg("60").stdin(Stdio::piped());
+        #[cfg(unix)]
+        command.process_group(0);
+        let mut child = command.spawn().map_err(|err| err.to_string())?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "test process stdin unavailable".to_owned())?;
+        Ok(Arc::new(WarmClaudeRuntime {
+            stdin: AsyncMutex::new(stdin),
+            state: AsyncMutex::new(super::WarmClaudeState {
+                alive: true,
+                active: Some(ClaudeActiveTurn {
+                    run_id,
+                    started_at: Instant::now(),
+                    first_delta_at: None,
+                    work_item_id: Some(work_item_id),
+                    channel_id: Some(channel_id),
+                    thread_root_id: None,
+                    stream_key,
+                }),
+                session_id: Some("test-claude-session".to_owned()),
+                last_surface: None,
+                last_activity: Instant::now(),
+            }),
+            pid: child.id().map(|id| id as i32),
+            environment_variables: String::new(),
+        }))
+    }
+
+    #[tokio::test]
+    async fn failed_warm_claude_turn_keeps_agent_routable_and_stops_runtime() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let agent_id = insert_test_agent(&pool, "claude-failure-agent").await?;
+            sqlx::query("update agents set status = 'running', runtime = 'claude' where id = $1")
+                .bind(agent_id)
+                .execute(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+            let channel_id = insert_test_channel(&pool, "claude-failure-channel").await?;
+            let work_item_id: Uuid = sqlx::query_scalar(
+                r#"
+                insert into agent_work_items (agent_id, channel_id, title, status)
+                values ($1, $2, 'warm claude failure', 'running')
+                returning id
+                "#,
+            )
+            .bind(agent_id)
+            .bind(channel_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            let run_id: Uuid = sqlx::query_scalar(
+                r#"
+                insert into agent_runs (agent_id, work_item_id, command, status)
+                values ($1, $2, 'claude stream-json', 'running')
+                returning id
+                "#,
+            )
+            .bind(agent_id)
+            .bind(work_item_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            let stream_key = format!("{run_id}:warm-claude");
+            sqlx::query(
+                r#"
+                insert into messages (
+                    channel_id, sender_agent_id, sender_name, sender_role,
+                    body, delivery_state, stream_key
+                )
+                values ($1, $2, 'claude-failure-agent', 'agent', 'partial', 'streaming', $3)
+                "#,
+            )
+            .bind(channel_id)
+            .bind(agent_id)
+            .bind(&stream_key)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let runtime =
+                test_runtime_with_active_turn(run_id, work_item_id, channel_id, stream_key.clone())
+                    .await?;
+            finish_warm_claude_active_turn(
+                &pool,
+                agent_id,
+                &runtime,
+                false,
+                Some("Not logged in · Please run /login".to_owned()),
+            )
+            .await?;
+
+            let agent_status: String =
+                sqlx::query_scalar("select status from agents where id = $1")
+                    .bind(agent_id)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|err| err.to_string())?;
+            assert_eq!(agent_status, "idle");
+
+            let run = sqlx::query("select status, log, stopped_at from agent_runs where id = $1")
+                .bind(run_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+            assert_eq!(run.get::<String, _>("status"), "failed");
+            assert!(run
+                .get::<String, _>("log")
+                .contains("Not logged in · Please run /login"));
+            assert!(run.get::<Option<String>, _>("stopped_at").is_some());
+
+            let work_status: String =
+                sqlx::query_scalar("select status from agent_work_items where id = $1")
+                    .bind(work_item_id)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|err| err.to_string())?;
+            assert_eq!(work_status, "failed");
+
+            let delivery_state: String =
+                sqlx::query_scalar("select delivery_state from messages where stream_key = $1")
+                    .bind(&stream_key)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|err| err.to_string())?;
+            assert_eq!(delivery_state, "error");
+
+            let runtime_status: String = sqlx::query_scalar(
+                "select status from runtime_sessions where agent_id = $1 and runtime = 'claude'",
+            )
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            assert_eq!(runtime_status, "stopped");
+            assert!(!runtime.state.lock().await.alive);
+
+            let run_error_count: i64 = sqlx::query_scalar(
+                "select count(*) from agent_activities where agent_id = $1 and run_id = $2 and kind = 'run_error'",
+            )
+            .bind(agent_id)
+            .bind(run_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            assert_eq!(run_error_count, 1);
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        result.unwrap();
+    }
+}

--- a/src-tauri/src/runtime/claude/turn.rs
+++ b/src-tauri/src/runtime/claude/turn.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use super::{ClaudeSurface, WarmClaudeRuntime};
 use crate::events::activity::{record_agent_activity, work_status_title};
 use crate::runtime::{
-    process::upsert_runtime_thread_id,
+    process::{terminate_process_group, upsert_runtime_thread_id},
     streaming::{consume_streaming_agent_control_lines, finish_streaming_agent_message},
 };
 use crate::ui_notifications::{
@@ -85,11 +85,8 @@ pub(super) async fn finish_warm_claude_active_turn(
     } else {
         "failed"
     };
-    let agent_status = if success || was_cancelled {
-        "idle"
-    } else {
-        "error"
-    };
+    let should_reset_runtime = !success && !was_cancelled;
+    let agent_status = "idle";
     let log_line = if was_cancelled {
         "claude warm turn cancelled\n".to_owned()
     } else {
@@ -98,6 +95,15 @@ pub(super) async fn finish_warm_claude_active_turn(
             .map(|error| format!("claude warm turn failed: {error}\n"))
             .unwrap_or_else(|| format!("claude warm turn completed in {elapsed_ms} ms\n"))
     };
+    if should_reset_runtime {
+        {
+            let mut state = runtime.state.lock().await;
+            state.alive = false;
+        }
+        if let Some(pid) = runtime.pid {
+            let _ = terminate_process_group(pid).await;
+        }
+    }
     sqlx::query(
         r#"
         update agent_runs
@@ -188,7 +194,7 @@ pub(super) async fn finish_warm_claude_active_turn(
         if success || was_cancelled {
             "idle"
         } else {
-            "failed"
+            "stopped"
         },
     )
     .await?;

--- a/src-tauri/src/runtime/claude/turn.rs
+++ b/src-tauri/src/runtime/claude/turn.rs
@@ -8,6 +8,7 @@ use crate::events::activity::{record_agent_activity, work_status_title};
 use crate::runtime::{
     process::{terminate_process_group, upsert_runtime_thread_id},
     streaming::{consume_streaming_agent_control_lines, finish_streaming_agent_message},
+    turn_outcome::resolve_warm_turn_outcome,
 };
 use crate::ui_notifications::{
     notify_supervisor_wake, notify_ui_agent_run_changed, notify_ui_work_item_changed,
@@ -78,15 +79,7 @@ pub(super) async fn finish_warm_claude_active_turn(
         .await?;
     }
 
-    let run_status = if was_cancelled {
-        "cancelled"
-    } else if success {
-        "exited"
-    } else {
-        "failed"
-    };
-    let should_reset_runtime = !success && !was_cancelled;
-    let agent_status = "idle";
+    let outcome = resolve_warm_turn_outcome(success, was_cancelled);
     let log_line = if was_cancelled {
         "claude warm turn cancelled\n".to_owned()
     } else {
@@ -95,7 +88,7 @@ pub(super) async fn finish_warm_claude_active_turn(
             .map(|error| format!("claude warm turn failed: {error}\n"))
             .unwrap_or_else(|| format!("claude warm turn completed in {elapsed_ms} ms\n"))
     };
-    if should_reset_runtime {
+    if outcome.should_reset_runtime {
         {
             let mut state = runtime.state.lock().await;
             state.alive = false;
@@ -115,7 +108,7 @@ pub(super) async fn finish_warm_claude_active_turn(
         "#,
     )
     .bind(active.run_id)
-    .bind(run_status)
+    .bind(outcome.run_status)
     .bind(&log_line)
     .execute(pool)
     .await
@@ -124,7 +117,7 @@ pub(super) async fn finish_warm_claude_active_turn(
 
     sqlx::query("update agents set status = $2 where id = $1")
         .bind(agent_id)
-        .bind(agent_status)
+        .bind(outcome.agent_status)
         .execute(pool)
         .await
         .map_err(to_string)?;
@@ -191,29 +184,15 @@ pub(super) async fn finish_warm_claude_active_turn(
         agent_id,
         "claude",
         &provider_thread_id,
-        if success || was_cancelled {
-            "idle"
-        } else {
-            "stopped"
-        },
+        outcome.runtime_session_status,
     )
     .await?;
     record_agent_activity(
         pool,
         Some(agent_id),
         Some(active.run_id),
-        if success || was_cancelled {
-            "run"
-        } else {
-            "run_error"
-        },
-        if was_cancelled {
-            "Stopped"
-        } else if success {
-            "Completed"
-        } else {
-            "Failed"
-        },
+        outcome.activity_kind,
+        outcome.activity_title,
         if success || was_cancelled {
             format!("duration={elapsed_ms} ms")
         } else {

--- a/src-tauri/src/runtime/codex.rs
+++ b/src-tauri/src/runtime/codex.rs
@@ -1614,15 +1614,197 @@ async fn remove_warm_codex_runtime_if_same(
 mod tests {
     use std::{
         collections::{HashMap, HashSet},
+        process::Stdio,
+        sync::Arc,
         time::{Duration, Instant},
     };
 
+    use sqlx::Row;
+    use tokio::{process::Command, sync::Mutex as AsyncMutex};
+
     use crate::runtime::surface::{codex_active_turn_schedule_state, CodexActiveTurnScheduleState};
+    use crate::test_support::{
+        drop_test_schema, insert_test_agent, insert_test_channel, test_pool,
+    };
 
     use super::{
-        codex_rotation_marker, prepend_codex_rotation_marker, track_codex_agent_message_stream,
-        CodexActiveTurn, CODEX_TURN_START_TIMEOUT,
+        codex_rotation_marker, finish_warm_codex_active_turn, prepend_codex_rotation_marker,
+        track_codex_agent_message_stream, CodexActiveTurn, WarmCodexRuntime,
+        CODEX_TURN_START_TIMEOUT,
     };
+
+    async fn test_runtime_with_active_turn(
+        run_id: uuid::Uuid,
+        work_item_id: uuid::Uuid,
+        channel_id: uuid::Uuid,
+        stream_key: String,
+    ) -> Result<Arc<WarmCodexRuntime>, String> {
+        let mut command = Command::new("sleep");
+        command.arg("60").stdin(Stdio::piped());
+        #[cfg(unix)]
+        command.process_group(0);
+        let mut child = command.spawn().map_err(|err| err.to_string())?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "test process stdin unavailable".to_owned())?;
+        Ok(Arc::new(WarmCodexRuntime {
+            stdin: AsyncMutex::new(stdin),
+            state: AsyncMutex::new(super::WarmCodexState {
+                alive: true,
+                active: Some(CodexActiveTurn {
+                    run_id,
+                    turn_request_id: 1,
+                    turn_id: Some("turn-1".to_owned()),
+                    started_at: Instant::now(),
+                    last_event_at: Instant::now(),
+                    first_delta_at: None,
+                    work_item_id: Some(work_item_id),
+                    channel_id: Some(channel_id),
+                    thread_root_id: None,
+                    stream_keys: HashSet::from([stream_key]),
+                    completed_agent_message_stream_keys: HashSet::new(),
+                    latest_agent_message_stream_key: None,
+                    steer_requests: HashMap::new(),
+                    steer_disabled: false,
+                    interrupt_request_id: None,
+                }),
+                next_request_id: 2,
+                pending_rotation_marker: None,
+                last_activity: Instant::now(),
+            }),
+            thread_id: "test-codex-thread".to_owned(),
+            pid: child.id().map(|id| id as i32),
+            environment_variables: String::new(),
+        }))
+    }
+
+    #[tokio::test]
+    async fn failed_warm_codex_turn_keeps_agent_routable_and_stops_runtime() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let agent_id = insert_test_agent(&pool, "codex-failure-agent").await?;
+            sqlx::query("update agents set status = 'running', runtime = 'codex' where id = $1")
+                .bind(agent_id)
+                .execute(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+            let channel_id = insert_test_channel(&pool, "codex-failure-channel").await?;
+            let work_item_id: uuid::Uuid = sqlx::query_scalar(
+                r#"
+                insert into agent_work_items (agent_id, channel_id, title, status)
+                values ($1, $2, 'warm codex failure', 'running')
+                returning id
+                "#,
+            )
+            .bind(agent_id)
+            .bind(channel_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            let run_id: uuid::Uuid = sqlx::query_scalar(
+                r#"
+                insert into agent_runs (agent_id, work_item_id, command, status)
+                values ($1, $2, 'codex app-server', 'running')
+                returning id
+                "#,
+            )
+            .bind(agent_id)
+            .bind(work_item_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            let stream_key = format!("{run_id}:warm-codex");
+            sqlx::query(
+                r#"
+                insert into messages (
+                    channel_id, sender_agent_id, sender_name, sender_role,
+                    body, delivery_state, stream_key
+                )
+                values ($1, $2, 'codex-failure-agent', 'agent', 'partial', 'streaming', $3)
+                "#,
+            )
+            .bind(channel_id)
+            .bind(agent_id)
+            .bind(&stream_key)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let runtime =
+                test_runtime_with_active_turn(run_id, work_item_id, channel_id, stream_key.clone())
+                    .await?;
+            finish_warm_codex_active_turn(
+                &pool,
+                agent_id,
+                &runtime,
+                false,
+                Some("stream disconnected before completion".to_owned()),
+            )
+            .await?;
+
+            let agent_status: String =
+                sqlx::query_scalar("select status from agents where id = $1")
+                    .bind(agent_id)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|err| err.to_string())?;
+            assert_eq!(agent_status, "idle");
+
+            let run = sqlx::query("select status, log, stopped_at from agent_runs where id = $1")
+                .bind(run_id)
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+            assert_eq!(run.get::<String, _>("status"), "failed");
+            assert!(run
+                .get::<String, _>("log")
+                .contains("stream disconnected before completion"));
+            assert!(run.get::<Option<String>, _>("stopped_at").is_some());
+
+            let work_status: String =
+                sqlx::query_scalar("select status from agent_work_items where id = $1")
+                    .bind(work_item_id)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|err| err.to_string())?;
+            assert_eq!(work_status, "failed");
+
+            let delivery_state: String =
+                sqlx::query_scalar("select delivery_state from messages where stream_key = $1")
+                    .bind(&stream_key)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|err| err.to_string())?;
+            assert_eq!(delivery_state, "error");
+
+            let runtime_status: String = sqlx::query_scalar(
+                "select status from runtime_sessions where agent_id = $1 and runtime = 'codex'",
+            )
+            .bind(agent_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            assert_eq!(runtime_status, "stopped");
+            assert!(!runtime.state.lock().await.alive);
+
+            let run_error_count: i64 = sqlx::query_scalar(
+                "select count(*) from agent_activities where agent_id = $1 and run_id = $2 and kind = 'run_error'",
+            )
+            .bind(agent_id)
+            .bind(run_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+            assert_eq!(run_error_count, 1);
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        result.unwrap();
+    }
 
     #[test]
     fn codex_active_turn_without_turn_id_times_out_for_scheduling() {

--- a/src-tauri/src/runtime/codex/turn.rs
+++ b/src-tauri/src/runtime/codex/turn.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use super::{CodexSteerRequest, WarmCodexRuntime};
 use crate::events::activity::{record_agent_activity, work_status_title};
 use crate::runtime::{
-    process::upsert_runtime_thread_id,
+    process::{terminate_process_group, upsert_runtime_thread_id},
     streaming::{
         consume_streaming_agent_control_lines, delete_streaming_agent_message_by_key,
         dispatch_streaming_agent_message_mentions, finish_streaming_agent_message,
@@ -173,11 +173,8 @@ pub(super) async fn finish_warm_codex_active_turn(
     } else {
         "failed"
     };
-    let agent_status = if success || was_cancelled {
-        "idle"
-    } else {
-        "error"
-    };
+    let should_reset_runtime = !success && !was_cancelled;
+    let agent_status = "idle";
     let log_line = if was_cancelled {
         "codex warm turn cancelled\n".to_owned()
     } else {
@@ -186,6 +183,15 @@ pub(super) async fn finish_warm_codex_active_turn(
             .map(|error| format!("codex warm turn failed: {error}\n"))
             .unwrap_or_else(|| format!("codex warm turn completed in {elapsed_ms} ms\n"))
     };
+    if should_reset_runtime {
+        {
+            let mut state = runtime.state.lock().await;
+            state.alive = false;
+        }
+        if let Some(pid) = runtime.pid {
+            let _ = terminate_process_group(pid).await;
+        }
+    }
     sqlx::query(
         r#"
         update agent_runs
@@ -270,7 +276,7 @@ pub(super) async fn finish_warm_codex_active_turn(
         if success || was_cancelled {
             "idle"
         } else {
-            "failed"
+            "stopped"
         },
     )
     .await?;

--- a/src-tauri/src/runtime/codex/turn.rs
+++ b/src-tauri/src/runtime/codex/turn.rs
@@ -12,6 +12,7 @@ use crate::runtime::{
         dispatch_streaming_agent_message_mentions, finish_streaming_agent_message,
         finish_streaming_agent_message_deferred_mentions,
     },
+    turn_outcome::resolve_warm_turn_outcome,
 };
 use crate::ui_notifications::{
     notify_supervisor_wake, notify_ui_agent_run_changed, notify_ui_work_item_changed,
@@ -166,15 +167,7 @@ pub(super) async fn finish_warm_codex_active_turn(
         .await?;
     }
 
-    let run_status = if was_cancelled {
-        "cancelled"
-    } else if success {
-        "exited"
-    } else {
-        "failed"
-    };
-    let should_reset_runtime = !success && !was_cancelled;
-    let agent_status = "idle";
+    let outcome = resolve_warm_turn_outcome(success, was_cancelled);
     let log_line = if was_cancelled {
         "codex warm turn cancelled\n".to_owned()
     } else {
@@ -183,7 +176,7 @@ pub(super) async fn finish_warm_codex_active_turn(
             .map(|error| format!("codex warm turn failed: {error}\n"))
             .unwrap_or_else(|| format!("codex warm turn completed in {elapsed_ms} ms\n"))
     };
-    if should_reset_runtime {
+    if outcome.should_reset_runtime {
         {
             let mut state = runtime.state.lock().await;
             state.alive = false;
@@ -203,7 +196,7 @@ pub(super) async fn finish_warm_codex_active_turn(
         "#,
     )
     .bind(active.run_id)
-    .bind(run_status)
+    .bind(outcome.run_status)
     .bind(&log_line)
     .execute(pool)
     .await
@@ -212,7 +205,7 @@ pub(super) async fn finish_warm_codex_active_turn(
 
     sqlx::query("update agents set status = $2 where id = $1")
         .bind(agent_id)
-        .bind(agent_status)
+        .bind(outcome.agent_status)
         .execute(pool)
         .await
         .map_err(to_string)?;
@@ -273,29 +266,15 @@ pub(super) async fn finish_warm_codex_active_turn(
         agent_id,
         "codex",
         &runtime.thread_id,
-        if success || was_cancelled {
-            "idle"
-        } else {
-            "stopped"
-        },
+        outcome.runtime_session_status,
     )
     .await?;
     record_agent_activity(
         pool,
         Some(agent_id),
         Some(active.run_id),
-        if success || was_cancelled {
-            "run"
-        } else {
-            "run_error"
-        },
-        if was_cancelled {
-            "Stopped"
-        } else if success {
-            "Completed"
-        } else {
-            "Failed"
-        },
+        outcome.activity_kind,
+        outcome.activity_title,
         if success || was_cancelled {
             format!("duration={elapsed_ms} ms")
         } else {

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod process;
 pub(crate) mod streaming;
 pub(crate) mod supervisor;
 pub(crate) mod surface;
+pub(crate) mod turn_outcome;

--- a/src-tauri/src/runtime/turn_outcome.rs
+++ b/src-tauri/src/runtime/turn_outcome.rs
@@ -1,0 +1,109 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WarmTurnOutcome {
+    pub(crate) agent_status: &'static str,
+    pub(crate) run_status: &'static str,
+    pub(crate) should_reset_runtime: bool,
+    pub(crate) runtime_session_status: &'static str,
+    pub(crate) activity_kind: &'static str,
+    pub(crate) activity_title: &'static str,
+}
+
+pub(crate) fn resolve_warm_turn_outcome(success: bool, was_cancelled: bool) -> WarmTurnOutcome {
+    if was_cancelled {
+        return WarmTurnOutcome {
+            agent_status: "idle",
+            run_status: "cancelled",
+            should_reset_runtime: false,
+            runtime_session_status: "idle",
+            activity_kind: "run",
+            activity_title: "Stopped",
+        };
+    }
+
+    if success {
+        WarmTurnOutcome {
+            agent_status: "idle",
+            run_status: "exited",
+            should_reset_runtime: false,
+            runtime_session_status: "idle",
+            activity_kind: "run",
+            activity_title: "Completed",
+        }
+    } else {
+        WarmTurnOutcome {
+            agent_status: "idle",
+            run_status: "failed",
+            should_reset_runtime: true,
+            runtime_session_status: "stopped",
+            activity_kind: "run_error",
+            activity_title: "Failed",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_warm_turn_outcome, WarmTurnOutcome};
+
+    #[test]
+    fn warm_turn_outcome_matrix_keeps_agents_routable_and_resets_only_failures() {
+        let cases = [
+            (
+                true,
+                false,
+                WarmTurnOutcome {
+                    agent_status: "idle",
+                    run_status: "exited",
+                    should_reset_runtime: false,
+                    runtime_session_status: "idle",
+                    activity_kind: "run",
+                    activity_title: "Completed",
+                },
+            ),
+            (
+                false,
+                false,
+                WarmTurnOutcome {
+                    agent_status: "idle",
+                    run_status: "failed",
+                    should_reset_runtime: true,
+                    runtime_session_status: "stopped",
+                    activity_kind: "run_error",
+                    activity_title: "Failed",
+                },
+            ),
+            (
+                true,
+                true,
+                WarmTurnOutcome {
+                    agent_status: "idle",
+                    run_status: "cancelled",
+                    should_reset_runtime: false,
+                    runtime_session_status: "idle",
+                    activity_kind: "run",
+                    activity_title: "Stopped",
+                },
+            ),
+            (
+                false,
+                true,
+                WarmTurnOutcome {
+                    agent_status: "idle",
+                    run_status: "cancelled",
+                    should_reset_runtime: false,
+                    runtime_session_status: "idle",
+                    activity_kind: "run",
+                    activity_title: "Stopped",
+                },
+            ),
+        ];
+
+        for (success, was_cancelled, expected) in cases {
+            assert_eq!(
+                resolve_warm_turn_outcome(success, was_cancelled),
+                expected,
+                "success={success} was_cancelled={was_cancelled}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Problem

All Lantor agents could end up stuck in `status='error'` and become unroutable after a **transient** provider/runtime failure. Closes the core mechanism behind #149.

Observed incident (2026-06-26/27): all 5 local agents showed `status='error'` and stopped receiving mentions/DMs. Underlying turn failures were transient:
- Claude agents: `Not logged in · Please run /login` — a **local pre-flight** rejection (`duration_api_ms:0`, `api_error_status:null`), i.e. the warm/resumed session's credential went stale, **not** a server-side 401. A fresh `claude` process with the same HOME/model/flags authenticated fine.
- Codex agents: `stream disconnected before completion ... chatgpt.com/backend-api/codex/responses` — transient network/transport. A fresh `codex exec` ran fine.

## Root cause

`src-tauri/src/runtime/claude/turn.rs` and `src-tauri/src/runtime/codex/turn.rs` set the agent status on warm-turn finish as:

```rust
let agent_status = if success || was_cancelled { "idle" } else { "error" };
```

There is **no transient/fatal distinction** — any failed turn poisons the agent to `error`. Routing/dispatch then exclude it:

```
agent_routing.rs:154,166,435,462    status <> 'error'
agent_work_dispatch.rs:360,443      and a.status <> 'error'
```

So one transient hiccup permanently removed the agent from routing until a manual DB reset + stale-process kill.

## Fix

In the warm-turn finish handler of both runtimes:
- Always return the agent to **`idle`** (stays routable).
- On a non-success/non-cancelled turn, **discard the bad warm runtime**: set `state.alive = false`, kill the warm process group (`terminate_process_group`), and mark `runtime_session = stopped`. The next mention then starts a **fresh** session — and fresh sessions are verified to authenticate/connect fine.
- `agent_runs` still records `failed` + `run_error` for audit/observability.
- Spawn-time fatal start errors are **unchanged** (still set `error`).

This converts "one transient failure → permanently dead agent" into "one transient failure → next turn transparently recovers on a fresh session."

## Verification

- `cargo fmt --check`, `cargo build` pass.
- Restarted the patched build; mentioned all 5 agents (Claude + Codex runtimes) — all replied normally.
- DB cross-check: each agent's latest `agent_run` = `exited`; `count(*) from agents where status='error'` = `0`.

## Scope / follow-ups (intentionally not in this PR)

This is the P0 stop-the-bleed fix. Tracked separately (see #149, #22):
- Consecutive-failure counter / `degraded` state so a *stably* misconfigured agent (e.g. bad model name) doesn't thrash as "fails every turn but always routable."
- Surface last error on the agent profile + a "Restart runtime / clear error" action.
- Per-Claude-agent `CLAUDE_CONFIG_DIR` isolation (or long-lived token, with redaction) to remove the shared-OAuth-state flapping inducer.
- Classified provider retry/recovery policy (#22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)