### PR TITLE
Fix composer resize scroll jump

### DIFF
--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -354,6 +354,14 @@ export function Conversation({
       previous.clientHeight !== element.clientHeight;
   }
 
+  function isMessageListComposerResize(element: HTMLDivElement) {
+    const previous = messageListMetricsRef.current;
+    if (previous.scrollHeight === 0 && previous.clientHeight === 0) return false;
+    const clientHeightDelta = element.clientHeight - previous.clientHeight;
+    const scrollHeightDelta = element.scrollHeight - previous.scrollHeight;
+    return clientHeightDelta < 0 && scrollHeightDelta <= 0;
+  }
+
   function cancelPendingMessageBottomScroll() {
     if (bottomScrollFrameRef.current !== null) {
       window.cancelAnimationFrame(bottomScrollFrameRef.current);
@@ -569,6 +577,10 @@ export function Conversation({
     function keepBottomVisible(source: "viewport" | "content") {
       const list = messageListRef.current;
       if (!list) return;
+      if (isMessageListComposerResize(list)) {
+        rememberMessageListMetrics(list);
+        return;
+      }
       if (source === "viewport" && isMessageListViewportOnlyResize(list)) {
         rememberMessageListMetrics(list);
         return;


### PR DESCRIPTION
## Summary
- prevent composer auto-grow viewport shrink from triggering keep-bottom scrolling
- treat message list clientHeight shrink without content growth as a metrics-only resize
- preserve follow-scroll behavior for real content growth like new messages and loaded media

## Verification
- npm run build
- manual check: typing past one line in the composer no longer shakes the channel view

## Review Notes
- This is intentionally scoped to Conversation.tsx and leaves textarea/CSS behavior unchanged.
- Reviewers noted a non-blocking mobile/narrow viewport risk: genuine viewport shrink with no content growth may also skip re-pinning, so that should be spot-checked on device.