### PR TITLE
feat: message/thread reference chips with jump + back navigation

### DIFF
--- a/src/components/ComposerReferenceTextarea.tsx
+++ b/src/components/ComposerReferenceTextarea.tsx
@@ -1,0 +1,51 @@
+import { forwardRef, type ReactNode, type TextareaHTMLAttributes } from "react";
+
+type ComposerReferenceTextareaProps = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "value"> & {
+  value: string;
+};
+
+const REFERENCE_TOKEN_PATTERN = /\[\[(message|thread):([^\]\s]+)\]\]/gi;
+
+function renderReferenceText(value: string) {
+  const parts: ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = REFERENCE_TOKEN_PATTERN.exec(value)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(value.slice(lastIndex, match.index));
+    }
+    const kind = match[1].toLowerCase();
+    const id = match[2];
+    parts.push(
+      <span key={`${match.index}:${match[0]}`} className={`composer-reference-token ${kind}`}>
+        {kind === "thread" ? "Thread" : "Message"} {id.slice(0, 8)}
+      </span>,
+    );
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < value.length) {
+    parts.push(value.slice(lastIndex));
+  }
+  if (parts.length === 0) return value;
+  return parts;
+}
+
+export const ComposerReferenceTextarea = forwardRef<HTMLTextAreaElement, ComposerReferenceTextareaProps>(
+  function ComposerReferenceTextarea({ value, className, ...props }, ref) {
+    const hasReferenceToken = REFERENCE_TOKEN_PATTERN.test(value);
+    REFERENCE_TOKEN_PATTERN.lastIndex = 0;
+    return (
+      <div className={`composer-reference-input ${hasReferenceToken ? "has-reference-token" : ""}`}>
+        <div className="composer-reference-overlay" aria-hidden="true">
+          {value ? renderReferenceText(value) : "\u00a0"}
+        </div>
+        <textarea
+          ref={ref}
+          className={className}
+          value={value}
+          {...props}
+        />
+      </div>
+    );
+  },
+);

--- a/src/components/ComposerReferenceTextarea.tsx
+++ b/src/components/ComposerReferenceTextarea.tsx
@@ -15,10 +15,14 @@ function renderReferenceText(value: string) {
       parts.push(value.slice(lastIndex, match.index));
     }
     const kind = match[1].toLowerCase();
-    const id = match[2];
     parts.push(
+      // Render the full token text verbatim so the overlay mirrors the
+      // underlying textarea character-for-character — the highlight must not
+      // change glyph advance width, otherwise the caret / click hit-testing /
+      // selection drift after the token. The shortened chip lives in the
+      // separate composer reference-preview strip instead.
       <span key={`${match.index}:${match[0]}`} className={`composer-reference-token ${kind}`}>
-        {kind === "thread" ? "Thread" : "Message"} {id.slice(0, 8)}
+        {match[0]}
       </span>,
     );
     lastIndex = match.index + match[0].length;

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -9,6 +9,7 @@ import {
   LayoutList,
   MessageSquare,
   Paperclip,
+  Quote,
   Send,
   Settings,
   Trash2,
@@ -25,15 +26,18 @@ import { APP_DISPLAY_NAME } from "../branding";
 import { isCompactFollowupMessage, messageHasVisibleContent, wasEdited } from "../message-grouping";
 import { DESKTOP_MESSAGE_PREVIEW_CHARS, DESKTOP_MESSAGE_PREVIEW_LINES } from "../message-preview";
 import { messageShareLink, messageToMarkdown } from "../message-share";
+import { appendMessageReferenceToken, messageReferenceToken, parseMessageReferences, removeMessageReferenceToken, withoutMessageReferenceTokens, type MessageReferenceKind } from "../message-references";
 import { Agent, AgentActivity, AgentRun, AgentWorkItem, Artifact, Channel, DraftAttachment, Message, OwnerProfile, TASK_STATUSES, Task, ThreadReplySummary } from "../types";
 import { agentForMessageSender, deletedAgentForMessageSender, formatClockTime, formatDateDivider, formatTime, isSameCalendarDay, ownerAsAvatarAgent, visibleAgentDescription, visibleChannelDescription } from "../ui-utils";
 import { ActivityProgressDock, activeProgressByAgent } from "./ActivityProgressDock";
 import { AgentAvatar, AgentAvatarWithProfile } from "./AgentAvatar";
+import { ComposerReferenceTextarea } from "./ComposerReferenceTextarea";
 import { DraftAttachmentsPreview } from "./DraftAttachmentsPreview";
 import { MessageActionMenu } from "./MessageActionMenu";
 import { MessageAttachments } from "./MessageAttachments";
 import { MessageArtifacts } from "./MessageArtifacts";
 import { MessageMarkdown } from "./MessageMarkdown";
+import { MessageReferencePreview, type MessageReferencePreviewItem } from "./MessageReferencePreview";
 import { TaskAssigneePicker } from "./TaskAssigneePicker";
 
 type WritingSuggestionsTextareaAttrs = TextareaHTMLAttributes<HTMLTextAreaElement> & { "writingsuggestions": "false" };
@@ -82,6 +86,7 @@ type ConversationProps = {
   openAgentDetail: (agent: Agent) => void;
   openArtifact: (artifact: Artifact) => void;
   openWorkItem?: (item: AgentWorkItem, focusedMessageIdOverride?: string | null) => void;
+  onReferenceMessageJump: (originMessageId: string, targetMessageId: string) => void;
   shareBaseUrl: string | null;
   savedMessageIds: Set<string>;
   focusedMessageId: string | null;
@@ -115,6 +120,13 @@ function taskStatusLabel(status: string) {
 
 type ReplyProgress = ReturnType<typeof activeProgressByAgent>[number];
 type ActiveReplyMenuPlacement = "above" | "below";
+const MESSAGE_LIST_COMPOSER_RESIZE_SUPPRESS_MS = 200;
+
+function compactReferencePreview(body: string) {
+  const text = withoutMessageReferenceTokens(body).replace(/\s+/g, " ").trim();
+  if (!text) return "No text preview";
+  return text.length > 140 ? `${text.slice(0, 139).trimEnd()}...` : text;
+}
 
 function compactReplyProgressText(value: string, limit: number) {
   const normalized = value.replace(/\s+/g, " ").trim();
@@ -243,6 +255,7 @@ export function Conversation({
   openAgentDetail,
   openArtifact,
   openWorkItem,
+  onReferenceMessageJump,
   shareBaseUrl,
   savedMessageIds,
   focusedMessageId,
@@ -259,7 +272,9 @@ export function Conversation({
   const bottomScrollFrameRef = useRef<number | null>(null);
   const bottomScrollTimeoutRef = useRef<number | null>(null);
   const shouldFollowMessagesRef = useRef(true);
+  const focusedMessageScrollKeyRef = useRef<string | null>(null);
   const userMessageScrollUntilRef = useRef(0);
+  const messageListFollowSuppressUntilRef = useRef(0);
   const messageListMetricsRef = useRef({ scrollHeight: 0, scrollTop: 0, clientHeight: 0 });
   const channelActionsRef = useRef<HTMLDivElement | null>(null);
   const isDm = channel?.kind === "dm";
@@ -325,6 +340,80 @@ export function Conversation({
       ? `DM with @${dmAgent?.handle || "agent"}`
       : `#${channel.name}`
     : APP_DISPLAY_NAME;
+  const rootMessageById = useMemo(() => new Map(rootMessages.map((message) => [message.id, message])), [rootMessages]);
+  const channelNameById = useMemo(() => new Map(channels.map((value) => [value.id, value.name])), [channels]);
+
+  function messageReferencePreviewItem(kind: MessageReferenceKind, id: string, token?: string): MessageReferencePreviewItem {
+    const message = rootMessageById.get(id);
+    if (!message) {
+      return {
+        key: `${kind}:${id}:${token ?? ""}`,
+        kind,
+        id,
+        token,
+        channelName: channel?.name ?? "unknown",
+        senderName: "Missing reference",
+        preview: id,
+        meta: "not loaded",
+        missing: true,
+      };
+    }
+    const replyCount = threadReplyCounts[message.id] ?? 0;
+    return {
+      key: `${kind}:${id}:${token ?? ""}`,
+      kind,
+      id,
+      token,
+      channelName: channelNameById.get(message.channel_id) ?? channel?.name ?? "unknown",
+      senderName: message.sender_name,
+      preview: compactReferencePreview(message.body),
+      meta: kind === "thread"
+        ? `${replyCount} ${replyCount === 1 ? "reply" : "replies"} · ${formatTime(message.created_at)}`
+        : formatTime(message.created_at),
+    };
+  }
+
+  function referencePreviewItemsForText(text: string) {
+    return parseMessageReferences(text).map((reference) => (
+      messageReferencePreviewItem(reference.kind, reference.id, reference.token)
+    ));
+  }
+
+  function renderMessageReferencePreviews(message: Message) {
+    const items = referencePreviewItemsForText(message.body);
+    if (items.length === 0) return null;
+    return (
+      <MessageReferencePreview
+        items={items}
+        variant="message"
+        onOpen={(item) => {
+          if (item.kind === "thread") {
+            setActiveThreadId(item.id);
+            return;
+          }
+          onReferenceMessageJump(message.id, item.id);
+          targetRootMessageIntoView(item.id);
+        }}
+      />
+    );
+  }
+
+  function visibleMessageBody(message: Message) {
+    return withoutMessageReferenceTokens(message.body);
+  }
+
+  function insertMessageReference(message: Message, kind: MessageReferenceKind) {
+    const referenceId = kind === "thread" ? (message.thread_root_id ?? message.id) : message.id;
+    setDraft(appendMessageReferenceToken(draft, kind, referenceId));
+    setMessageMenu(null);
+  }
+
+  async function copyMessageReference(message: Message, kind: MessageReferenceKind) {
+    const referenceId = kind === "thread" ? (message.thread_root_id ?? message.id) : message.id;
+    await copyText(messageReferenceToken(kind, referenceId));
+    setMessageMenu(null);
+  }
+
   function isMessageListAtBottom(element: HTMLDivElement) {
     return messageListDistanceFromBottom(element) < 32;
   }
@@ -362,6 +451,20 @@ export function Conversation({
     return clientHeightDelta < 0 && scrollHeightDelta <= 0;
   }
 
+  function suppressMessageListFollowForComposerResize(element: HTMLDivElement) {
+    if (!isMessageListComposerResize(element)) return false;
+    messageListFollowSuppressUntilRef.current = Date.now() + MESSAGE_LIST_COMPOSER_RESIZE_SUPPRESS_MS;
+    rememberMessageListMetrics(element);
+    return true;
+  }
+
+  function isMessageListFollowSuppressed(element: HTMLDivElement) {
+    if (Date.now() >= messageListFollowSuppressUntilRef.current) return false;
+    if (element.scrollHeight > messageListMetricsRef.current.scrollHeight) return false;
+    rememberMessageListMetrics(element);
+    return true;
+  }
+
   function cancelPendingMessageBottomScroll() {
     if (bottomScrollFrameRef.current !== null) {
       window.cancelAnimationFrame(bottomScrollFrameRef.current);
@@ -391,19 +494,25 @@ export function Conversation({
     return event.clientX >= element.getBoundingClientRect().right - scrollbarWidth - 2;
   }
 
+  function shouldSuppressMessageListFollow(element: HTMLDivElement) {
+    return suppressMessageListFollowForComposerResize(element) || isMessageListFollowSuppressed(element);
+  }
+
   function scrollMessagesToBottomNow(behavior: ScrollBehavior = "auto") {
     const element = messageListRef.current;
-    if (!element) return;
+    if (!element) return false;
+    if (behavior === "auto" && shouldSuppressMessageListFollow(element)) return false;
     userMessageScrollUntilRef.current = 0;
     element.scrollTo({ top: element.scrollHeight, behavior });
     if (behavior === "auto") {
       shouldFollowMessagesRef.current = true;
       rememberMessageListMetrics(element);
     }
+    return true;
   }
 
   function scrollMessagesToBottom(behavior: ScrollBehavior = "auto") {
-    scrollMessagesToBottomNow(behavior);
+    if (!scrollMessagesToBottomNow(behavior)) return;
     if (behavior !== "auto") return;
     cancelPendingMessageBottomScroll();
     bottomScrollFrameRef.current = window.requestAnimationFrame(() => {
@@ -419,6 +528,7 @@ export function Conversation({
   function handleMessageListScroll() {
     const element = messageListRef.current;
     if (!element) return;
+    if (shouldSuppressMessageListFollow(element)) return;
     const atBottom = isMessageListAtBottom(element);
     const layoutChanged =
       messageListMetricsRef.current.scrollHeight !== element.scrollHeight
@@ -446,6 +556,18 @@ export function Conversation({
     stopFollowingMessages();
   }
 
+  function targetRootMessageIntoView(messageId: string) {
+    const list = messageListRef.current;
+    const element = list?.querySelector<HTMLElement>(`[data-message-id="${messageId}"]`);
+    if (!list || !element) return;
+    stopFollowingMessages(list);
+    element.scrollIntoView({ block: "center" });
+    window.requestAnimationFrame(() => {
+      const currentList = messageListRef.current;
+      if (currentList) rememberMessageListMetrics(currentList);
+    });
+  }
+
   function updateActiveReplyMenuPlacement(messageId: string, summaryElement: HTMLElement) {
     const menu = summaryElement.querySelector<HTMLElement>(".thread-reply-active-menu");
     if (!menu) return;
@@ -468,6 +590,8 @@ export function Conversation({
   }
 
   function handleMessageListContentLoad() {
+    const element = messageListRef.current;
+    if (element && shouldSuppressMessageListFollow(element)) return;
     if (!shouldFollowMessagesRef.current) return;
     scrollMessagesToBottom();
   }
@@ -577,10 +701,7 @@ export function Conversation({
     function keepBottomVisible(source: "viewport" | "content") {
       const list = messageListRef.current;
       if (!list) return;
-      if (isMessageListComposerResize(list)) {
-        rememberMessageListMetrics(list);
-        return;
-      }
+      if (shouldSuppressMessageListFollow(list)) return;
       if (source === "viewport" && isMessageListViewportOnlyResize(list)) {
         rememberMessageListMetrics(list);
         return;
@@ -627,11 +748,16 @@ export function Conversation({
   }, [channel?.id]);
 
   useLayoutEffect(() => {
+    // Don't auto-follow to bottom while the user has jumped to a referenced
+    // message (clicked a reference chip). Otherwise every agent-activity refresh
+    // bumps messageListProgressVersion and yanks them back down to the bottom.
+    if (focusedMessageId) return;
     if (!shouldFollowMessagesRef.current) return;
     scrollMessagesToBottom();
   }, [
     activeTab,
     channel?.id,
+    focusedMessageId,
     messageListProgressVersion,
     rootMessages.length,
     lastRootMessage?.id,
@@ -640,7 +766,12 @@ export function Conversation({
   ]);
 
   useLayoutEffect(() => {
-    if (!focusedMessageId) return;
+    if (!focusedMessageId) {
+      focusedMessageScrollKeyRef.current = null;
+      return;
+    }
+    const focusedMessageScrollKey = `${channel?.id ?? "none"}:${focusedMessageId}`;
+    if (focusedMessageScrollKeyRef.current === focusedMessageScrollKey) return;
     let frameId = 0;
     let settleFrameId = 0;
     let attemptsRemaining = 6;
@@ -648,6 +779,7 @@ export function Conversation({
       const list = messageListRef.current;
       const element = list?.querySelector<HTMLElement>(`[data-message-id="${focusedMessageId}"]`);
       if (element) {
+        focusedMessageScrollKeyRef.current = focusedMessageScrollKey;
         stopFollowingMessages(list);
         element.scrollIntoView({ block: "center" });
         settleFrameId = window.requestAnimationFrame(() => {
@@ -668,7 +800,6 @@ export function Conversation({
   }, [
     channel?.id,
     focusedMessageId,
-    messageListProgressVersion,
     rootMessages.length,
     lastRootMessage?.id,
     lastRootMessage?.updated_at,
@@ -903,7 +1034,7 @@ export function Conversation({
                   )}
                   <article className="system-message">
                     <div className="system-message-line">
-                      <MessageMarkdown body={message.body} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${message.id}`} />
+                      <MessageMarkdown body={visibleMessageBody(message)} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${message.id}`} />
                       <time>{formatTime(message.created_at)}</time>
                     </div>
                   </article>
@@ -994,6 +1125,19 @@ export function Conversation({
                     <div className="message-hover-actions" aria-label="Message actions">
                       <button
                         type="button"
+                        data-tooltip="Reference"
+                        title="Reference message"
+                        aria-label="Reference message"
+                        onPointerDown={(event) => event.stopPropagation()}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          insertMessageReference(message, "message");
+                        }}
+                      >
+                        <Quote size={14} />
+                      </button>
+                      <button
+                        type="button"
                         data-tooltip={replyCount > 0 ? "View thread" : "Reply in thread"}
                         title={replyCount > 0 ? "View thread replies" : "Reply in thread"}
                         aria-label={replyCount > 0 ? "View thread replies" : "Reply in thread"}
@@ -1024,7 +1168,10 @@ export function Conversation({
                     {(message.delivery_state !== "streaming" || messageHasVisibleContent(message)) && (
                       <>
                         <div className={isLongChannelMessage && !isChannelMessageExpanded ? "message-long-preview collapsed" : "message-long-preview"}>
-                          <MessageMarkdown body={message.body} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${message.id}`} />
+                          {renderMessageReferencePreviews(message)}
+                          {visibleMessageBody(message) && (
+                            <MessageMarkdown body={visibleMessageBody(message)} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${message.id}`} />
+                          )}
                         </div>
                         {isLongChannelMessage && (
                           <button
@@ -1136,6 +1283,10 @@ export function Conversation({
               isSaved={savedMessageIds.has(messageMenu.message.id)}
               onCopyLink={() => copyMessageLink(messageMenu.message)}
               onCopyMarkdown={() => copyMessageMarkdown(messageMenu.message)}
+              onCopyReferenceMessage={() => copyMessageReference(messageMenu.message, "message")}
+              onCopyReferenceThread={() => copyMessageReference(messageMenu.message, "thread")}
+              onReferenceMessage={() => insertMessageReference(messageMenu.message, "message")}
+              onReferenceThread={() => insertMessageReference(messageMenu.message, "thread")}
               onToggleSaved={() => {
                 onToggleMessageSaved(messageMenu.message, !savedMessageIds.has(messageMenu.message.id));
                 setMessageMenu(null);
@@ -1216,6 +1367,7 @@ export function Conversation({
           draft={draft}
           draftAttachments={draftAttachments}
           setDraft={setDraft}
+          resolveReferencePreviewItems={referencePreviewItemsForText}
           addDraftAttachments={addDraftAttachments}
           removeDraftAttachment={removeDraftAttachment}
           sendRootMessage={sendRootMessage}
@@ -1283,6 +1435,7 @@ type ConversationComposerProps = {
   draft: string;
   draftAttachments: DraftAttachment[];
   setDraft: (value: string) => void;
+  resolveReferencePreviewItems: (text: string) => MessageReferencePreviewItem[];
   addDraftAttachments: (files: FileList | File[]) => void;
   removeDraftAttachment: (id: string) => void;
   sendRootMessage: (asTask?: boolean, bodyOverride?: string, attachmentsOverride?: DraftAttachment[]) => void;
@@ -1345,6 +1498,7 @@ function ConversationComposer({
   draft,
   draftAttachments,
   setDraft,
+  resolveReferencePreviewItems,
   addDraftAttachments,
   removeDraftAttachment,
   sendRootMessage,
@@ -1368,6 +1522,7 @@ function ConversationComposer({
     focusComposer,
   } = useMentionPicker({ agents: mentionAgents, channels, value: text, setValue: updateText, textareaRef });
   useAutoGrowTextarea(textareaRef, text);
+  const referencePreviewItems = resolveReferencePreviewItems(text);
 
   useEffect(() => {
     if (isDm) setSendAsTask(false);
@@ -1536,15 +1691,25 @@ function ConversationComposer({
           event.target.value = "";
         }}
       />
+      <MessageReferencePreview
+        items={referencePreviewItems}
+        variant="composer"
+        onRemove={(item) => {
+          if (!item.token) return;
+          const nextText = removeMessageReferenceToken(text, item.token);
+          updateText(nextText);
+          setDraft(nextText);
+        }}
+      />
       <DraftAttachmentsPreview attachments={draftAttachments} onRemove={removeDraftAttachment} />
-      <textarea
+      <ComposerReferenceTextarea
         ref={textareaRef}
+        {...disableWritingSuggestionsAttrs}
         rows={1}
         value={text}
         autoCapitalize="none"
         autoComplete="off"
         autoCorrect="off"
-        {...disableWritingSuggestionsAttrs}
         spellCheck={false}
         onChange={(event) => {
           updateText(event.target.value);

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -26,7 +26,7 @@ import { APP_DISPLAY_NAME } from "../branding";
 import { isCompactFollowupMessage, messageHasVisibleContent, wasEdited } from "../message-grouping";
 import { DESKTOP_MESSAGE_PREVIEW_CHARS, DESKTOP_MESSAGE_PREVIEW_LINES } from "../message-preview";
 import { messageShareLink, messageToMarkdown } from "../message-share";
-import { appendMessageReferenceToken, messageReferenceToken, parseMessageReferences, removeMessageReferenceToken, withoutMessageReferenceTokens, type MessageReferenceKind } from "../message-references";
+import { appendMessageReferenceToken, messageReferenceToken, parseMessageReferences, removeMessageReferenceToken, withoutMessageReferenceTokens, type MessageReferenceKind, type ResolvedMessageReference } from "../message-references";
 import { Agent, AgentActivity, AgentRun, AgentWorkItem, Artifact, Channel, DraftAttachment, Message, OwnerProfile, TASK_STATUSES, Task, ThreadReplySummary } from "../types";
 import { agentForMessageSender, deletedAgentForMessageSender, formatClockTime, formatDateDivider, formatTime, isSameCalendarDay, ownerAsAvatarAgent, visibleAgentDescription, visibleChannelDescription } from "../ui-utils";
 import { ActivityProgressDock, activeProgressByAgent } from "./ActivityProgressDock";
@@ -56,6 +56,7 @@ type ConversationProps = {
   activeTab: "chat" | "tasks";
   activeRoot: Message | null;
   rootMessages: Message[];
+  messages: Message[];
   threadReplyCounts: Record<string, number>;
   threadUnreadCounts: Record<string, number>;
   threadReplySummaries: Record<string, ThreadReplySummary>;
@@ -87,6 +88,7 @@ type ConversationProps = {
   openArtifact: (artifact: Artifact) => void;
   openWorkItem?: (item: AgentWorkItem, focusedMessageIdOverride?: string | null) => void;
   onReferenceMessageJump: (originMessageId: string, targetMessageId: string) => void;
+  onReferenceThreadJump: (originMessageId: string, threadId: string) => void;
   shareBaseUrl: string | null;
   savedMessageIds: Set<string>;
   focusedMessageId: string | null;
@@ -225,6 +227,7 @@ export function Conversation({
   activeTab,
   activeRoot,
   rootMessages,
+  messages,
   threadReplyCounts,
   threadUnreadCounts,
   threadReplySummaries,
@@ -256,6 +259,7 @@ export function Conversation({
   openArtifact,
   openWorkItem,
   onReferenceMessageJump,
+  onReferenceThreadJump,
   shareBaseUrl,
   savedMessageIds,
   focusedMessageId,
@@ -379,27 +383,27 @@ export function Conversation({
     ));
   }
 
-  function renderMessageReferencePreviews(message: Message) {
-    const items = referencePreviewItemsForText(message.body);
-    if (items.length === 0) return null;
-    return (
-      <MessageReferencePreview
-        items={items}
-        variant="message"
-        onOpen={(item) => {
-          if (item.kind === "thread") {
-            setActiveThreadId(item.id);
-            return;
-          }
-          onReferenceMessageJump(message.id, item.id);
-          targetRootMessageIntoView(item.id);
-        }}
-      />
-    );
+  function handleReferenceOpen(sourceMessage: Message, reference: ResolvedMessageReference) {
+    if (reference.kind === "thread") {
+      onReferenceThreadJump(sourceMessage.id, reference.id);
+      return;
+    }
+    onReferenceMessageJump(sourceMessage.id, reference.id);
+    targetRootMessageIntoView(reference.id);
   }
 
-  function visibleMessageBody(message: Message) {
-    return withoutMessageReferenceTokens(message.body);
+  function renderMessageBody(message: Message) {
+    if (!message.body.trim()) return null;
+    return (
+      <MessageMarkdown
+        body={message.body}
+        messages={messages}
+        channels={channels}
+        onOpenReference={(reference) => handleReferenceOpen(message, reference)}
+        onLocalAgentLink={openLinkedAgentDetail}
+        scrollKey={`message:${message.id}`}
+      />
+    );
   }
 
   function insertMessageReference(message: Message, kind: MessageReferenceKind) {
@@ -1034,7 +1038,7 @@ export function Conversation({
                   )}
                   <article className="system-message">
                     <div className="system-message-line">
-                      <MessageMarkdown body={visibleMessageBody(message)} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${message.id}`} />
+                      {renderMessageBody(message)}
                       <time>{formatTime(message.created_at)}</time>
                     </div>
                   </article>
@@ -1168,10 +1172,7 @@ export function Conversation({
                     {(message.delivery_state !== "streaming" || messageHasVisibleContent(message)) && (
                       <>
                         <div className={isLongChannelMessage && !isChannelMessageExpanded ? "message-long-preview collapsed" : "message-long-preview"}>
-                          {renderMessageReferencePreviews(message)}
-                          {visibleMessageBody(message) && (
-                            <MessageMarkdown body={visibleMessageBody(message)} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${message.id}`} />
-                          )}
+                          {renderMessageBody(message)}
                         </div>
                         {isLongChannelMessage && (
                           <button

--- a/src/components/MessageActionMenu.tsx
+++ b/src/components/MessageActionMenu.tsx
@@ -1,4 +1,4 @@
-import { Bookmark, Copy, Link } from "lucide-react";
+import { Bookmark, Copy, Link, MessageSquare, Quote } from "lucide-react";
 import { useEffect, useRef } from "react";
 
 type MessageActionMenuProps = {
@@ -7,6 +7,10 @@ type MessageActionMenuProps = {
   isSaved: boolean;
   onCopyLink: () => void;
   onCopyMarkdown: () => void;
+  onCopyReferenceMessage?: () => void;
+  onCopyReferenceThread?: () => void;
+  onReferenceMessage?: () => void;
+  onReferenceThread?: () => void;
   onToggleSaved: () => void;
   onClose: () => void;
 };
@@ -17,6 +21,10 @@ export function MessageActionMenu({
   isSaved,
   onCopyLink,
   onCopyMarkdown,
+  onCopyReferenceMessage,
+  onCopyReferenceThread,
+  onReferenceMessage,
+  onReferenceThread,
   onToggleSaved,
   onClose,
 }: MessageActionMenuProps) {
@@ -47,7 +55,7 @@ export function MessageActionMenu({
       className="message-action-menu"
       style={{
         left: Math.max(12, Math.min(x, window.innerWidth - 248)),
-        top: Math.max(12, Math.min(y, window.innerHeight - 230)),
+        top: Math.max(12, Math.min(y, window.innerHeight - 320)),
       }}
       onPointerDown={(event) => event.stopPropagation()}
       onClick={(event) => event.stopPropagation()}
@@ -62,6 +70,30 @@ export function MessageActionMenu({
         <Copy size={18} />
         <span>Copy markdown</span>
       </button>
+      {onCopyReferenceMessage && (
+        <button type="button" onClick={onCopyReferenceMessage}>
+          <Copy size={18} />
+          <span>Copy message reference</span>
+        </button>
+      )}
+      {onCopyReferenceThread && (
+        <button type="button" onClick={onCopyReferenceThread}>
+          <Copy size={18} />
+          <span>Copy thread reference</span>
+        </button>
+      )}
+      {onReferenceMessage && (
+        <button type="button" onClick={onReferenceMessage}>
+          <Quote size={18} />
+          <span>Reference message</span>
+        </button>
+      )}
+      {onReferenceThread && (
+        <button type="button" onClick={onReferenceThread}>
+          <MessageSquare size={18} />
+          <span>Reference thread</span>
+        </button>
+      )}
       <button type="button" onClick={onToggleSaved}>
         <Bookmark size={18} />
         <span>{isSaved ? "Unsave message" : "Save message"}</span>

--- a/src/components/MessageMarkdown.tsx
+++ b/src/components/MessageMarkdown.tsx
@@ -18,10 +18,20 @@ import type { PluggableList } from "unified";
 import "katex/dist/katex.min.css";
 import { openExternalUrl } from "../apiClient";
 import { copyText } from "../clipboard";
+import {
+  MESSAGE_REFERENCE_PATTERN,
+  type ResolvedMessageReference,
+  resolveMessageReference,
+} from "../message-references";
+import type { Channel, Message } from "../types";
+import { MessageReferenceCard } from "./MessageReferenceCard";
 
 type MessageMarkdownProps = {
   body: string;
   onLocalAgentLink?: (handle: string) => void;
+  messages?: Message[];
+  channels?: Channel[];
+  onOpenReference?: (reference: ResolvedMessageReference) => void;
   scrollKey?: string;
 };
 
@@ -82,6 +92,12 @@ function linkifyMessageBody(body: string) {
     .join("");
 }
 
+function messageReferenceMarkdown(body: string) {
+  return body.replace(MESSAGE_REFERENCE_PATTERN, (_match, kind: string, id: string) => (
+    `[${kind}:${id}](${LOCAL_ENTITY_PATH_PREFIX}reference/${kind}/${id})`
+  ));
+}
+
 function textFromNode(node: ReactNode): string {
   if (typeof node === "string" || typeof node === "number") return String(node);
   if (Array.isArray(node)) return node.map(textFromNode).join("");
@@ -121,6 +137,18 @@ function localAgentHandleFromHref(href: string | undefined) {
   } catch {
     return null;
   }
+}
+
+function referenceFromHref(
+  href: string | undefined,
+  messages: Message[] | undefined,
+  channels: Channel[] | undefined,
+) {
+  if (!href?.startsWith(`${LOCAL_ENTITY_PATH_PREFIX}reference/`)) return null;
+  if (!messages || !channels) return null;
+  const [, kind, id] = href.match(/^\/lantor\/reference\/(message|thread)\/([0-9a-fA-F-]{8,36})/) ?? [];
+  if (kind !== "message" && kind !== "thread") return null;
+  return resolveMessageReference({ kind, id, token: `[[${kind}:${id}]]` }, messages, channels);
 }
 
 function handleLinkClick(
@@ -181,12 +209,29 @@ function MarkdownTableScroll({ children, scrollKey }: { children?: ReactNode; sc
   );
 }
 
-export function MessageMarkdown({ body, onLocalAgentLink, scrollKey }: MessageMarkdownProps) {
-  const linkedBody = linkifyMessageBody(body);
+export function MessageMarkdown({
+  body,
+  onLocalAgentLink,
+  messages,
+  channels,
+  onOpenReference,
+  scrollKey,
+}: MessageMarkdownProps) {
+  const linkedBody = messageReferenceMarkdown(linkifyMessageBody(body));
   const tableIndexRef = useRef(0);
   tableIndexRef.current = 0;
   const markdownComponents = useMemo<Components>(() => ({
     a: ({ children, href, node: _node, ...props }) => {
+      const reference = referenceFromHref(href, messages, channels);
+      if (reference) {
+        return (
+          <MessageReferenceCard
+            reference={reference}
+            compact
+            onOpen={onOpenReference}
+          />
+        );
+      }
       const isLocalLink = Boolean(href?.startsWith(LOCAL_ENTITY_PATH_PREFIX));
       return (
         <a
@@ -211,7 +256,7 @@ export function MessageMarkdown({ body, onLocalAgentLink, scrollKey }: MessageMa
       tableIndexRef.current += 1;
       return <MarkdownTableScroll scrollKey={tableScrollKey}>{children}</MarkdownTableScroll>;
     },
-  }), [onLocalAgentLink, scrollKey]);
+  }), [channels, messages, onLocalAgentLink, onOpenReference, scrollKey]);
 
   return (
     <div className="markdown-body">

--- a/src/components/MessageReferenceCard.tsx
+++ b/src/components/MessageReferenceCard.tsx
@@ -1,0 +1,161 @@
+import { Hash, MessageSquare, PanelRightOpen, X } from "lucide-react";
+import type { KeyboardEvent, MouseEvent } from "react";
+import type { Channel, Message } from "../types";
+import { formatTime } from "../ui-utils";
+import {
+  type ResolvedMessageReference,
+  parseMessageReferences,
+  resolveMessageReference,
+} from "../message-references";
+
+type MessageReferenceCardProps = {
+  reference: ResolvedMessageReference;
+  compact?: boolean;
+  removable?: boolean;
+  onOpen?: (reference: ResolvedMessageReference) => void;
+  onRemove?: (token: string) => void;
+};
+
+export function firstLinePreview(body: string, limit = 140) {
+  const normalized = body.replace(/\s+/g, " ").trim();
+  if (!normalized) return "Empty message";
+  return normalized.length > limit ? `${normalized.slice(0, limit - 1).trimEnd()}...` : normalized;
+}
+
+function referenceLabel(reference: ResolvedMessageReference) {
+  return reference.kind === "thread" ? "Thread" : "Message";
+}
+
+function referenceMeta(reference: ResolvedMessageReference) {
+  const parts = [
+    reference.channel ? `#${reference.channel.name}` : "Unknown channel",
+    reference.message?.sender_name ?? "Unknown sender",
+  ];
+  if (reference.kind === "thread" && reference.replyCount !== null) {
+    parts.push(`${reference.replyCount} ${reference.replyCount === 1 ? "reply" : "replies"}`);
+  }
+  if (reference.message) parts.push(formatTime(reference.message.created_at));
+  return parts.join(" · ");
+}
+
+export function MessageReferenceCard({
+  reference,
+  compact = false,
+  removable = false,
+  onOpen,
+  onRemove,
+}: MessageReferenceCardProps) {
+  const Icon = reference.kind === "thread" ? PanelRightOpen : MessageSquare;
+  const preview = reference.message
+    ? firstLinePreview(reference.message.body, compact ? 96 : 150)
+    : `Missing ${reference.kind} ${reference.id.slice(0, 8)}`;
+  const className = [
+    "message-reference-card",
+    reference.kind,
+    compact ? "compact" : "",
+    reference.message ? "" : "missing",
+  ].filter(Boolean).join(" ");
+  const openProps = {
+    role: onOpen ? "button" : undefined,
+    tabIndex: onOpen ? 0 : undefined,
+    onClick: (event: MouseEvent) => {
+      event.stopPropagation();
+      onOpen?.(reference);
+    },
+    onKeyDown: (event: KeyboardEvent) => {
+      if (!onOpen) return;
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      onOpen(reference);
+    },
+  };
+
+  if (compact) {
+    const channelLabel = reference.channel ? `#${reference.channel.name}` : "Unknown channel";
+    const senderLabel = reference.message?.sender_name ?? "Unknown";
+    return (
+      <span
+        className={className}
+        {...openProps}
+        title={reference.message ? preview : reference.token}
+      >
+        <span className="message-reference-icon" aria-hidden="true">
+          <Icon size={13} />
+        </span>
+        <span className="message-reference-inline-copy">
+          <strong>{referenceLabel(reference)}</strong>
+          <span>{channelLabel} · {senderLabel}</span>
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={className}
+      {...openProps}
+      title={reference.message ? preview : reference.token}
+    >
+      <span className="message-reference-icon" aria-hidden="true">
+        <Icon size={compact ? 15 : 16} />
+      </span>
+      <span className="message-reference-copy">
+        <span className="message-reference-kicker">
+          <strong>{referenceLabel(reference)}</strong>
+          <span>{referenceMeta(reference)}</span>
+        </span>
+        <span className="message-reference-preview">{preview}</span>
+      </span>
+      {reference.channel && (
+        <span className="message-reference-channel" aria-hidden="true">
+          <Hash size={12} />
+        </span>
+      )}
+      {removable && (
+        <button
+          type="button"
+          className="message-reference-remove"
+          aria-label={`Remove ${reference.kind} reference`}
+          onClick={(event) => {
+            event.stopPropagation();
+            onRemove?.(reference.token);
+          }}
+        >
+          <X size={14} />
+        </button>
+      )}
+    </span>
+  );
+}
+
+type MessageReferencePreviewProps = {
+  text: string;
+  messages: Message[];
+  channels: Channel[];
+  onOpen?: (reference: ResolvedMessageReference) => void;
+  onRemove?: (token: string) => void;
+};
+
+export function MessageReferencePreview({
+  text,
+  messages,
+  channels,
+  onOpen,
+  onRemove,
+}: MessageReferencePreviewProps) {
+  const references = parseMessageReferences(text).map((reference) => resolveMessageReference(reference, messages, channels));
+  if (references.length === 0) return null;
+  return (
+    <div className="message-reference-preview-list" aria-label="Message references">
+      {references.map((reference) => (
+        <MessageReferenceCard
+          key={`${reference.kind}:${reference.id}`}
+          reference={reference}
+          removable={Boolean(onRemove)}
+          onOpen={onOpen}
+          onRemove={onRemove}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/MessageReferenceCard.tsx
+++ b/src/components/MessageReferenceCard.tsx
@@ -1,6 +1,6 @@
 import { Hash, MessageSquare, PanelRightOpen, X } from "lucide-react";
-import { useState, type CSSProperties, type KeyboardEvent, type MouseEvent } from "react";
-import { createPortal } from "react-dom";
+import { useSyncExternalStore, type CSSProperties, type KeyboardEvent, type MouseEvent } from "react";
+import { createRoot } from "react-dom/client";
 import type { Channel, Message } from "../types";
 import { formatTime } from "../ui-utils";
 import {
@@ -65,6 +65,75 @@ function referenceMeta(reference: ResolvedMessageReference) {
   return parts.join(" · ");
 }
 
+// Hover-preview state lives in a module-level singleton, not inside each chip.
+// The inline chip is rendered by react-markdown, whose subtree can re-render /
+// remount whenever the message feed refreshes (e.g. agent activity ticks). If
+// the hover state lived in the chip component, that remount would drop it and
+// the preview card would flicker away mid-hover. Keeping it here — with a single
+// portal host rendered once into <body> — makes the card survive any chip
+// remount: the anchored chip only reports enter/leave, it never owns the card.
+type ReferenceHoverState = { reference: ResolvedMessageReference; rect: DOMRect } | null;
+
+let hoverState: ReferenceHoverState = null;
+const hoverListeners = new Set<() => void>();
+let hoverLayerMounted = false;
+
+function emitHoverChange() {
+  for (const listener of hoverListeners) listener();
+}
+
+function subscribeHover(listener: () => void) {
+  hoverListeners.add(listener);
+  return () => {
+    hoverListeners.delete(listener);
+  };
+}
+
+function getHoverSnapshot(): ReferenceHoverState {
+  return hoverState;
+}
+
+function hideReferenceHover() {
+  if (!hoverState) return;
+  hoverState = null;
+  emitHoverChange();
+}
+
+function showReferenceHover(reference: ResolvedMessageReference, rect: DOMRect) {
+  hoverState = { reference, rect };
+  ensureHoverLayerMounted();
+  emitHoverChange();
+}
+
+function ensureHoverLayerMounted() {
+  if (hoverLayerMounted || typeof document === "undefined") return;
+  hoverLayerMounted = true;
+  const host = document.createElement("div");
+  host.className = "reference-hover-root";
+  document.body.appendChild(host);
+  // Any scroll invalidates the anchored rect, so close rather than let the card
+  // drift away from its chip.
+  window.addEventListener("scroll", hideReferenceHover, true);
+  createRoot(host).render(<ReferenceHoverLayer />);
+}
+
+function ReferenceHoverLayer() {
+  const state = useSyncExternalStore(subscribeHover, getHoverSnapshot, getHoverSnapshot);
+  if (!state) return null;
+  const { reference, rect } = state;
+  const message = reference.message;
+  if (!message) return null;
+  return (
+    <div className={`message-reference-hovercard ${reference.kind}`} style={hovercardStyle(rect)} role="tooltip">
+      <div className="message-reference-hovercard-head">
+        <strong>{referenceLabel(reference)}</strong>
+        <span>{referenceMeta(reference)}</span>
+      </div>
+      <div className="message-reference-hovercard-body">{firstLinesPreview(message.body)}</div>
+    </div>
+  );
+}
+
 export function MessageReferenceCard({
   reference,
   compact = false,
@@ -72,7 +141,6 @@ export function MessageReferenceCard({
   onOpen,
   onRemove,
 }: MessageReferenceCardProps) {
-  const [hoverRect, setHoverRect] = useState<DOMRect | null>(null);
   const Icon = reference.kind === "thread" ? PanelRightOpen : MessageSquare;
   const preview = reference.message
     ? firstLinePreview(reference.message.body, compact ? 96 : 150)
@@ -101,15 +169,14 @@ export function MessageReferenceCard({
   if (compact) {
     const channelLabel = reference.channel ? `#${reference.channel.name}` : "Unknown channel";
     const senderLabel = reference.message?.sender_name ?? "Unknown";
-    const showHovercard = Boolean(hoverRect && reference.message);
     return (
       <span
         className={className}
         {...openProps}
         onMouseEnter={(event) => {
-          if (reference.message) setHoverRect(event.currentTarget.getBoundingClientRect());
+          if (reference.message) showReferenceHover(reference, event.currentTarget.getBoundingClientRect());
         }}
-        onMouseLeave={() => setHoverRect(null)}
+        onMouseLeave={hideReferenceHover}
       >
         <span className="message-reference-icon" aria-hidden="true">
           <Icon size={13} />
@@ -118,16 +185,6 @@ export function MessageReferenceCard({
           <strong>{referenceLabel(reference)}</strong>
           <span>{channelLabel} · {senderLabel}</span>
         </span>
-        {showHovercard && reference.message && createPortal(
-          <div className={`message-reference-hovercard ${reference.kind}`} style={hovercardStyle(hoverRect!)} role="tooltip">
-            <div className="message-reference-hovercard-head">
-              <strong>{referenceLabel(reference)}</strong>
-              <span>{referenceMeta(reference)}</span>
-            </div>
-            <div className="message-reference-hovercard-body">{firstLinesPreview(reference.message.body)}</div>
-          </div>,
-          document.body,
-        )}
       </span>
     );
   }

--- a/src/components/MessageReferenceCard.tsx
+++ b/src/components/MessageReferenceCard.tsx
@@ -1,11 +1,13 @@
 import { Hash, MessageSquare, PanelRightOpen, X } from "lucide-react";
-import type { KeyboardEvent, MouseEvent } from "react";
+import { useState, type CSSProperties, type KeyboardEvent, type MouseEvent } from "react";
+import { createPortal } from "react-dom";
 import type { Channel, Message } from "../types";
 import { formatTime } from "../ui-utils";
 import {
   type ResolvedMessageReference,
   parseMessageReferences,
   resolveMessageReference,
+  withoutMessageReferenceTokens,
 } from "../message-references";
 
 type MessageReferenceCardProps = {
@@ -20,6 +22,31 @@ export function firstLinePreview(body: string, limit = 140) {
   const normalized = body.replace(/\s+/g, " ").trim();
   if (!normalized) return "Empty message";
   return normalized.length > limit ? `${normalized.slice(0, limit - 1).trimEnd()}...` : normalized;
+}
+
+function firstLinesPreview(body: string, maxLines = 3) {
+  const lines = withoutMessageReferenceTokens(body)
+    .replace(/\r/g, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return "Empty message";
+  return lines.slice(0, maxLines).join("\n");
+}
+
+function hovercardStyle(rect: DOMRect): CSSProperties {
+  const MAX_WIDTH = 320;
+  const left = Math.max(12, Math.min(rect.left, window.innerWidth - MAX_WIDTH - 12));
+  const placeAbove = rect.bottom > window.innerHeight - 168;
+  return {
+    position: "fixed",
+    left,
+    maxWidth: MAX_WIDTH,
+    pointerEvents: "none",
+    ...(placeAbove
+      ? { bottom: window.innerHeight - rect.top + 6 }
+      : { top: rect.bottom + 6 }),
+  };
 }
 
 function referenceLabel(reference: ResolvedMessageReference) {
@@ -45,6 +72,7 @@ export function MessageReferenceCard({
   onOpen,
   onRemove,
 }: MessageReferenceCardProps) {
+  const [hoverRect, setHoverRect] = useState<DOMRect | null>(null);
   const Icon = reference.kind === "thread" ? PanelRightOpen : MessageSquare;
   const preview = reference.message
     ? firstLinePreview(reference.message.body, compact ? 96 : 150)
@@ -73,11 +101,15 @@ export function MessageReferenceCard({
   if (compact) {
     const channelLabel = reference.channel ? `#${reference.channel.name}` : "Unknown channel";
     const senderLabel = reference.message?.sender_name ?? "Unknown";
+    const showHovercard = Boolean(hoverRect && reference.message);
     return (
       <span
         className={className}
         {...openProps}
-        title={reference.message ? preview : reference.token}
+        onMouseEnter={(event) => {
+          if (reference.message) setHoverRect(event.currentTarget.getBoundingClientRect());
+        }}
+        onMouseLeave={() => setHoverRect(null)}
       >
         <span className="message-reference-icon" aria-hidden="true">
           <Icon size={13} />
@@ -86,6 +118,16 @@ export function MessageReferenceCard({
           <strong>{referenceLabel(reference)}</strong>
           <span>{channelLabel} · {senderLabel}</span>
         </span>
+        {showHovercard && reference.message && createPortal(
+          <div className={`message-reference-hovercard ${reference.kind}`} style={hovercardStyle(hoverRect!)} role="tooltip">
+            <div className="message-reference-hovercard-head">
+              <strong>{referenceLabel(reference)}</strong>
+              <span>{referenceMeta(reference)}</span>
+            </div>
+            <div className="message-reference-hovercard-body">{firstLinesPreview(reference.message.body)}</div>
+          </div>,
+          document.body,
+        )}
       </span>
     );
   }

--- a/src/components/MessageReferencePreview.tsx
+++ b/src/components/MessageReferencePreview.tsx
@@ -1,0 +1,127 @@
+import { Copy, Hash, MessageSquare, X } from "lucide-react";
+import { useState } from "react";
+import { copyText } from "../clipboard";
+import { messageReferenceToken, type MessageReferenceKind } from "../message-references";
+
+export type MessageReferencePreviewItem = {
+  key: string;
+  kind: MessageReferenceKind;
+  id: string;
+  token?: string;
+  channelName: string;
+  senderName: string;
+  preview: string;
+  meta: string;
+  missing?: boolean;
+};
+
+type MessageReferencePreviewProps = {
+  items: MessageReferencePreviewItem[];
+  variant: "composer" | "message";
+  collapsedLimit?: number;
+  onRemove?: (item: MessageReferencePreviewItem) => void;
+  onOpen?: (item: MessageReferencePreviewItem) => void;
+};
+
+export function MessageReferencePreview({
+  items,
+  variant,
+  collapsedLimit = 3,
+  onRemove,
+  onOpen,
+}: MessageReferencePreviewProps) {
+  const [expanded, setExpanded] = useState(false);
+  if (items.length === 0) return null;
+  const shouldCollapse = items.length > collapsedLimit;
+  const visibleItems = shouldCollapse && !expanded ? items.slice(0, collapsedLimit) : items;
+  const hiddenCount = items.length - visibleItems.length;
+
+  return (
+    <div className={`message-reference-stack ${variant}`}>
+      {items.length > 1 && (
+        <div className="message-reference-stack-summary">
+          <span>{items.length} references attached</span>
+          <button
+            type="button"
+            onClick={() => {
+              void copyText(items.map((item) => item.token ?? messageReferenceToken(item.kind, item.id)).join("\n"));
+            }}
+          >
+            <Copy size={13} />
+            Copy all
+          </button>
+        </div>
+      )}
+      {visibleItems.map((item) => (
+        <div
+          key={item.key}
+          className={`message-reference-card ${item.kind} ${item.missing ? "missing" : ""}`}
+          role={onOpen ? "button" : undefined}
+          tabIndex={onOpen ? 0 : undefined}
+          onClick={(event) => {
+            if (!onOpen) return;
+            event.stopPropagation();
+            onOpen(item);
+          }}
+          onKeyDown={(event) => {
+            if (!onOpen || event.key !== "Enter") return;
+            event.preventDefault();
+            onOpen(item);
+          }}
+        >
+          <span className="message-reference-rail" aria-hidden="true" />
+          <span className="message-reference-icon" aria-hidden="true">
+            {item.kind === "thread" ? <MessageSquare size={15} /> : <Hash size={15} />}
+          </span>
+          <span className="message-reference-copy">
+            <span className="message-reference-title">
+              <strong>{item.kind === "thread" ? "Thread" : "Message"}</strong>
+              <span>#{item.channelName}</span>
+              {item.meta && <em>{item.meta}</em>}
+            </span>
+          <span className="message-reference-preview">
+            <b>{item.senderName}</b>
+            <span>{item.preview}</span>
+          </span>
+          </span>
+          <button
+            type="button"
+            className="message-reference-remove"
+            aria-label={`Copy ${item.kind} reference`}
+            title={`Copy ${item.kind} reference`}
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              event.stopPropagation();
+              void copyText(item.token ?? messageReferenceToken(item.kind, item.id));
+            }}
+          >
+            <Copy size={14} />
+          </button>
+          {onRemove && (
+            <button
+              type="button"
+              className="message-reference-remove"
+              aria-label={`Remove ${item.kind} reference`}
+              onPointerDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                onRemove(item);
+              }}
+            >
+              <X size={14} />
+            </button>
+          )}
+        </div>
+      ))}
+      {shouldCollapse && (
+        <button
+          type="button"
+          className="message-reference-stack-toggle"
+          onClick={() => setExpanded((current) => !current)}
+        >
+          {expanded ? "Show fewer references" : `+${hiddenCount} more ${hiddenCount === 1 ? "reference" : "references"}`}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -10,7 +10,7 @@ import { copyText } from "../clipboard";
 import { isCompactFollowupMessage, messageHasVisibleContent, wasEdited } from "../message-grouping";
 import { DESKTOP_MESSAGE_PREVIEW_CHARS, DESKTOP_MESSAGE_PREVIEW_LINES } from "../message-preview";
 import { messageShareLink, messageToMarkdown } from "../message-share";
-import { appendMessageReferenceToken, messageReferenceToken, parseMessageReferences, removeMessageReferenceToken, withoutMessageReferenceTokens, type MessageReferenceKind } from "../message-references";
+import { appendMessageReferenceToken, messageReferenceToken, parseMessageReferences, removeMessageReferenceToken, withoutMessageReferenceTokens, type MessageReferenceKind, type ResolvedMessageReference } from "../message-references";
 import { downloadThreadPanelSvg } from "../thread-svg-export";
 import { Agent, AgentActivity, AgentRun, AgentWorkItem, Artifact, Channel, DraftAttachment, Message, OwnerProfile, TASK_STATUSES, Task } from "../types";
 import { agentForMessageSender, deletedAgentForMessageSender, formatClockTime, formatDateDivider, formatTime, isSameCalendarDay, ownerAsAvatarAgent, visibleAgentDescription, visibleChannelDescription } from "../ui-utils";
@@ -105,6 +105,8 @@ type ThreadPanelProps = {
   openArtifact: (artifact: Artifact) => void;
   openWorkItem?: (item: AgentWorkItem, focusedMessageIdOverride?: string | null) => void;
   onReferenceMessageJump: (originMessageId: string, targetMessageId: string) => void;
+  onReferenceThreadJump: (originMessageId: string, threadId: string) => void;
+  messages: Message[];
   onLocateRoot: (message: Message) => void;
   shareBaseUrl: string | null;
   savedMessageIds: Set<string>;
@@ -190,6 +192,8 @@ export function ThreadPanel({
   openArtifact,
   openWorkItem,
   onReferenceMessageJump,
+  onReferenceThreadJump,
+  messages,
   onLocateRoot,
   shareBaseUrl,
   savedMessageIds,
@@ -275,25 +279,29 @@ export function ThreadPanel({
     ));
   }
 
-  function renderMessageReferencePreviews(message: Message) {
-    const items = referencePreviewItemsForText(message.body);
-    if (items.length === 0) return null;
-    return (
-      <MessageReferencePreview
-        items={items}
-        variant="message"
-        onOpen={(item) => {
-          const target = threadMessageById.get(item.id);
-          if (!target) return;
-          onReferenceMessageJump(message.id, target.id);
-          targetMessageIntoView(target.id);
-        }}
-      />
-    );
+  function handleReferenceOpen(sourceMessage: Message, reference: ResolvedMessageReference) {
+    if (reference.kind === "thread") {
+      onReferenceThreadJump(sourceMessage.id, reference.id);
+      return;
+    }
+    const target = threadMessageById.get(reference.id);
+    if (!target) return;
+    onReferenceMessageJump(sourceMessage.id, target.id);
+    targetMessageIntoView(target.id);
   }
 
-  function visibleMessageBody(message: Message) {
-    return withoutMessageReferenceTokens(message.body);
+  function renderMessageBody(message: Message) {
+    if (!message.body.trim()) return null;
+    return (
+      <MessageMarkdown
+        body={message.body}
+        messages={messages}
+        channels={channels}
+        onOpenReference={(reference) => handleReferenceOpen(message, reference)}
+        onLocalAgentLink={openLinkedAgentDetail}
+        scrollKey={`message:${message.id}`}
+      />
+    );
   }
 
   function insertMessageReference(message: Message, kind: MessageReferenceKind) {
@@ -909,7 +917,7 @@ export function ThreadPanel({
                 >
                 {activeRoot.sender_role === "system" ? (
                   <div className="system-message-line">
-                    <MessageMarkdown body={visibleMessageBody(activeRoot)} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${activeRoot.id}`} />
+                    {renderMessageBody(activeRoot)}
                     <time>{formatTime(activeRoot.created_at)}</time>
                   </div>
                 ) : (
@@ -993,10 +1001,7 @@ export function ThreadPanel({
                         return (
                           <>
                             <div className={isLongThreadMessage && !isThreadMessageExpanded ? "message-long-preview collapsed" : "message-long-preview"}>
-                              {renderMessageReferencePreviews(activeRoot)}
-                              {visibleMessageBody(activeRoot) && (
-                                <MessageMarkdown body={visibleMessageBody(activeRoot)} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${activeRoot.id}`} />
-                              )}
+                              {renderMessageBody(activeRoot)}
                             </div>
                             {isLongThreadMessage && (
                               <button
@@ -1155,7 +1160,7 @@ export function ThreadPanel({
                     )}
                     <article className="system-message">
                       <div className="system-message-line">
-                        <MessageMarkdown body={visibleMessageBody(reply)} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${reply.id}`} />
+                        {renderMessageBody(reply)}
                         <time>{formatTime(reply.created_at)}</time>
                       </div>
                     </article>
@@ -1279,10 +1284,7 @@ export function ThreadPanel({
                         return (
                           <>
                             <div className={isLongThreadMessage && !isThreadMessageExpanded ? "message-long-preview collapsed" : "message-long-preview"}>
-                              {renderMessageReferencePreviews(reply)}
-                              {visibleMessageBody(reply) && (
-                                <MessageMarkdown body={visibleMessageBody(reply)} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${reply.id}`} />
-                              )}
+                              {renderMessageBody(reply)}
                             </div>
                             {isLongThreadMessage && (
                               <button

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowLeft, Bookmark, CheckCircle2, Crosshair, FileImage, Hash, Maximize2, MessageSquare, Minimize2, Paperclip, RotateCcw, Send, X } from "lucide-react";
+import { ArrowDown, ArrowLeft, Bookmark, CheckCircle2, Crosshair, FileImage, Hash, Maximize2, MessageSquare, Minimize2, Paperclip, Quote, RotateCcw, Send, X } from "lucide-react";
 import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type TextareaHTMLAttributes, type WheelEvent as ReactWheelEvent } from "react";
 import { useAutoGrowTextarea } from "../hooks/useAutoGrowTextarea";
 import { useMentionPicker } from "../hooks/useMentionPicker";
@@ -10,16 +10,19 @@ import { copyText } from "../clipboard";
 import { isCompactFollowupMessage, messageHasVisibleContent, wasEdited } from "../message-grouping";
 import { DESKTOP_MESSAGE_PREVIEW_CHARS, DESKTOP_MESSAGE_PREVIEW_LINES } from "../message-preview";
 import { messageShareLink, messageToMarkdown } from "../message-share";
+import { appendMessageReferenceToken, messageReferenceToken, parseMessageReferences, removeMessageReferenceToken, withoutMessageReferenceTokens, type MessageReferenceKind } from "../message-references";
 import { downloadThreadPanelSvg } from "../thread-svg-export";
 import { Agent, AgentActivity, AgentRun, AgentWorkItem, Artifact, Channel, DraftAttachment, Message, OwnerProfile, TASK_STATUSES, Task } from "../types";
 import { agentForMessageSender, deletedAgentForMessageSender, formatClockTime, formatDateDivider, formatTime, isSameCalendarDay, ownerAsAvatarAgent, visibleAgentDescription, visibleChannelDescription } from "../ui-utils";
 import { ActivityProgressDock } from "./ActivityProgressDock";
 import { AgentAvatar, AgentAvatarWithProfile } from "./AgentAvatar";
+import { ComposerReferenceTextarea } from "./ComposerReferenceTextarea";
 import { DraftAttachmentsPreview } from "./DraftAttachmentsPreview";
 import { MessageActionMenu } from "./MessageActionMenu";
 import { MessageAttachments } from "./MessageAttachments";
 import { MessageArtifacts } from "./MessageArtifacts";
 import { MessageMarkdown } from "./MessageMarkdown";
+import { MessageReferencePreview, type MessageReferencePreviewItem } from "./MessageReferencePreview";
 import { TaskAssigneePicker } from "./TaskAssigneePicker";
 
 type WritingSuggestionsTextareaAttrs = TextareaHTMLAttributes<HTMLTextAreaElement> & { "writingsuggestions": "false" };
@@ -61,6 +64,12 @@ function shouldCollapseThreadMessage(body: string) {
   return text.split("\n").length > DESKTOP_MESSAGE_PREVIEW_LINES || text.length > DESKTOP_MESSAGE_PREVIEW_CHARS;
 }
 
+function compactReferencePreview(body: string) {
+  const text = withoutMessageReferenceTokens(body).replace(/\s+/g, " ").trim();
+  if (!text) return "No text preview";
+  return text.length > 140 ? `${text.slice(0, 139).trimEnd()}...` : text;
+}
+
 function waitForNextFrame() {
   return new Promise<void>((resolve) => {
     window.requestAnimationFrame(() => resolve());
@@ -95,6 +104,7 @@ type ThreadPanelProps = {
   openAgentDetail: (agent: Agent) => void;
   openArtifact: (artifact: Artifact) => void;
   openWorkItem?: (item: AgentWorkItem, focusedMessageIdOverride?: string | null) => void;
+  onReferenceMessageJump: (originMessageId: string, targetMessageId: string) => void;
   onLocateRoot: (message: Message) => void;
   shareBaseUrl: string | null;
   savedMessageIds: Set<string>;
@@ -179,6 +189,7 @@ export function ThreadPanel({
   openAgentDetail,
   openArtifact,
   openWorkItem,
+  onReferenceMessageJump,
   onLocateRoot,
   shareBaseUrl,
   savedMessageIds,
@@ -224,6 +235,94 @@ export function ThreadPanel({
       ? `Thread in DM with @${dmAgent?.handle || "agent"}`
       : `Thread in #${channel.name}`
     : `${APP_DISPLAY_NAME} thread`;
+  const threadMessages = useMemo(() => activeRoot ? [activeRoot, ...replies] : replies, [activeRoot, replies]);
+  const threadMessageById = useMemo(() => new Map(threadMessages.map((message) => [message.id, message])), [threadMessages]);
+  const channelNameById = useMemo(() => new Map(channels.map((value) => [value.id, value.name])), [channels]);
+
+  function messageReferencePreviewItem(kind: MessageReferenceKind, id: string, token?: string): MessageReferencePreviewItem {
+    const message = threadMessageById.get(id);
+    if (!message) {
+      return {
+        key: `${kind}:${id}:${token ?? ""}`,
+        kind,
+        id,
+        token,
+        channelName: channel?.name ?? "unknown",
+        senderName: "Missing reference",
+        preview: id,
+        meta: "not loaded",
+        missing: true,
+      };
+    }
+    const replyCount = kind === "thread" ? replies.filter((reply) => reply.thread_root_id === id).length : 0;
+    return {
+      key: `${kind}:${id}:${token ?? ""}`,
+      kind,
+      id,
+      token,
+      channelName: channelNameById.get(message.channel_id) ?? channel?.name ?? "unknown",
+      senderName: message.sender_name,
+      preview: compactReferencePreview(message.body),
+      meta: kind === "thread"
+        ? `${replyCount} ${replyCount === 1 ? "reply" : "replies"} · ${formatTime(message.created_at)}`
+        : formatTime(message.created_at),
+    };
+  }
+
+  function referencePreviewItemsForText(text: string) {
+    return parseMessageReferences(text).map((reference) => (
+      messageReferencePreviewItem(reference.kind, reference.id, reference.token)
+    ));
+  }
+
+  function renderMessageReferencePreviews(message: Message) {
+    const items = referencePreviewItemsForText(message.body);
+    if (items.length === 0) return null;
+    return (
+      <MessageReferencePreview
+        items={items}
+        variant="message"
+        onOpen={(item) => {
+          const target = threadMessageById.get(item.id);
+          if (!target) return;
+          onReferenceMessageJump(message.id, target.id);
+          targetMessageIntoView(target.id);
+        }}
+      />
+    );
+  }
+
+  function visibleMessageBody(message: Message) {
+    return withoutMessageReferenceTokens(message.body);
+  }
+
+  function insertMessageReference(message: Message, kind: MessageReferenceKind) {
+    const referenceId = kind === "thread" ? (message.thread_root_id ?? message.id) : message.id;
+    setReplyDraft(appendMessageReferenceToken(replyDraft, kind, referenceId));
+    setMessageMenu(null);
+  }
+
+  async function copyMessageReference(message: Message, kind: MessageReferenceKind) {
+    const referenceId = kind === "thread" ? (message.thread_root_id ?? message.id) : message.id;
+    await copyText(messageReferenceToken(kind, referenceId));
+    setMessageMenu(null);
+  }
+
+  function removeDraftReference(token: string) {
+    setReplyDraft(removeMessageReferenceToken(replyDraft, token));
+  }
+
+  function targetMessageIntoView(messageId: string) {
+    const element = threadMessageRefs.current.get(messageId);
+    if (!element) return;
+    stopFollowingThread();
+    element.scrollIntoView({ block: "center" });
+    setTapFocusedMessageId(messageId);
+    window.requestAnimationFrame(() => {
+      const scrollRoot = threadScrollRef.current;
+      if (scrollRoot) rememberThreadScrollMetrics(scrollRoot);
+    });
+  }
   const lastReply = replies[replies.length - 1] ?? null;
   const collapsibleThreadMessageIds = useMemo(() => {
     const messages = activeRoot ? [activeRoot, ...replies] : replies;
@@ -531,17 +630,23 @@ export function ThreadPanel({
   }, [activeRoot?.id]);
 
   useLayoutEffect(() => {
+    // While the user has jumped to a referenced message, don't auto-follow to
+    // bottom — otherwise each reply/agent-activity update yanks them back down.
+    if (focusedMessageId) return;
     if (!shouldFollowThreadRef.current) {
       restoreThreadScrollAnchor();
       return;
     }
     scrollThreadToBottom();
-  }, [activeRoot?.id, activeRoot?.updated_at, replies.length, lastReply?.id, lastReply?.updated_at, lastReply?.delivery_state]);
+  }, [activeRoot?.id, focusedMessageId, activeRoot?.updated_at, replies.length, lastReply?.id, lastReply?.updated_at, lastReply?.delivery_state]);
 
   useEffect(() => {
     if (!focusedMessageId) return;
     const element = threadScrollRef.current?.querySelector<HTMLElement>(`[data-message-id="${focusedMessageId}"]`);
-    element?.scrollIntoView({ block: "center" });
+    if (!element) return;
+    // Detach from bottom-follow so the jump target stays put once focus clears.
+    stopFollowingThread();
+    element.scrollIntoView({ block: "center" });
   }, [activeRoot?.id, focusedMessageId]);
 
   function hasSelectedText() {
@@ -732,6 +837,18 @@ export function ThreadPanel({
           >
             <Crosshair size={18} />
           </button>
+          <button
+            type="button"
+            className="thread-locate-root"
+            onClick={() => {
+              if (activeRoot) insertMessageReference(activeRoot, "thread");
+            }}
+            disabled={!activeRoot}
+            data-tooltip="Reference this thread"
+            aria-label="Reference this thread"
+          >
+            <Quote size={18} />
+          </button>
           <button type="button" className="thread-close" onClick={onClose} aria-label="Close thread panel"><X size={18} /></button>
         </span>
       </header>
@@ -792,7 +909,7 @@ export function ThreadPanel({
                 >
                 {activeRoot.sender_role === "system" ? (
                   <div className="system-message-line">
-                    <MessageMarkdown body={activeRoot.body} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${activeRoot.id}`} />
+                    <MessageMarkdown body={visibleMessageBody(activeRoot)} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${activeRoot.id}`} />
                     <time>{formatTime(activeRoot.created_at)}</time>
                   </div>
                 ) : (
@@ -844,6 +961,19 @@ export function ThreadPanel({
                       <div className="message-hover-actions" aria-label="Message actions">
                         <button
                           type="button"
+                          data-tooltip="Reference"
+                          title="Reference message"
+                          aria-label="Reference message"
+                          onPointerDown={(event) => event.stopPropagation()}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            insertMessageReference(activeRoot, "message");
+                          }}
+                        >
+                          <Quote size={14} />
+                        </button>
+                        <button
+                          type="button"
                           className={rootSaved ? "saved" : ""}
                           data-tooltip={rootSaved ? "Unsave" : "Save"}
                           title={rootSaved ? "Unsave message" : "Save message"}
@@ -863,7 +993,10 @@ export function ThreadPanel({
                         return (
                           <>
                             <div className={isLongThreadMessage && !isThreadMessageExpanded ? "message-long-preview collapsed" : "message-long-preview"}>
-                              <MessageMarkdown body={activeRoot.body} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${activeRoot.id}`} />
+                              {renderMessageReferencePreviews(activeRoot)}
+                              {visibleMessageBody(activeRoot) && (
+                                <MessageMarkdown body={visibleMessageBody(activeRoot)} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${activeRoot.id}`} />
+                              )}
                             </div>
                             {isLongThreadMessage && (
                               <button
@@ -1022,7 +1155,7 @@ export function ThreadPanel({
                     )}
                     <article className="system-message">
                       <div className="system-message-line">
-                        <MessageMarkdown body={reply.body} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${reply.id}`} />
+                        <MessageMarkdown body={visibleMessageBody(reply)} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${reply.id}`} />
                         <time>{formatTime(reply.created_at)}</time>
                       </div>
                     </article>
@@ -1114,6 +1247,19 @@ export function ThreadPanel({
                       <div className="message-hover-actions" aria-label="Message actions">
                         <button
                           type="button"
+                          data-tooltip="Reference"
+                          title="Reference message"
+                          aria-label="Reference message"
+                          onPointerDown={(event) => event.stopPropagation()}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            insertMessageReference(reply, "message");
+                          }}
+                        >
+                          <Quote size={14} />
+                        </button>
+                        <button
+                          type="button"
                           className={replySaved ? "saved" : ""}
                           data-tooltip={replySaved ? "Unsave" : "Save"}
                           title={replySaved ? "Unsave message" : "Save message"}
@@ -1133,7 +1279,10 @@ export function ThreadPanel({
                         return (
                           <>
                             <div className={isLongThreadMessage && !isThreadMessageExpanded ? "message-long-preview collapsed" : "message-long-preview"}>
-                              <MessageMarkdown body={reply.body} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${reply.id}`} />
+                              {renderMessageReferencePreviews(reply)}
+                              {visibleMessageBody(reply) && (
+                                <MessageMarkdown body={visibleMessageBody(reply)} onLocalAgentLink={openLinkedAgentDetail} scrollKey={`message:${reply.id}`} />
+                              )}
                             </div>
                             {isLongThreadMessage && (
                               <button
@@ -1174,6 +1323,10 @@ export function ThreadPanel({
               isSaved={savedMessageIds.has(messageMenu.message.id)}
               onCopyLink={() => copyMessageLink(messageMenu.message)}
               onCopyMarkdown={() => copyMessageMarkdown(messageMenu.message)}
+              onCopyReferenceMessage={() => copyMessageReference(messageMenu.message, "message")}
+              onCopyReferenceThread={() => copyMessageReference(messageMenu.message, "thread")}
+              onReferenceMessage={() => insertMessageReference(messageMenu.message, "message")}
+              onReferenceThread={() => insertMessageReference(messageMenu.message, "thread")}
               onToggleSaved={() => {
                 onToggleMessageSaved(messageMenu.message, !savedMessageIds.has(messageMenu.message.id));
                 setMessageMenu(null);
@@ -1199,6 +1352,8 @@ export function ThreadPanel({
           replyDraft={replyDraft}
           replyAttachments={replyAttachments}
           setReplyDraft={setReplyDraft}
+          resolveReferencePreviewItems={referencePreviewItemsForText}
+          removeDraftReference={removeDraftReference}
           addReplyAttachments={addReplyAttachments}
           removeReplyAttachment={removeReplyAttachment}
           sendReply={sendReply}
@@ -1218,6 +1373,8 @@ type ThreadReplyComposerProps = {
   replyDraft: string;
   replyAttachments: DraftAttachment[];
   setReplyDraft: (value: string) => void;
+  resolveReferencePreviewItems: (text: string) => MessageReferencePreviewItem[];
+  removeDraftReference: (token: string) => void;
   addReplyAttachments: (files: FileList | File[]) => void;
   removeReplyAttachment: (id: string) => void;
   sendReply: (bodyOverride?: string, attachmentsOverride?: DraftAttachment[]) => void;
@@ -1280,6 +1437,8 @@ function ThreadReplyComposer({
   replyDraft,
   replyAttachments,
   setReplyDraft,
+  resolveReferencePreviewItems,
+  removeDraftReference,
   addReplyAttachments,
   removeReplyAttachment,
   sendReply,
@@ -1301,6 +1460,7 @@ function ThreadReplyComposer({
     focusComposer,
   } = useMentionPicker({ agents: mentionAgents, channels, value: text, setValue: updateText, textareaRef });
   useAutoGrowTextarea(textareaRef, text);
+  const referencePreviewItems = resolveReferencePreviewItems(text);
 
   useEffect(() => {
     replyDragDepthRef.current = 0;
@@ -1432,15 +1592,25 @@ function ThreadReplyComposer({
           event.target.value = "";
         }}
       />
+      <MessageReferencePreview
+        items={referencePreviewItems}
+        variant="composer"
+        onRemove={(item) => {
+          if (!item.token) return;
+          const nextText = removeMessageReferenceToken(text, item.token);
+          updateText(nextText);
+          removeDraftReference(item.token);
+        }}
+      />
       <DraftAttachmentsPreview attachments={replyAttachments} onRemove={removeReplyAttachment} />
-      <textarea
+      <ComposerReferenceTextarea
         ref={textareaRef}
+        {...disableWritingSuggestionsAttrs}
         rows={1}
         value={text}
         autoCapitalize="none"
         autoComplete="off"
         autoCorrect="off"
-        {...disableWritingSuggestionsAttrs}
         spellCheck={false}
         onChange={(event) => {
           updateText(event.target.value);

--- a/src/hooks/useAutoGrowTextarea.ts
+++ b/src/hooks/useAutoGrowTextarea.ts
@@ -14,10 +14,19 @@ export function useAutoGrowTextarea(textareaRef: RefObject<HTMLTextAreaElement |
     if (!textareaElement) return;
     const computedStyle = window.getComputedStyle(textareaElement);
     const maxHeight = cssPixelValue(computedStyle.maxHeight);
-    textareaElement.style.height = "auto";
+    const previousHeight = textareaElement.style.height;
+    textareaElement.style.height = "0px";
     const nextHeight = Math.min(textareaElement.scrollHeight, maxHeight);
-    textareaElement.style.height = `${nextHeight}px`;
-    textareaElement.style.overflowY = textareaElement.scrollHeight > maxHeight ? "auto" : "hidden";
+    const nextHeightValue = `${nextHeight}px`;
+    if (previousHeight !== nextHeightValue) {
+      textareaElement.style.height = nextHeightValue;
+    } else {
+      textareaElement.style.height = previousHeight;
+    }
+    const nextOverflowY = textareaElement.scrollHeight > maxHeight ? "auto" : "hidden";
+    if (textareaElement.style.overflowY !== nextOverflowY) {
+      textareaElement.style.overflowY = nextOverflowY;
+    }
   }, [textareaRef]);
 
   const scheduleResize = useCallback(() => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -43,6 +43,7 @@ import {
   AgentWorkItem,
   Artifact,
   Bootstrap,
+  Channel,
   ChannelMember,
   DraftAttachment,
   EMPTY_AGENT_FORM,
@@ -246,6 +247,7 @@ type AppHistoryState = {
   showMobileSidebar: boolean;
   selectedAgentId: string | null;
   activeModal: MobileModal | null;
+  focusedMessageId: string | null;
 };
 
 type AppErrorBoundaryState = {
@@ -313,6 +315,7 @@ function isAppHistoryState(value: unknown): value is AppHistoryState {
     && typeof state.showThread === "boolean"
     && typeof state.showMobileSidebar === "boolean"
     && (state.selectedAgentId === null || typeof state.selectedAgentId === "string")
+    && (state.focusedMessageId === undefined || state.focusedMessageId === null || typeof state.focusedMessageId === "string")
     && (
       state.activeModal === null ||
       state.activeModal === "search" ||
@@ -330,6 +333,7 @@ function appHistoryKey(state: AppHistoryState) {
     state.showMobileSidebar ? "sidebar" : "content",
     state.selectedAgentId ?? "",
     state.activeModal ?? "",
+    state.focusedMessageId ?? "",
   ].join("|");
 }
 
@@ -793,7 +797,10 @@ function App() {
 
   useEffect(() => {
     if (!focusedMessageId) return;
-    const timer = window.setTimeout(() => setFocusedMessageId(null), 2600);
+    const timer = window.setTimeout(() => {
+      replaceNextAppHistoryEntryRef.current = true;
+      setFocusedMessageId(null);
+    }, 2600);
     return () => window.clearTimeout(timer);
   }, [focusedMessageId]);
 
@@ -820,6 +827,11 @@ function App() {
   const refreshInvalidationRef = useRef(0);
   const messageDeltaBufferRef = useRef<Map<string, { append: string; deliveryState: Message["delivery_state"] }>>(new Map());
   const optimisticMessagesRef = useRef<Map<string, Message>>(new Map());
+  // Channels created locally but not yet reflected by an authoritative bootstrap.
+  // Merged back in `refresh()` so an in-flight bootstrap can't drop the new
+  // channel and fall the active channel back to another one before the backend
+  // catches up. Entries self-evict once bootstrap returns the channel.
+  const optimisticChannelsRef = useRef<Map<string, Channel>>(new Map());
   const optimisticAttachmentUrlsRef = useRef<Map<string, string[]>>(new Map());
   // Per-message latest-intent sequence for save/unsave, so a late-failing
   // request cannot roll back over a newer toggle for the same message.
@@ -843,6 +855,7 @@ function App() {
   const restoringAppHistoryRef = useRef(false);
   const replaceNextAppHistoryEntryRef = useRef(false);
   const lastAppHistoryKeyRef = useRef<string | null>(null);
+  const historyFocusedMessageIdRef = useRef<string | null>(null);
   const searchResultThreadIdRef = useRef<string | null>(null);
   const searchResultAgentIdRef = useRef<string | null>(null);
   const [appHistoryIndex, setAppHistoryIndex] = useState(0);
@@ -862,6 +875,7 @@ function App() {
       });
       optimisticAttachmentUrlsRef.current.clear();
       optimisticMessagesRef.current.clear();
+      optimisticChannelsRef.current.clear();
     };
   }, []);
 
@@ -885,6 +899,7 @@ function App() {
       showMobileSidebar,
       selectedAgentId,
       activeModal: activeMobileModal,
+      focusedMessageId: historyFocusedMessageIdRef.current,
     };
   }
 
@@ -921,7 +936,9 @@ function App() {
   async function refresh(includeOptimistic = true, preferredActiveChannelId?: string) {
     const refreshInvalidation = refreshInvalidationRef.current;
     const next = normalizeBootstrap(await apiInvoke<Bootstrap>("bootstrap"));
-    const refreshed = withPendingSavedToggles(includeOptimistic ? withOptimisticMessages(next) : next);
+    const refreshed = withPendingSavedToggles(
+      includeOptimistic ? withOptimisticChannels(withOptimisticMessages(next)) : next,
+    );
     setData((current) => {
       if (!current || refreshInvalidation === refreshInvalidationRef.current) return refreshed;
       const refreshedMessageIds = new Set(refreshed.messages.map((message) => message.id));
@@ -933,11 +950,15 @@ function App() {
       };
     });
     setActiveChannelId((prev) => {
-      if (preferredActiveChannelId && next.channels.some((item) => item.id === preferredActiveChannelId)) {
+      // Use the merged list so a still-optimistic channel keeps the active
+      // selection instead of falling back to channels[0] when a stale bootstrap
+      // that predates its creation lands.
+      const channels = refreshed.channels;
+      if (preferredActiveChannelId && channels.some((item) => item.id === preferredActiveChannelId)) {
         return preferredActiveChannelId;
       }
-      if (next.channels.some((item) => item.id === prev)) return prev;
-      return next.channels[0]?.id || "";
+      if (channels.some((item) => item.id === prev)) return prev;
+      return channels[0]?.id || "";
     });
     setActiveThreadId((prev) => {
       const rootIds = new Set(next.messages.filter((item) => !item.thread_root_id).map((item) => item.id));
@@ -989,6 +1010,19 @@ function App() {
         : [...current.messages, message];
       return { ...current, messages: sortedMessages(messages) };
     });
+  }
+
+  function withOptimisticChannels(next: Bootstrap): Bootstrap {
+    if (optimisticChannelsRef.current.size === 0) return next;
+    const existingIds = new Set(next.channels.map((channel) => channel.id));
+    const pending: Channel[] = [];
+    for (const [id, channel] of optimisticChannelsRef.current) {
+      // Authoritative bootstrap now knows this channel — stop shadowing it.
+      if (existingIds.has(id)) optimisticChannelsRef.current.delete(id);
+      else pending.push(channel);
+    }
+    if (pending.length === 0) return next;
+    return { ...next, channels: [...next.channels, ...pending] };
   }
 
   function withOptimisticMessages(next: Bootstrap): Bootstrap {
@@ -1748,6 +1782,7 @@ function App() {
       const activeChannelIdFromState = event.state.activeChannelId ?? null;
       const activeThreadIdFromState = event.state.activeThreadId ?? null;
       const activeTabFromState = event.state.activeTab ?? "chat";
+      historyFocusedMessageIdRef.current = event.state.focusedMessageId ?? null;
       lastAppHistoryKeyRef.current = appHistoryKey({
         ...event.state,
         activeChannelId: activeChannelIdFromState,
@@ -1764,6 +1799,7 @@ function App() {
       setShowMobileSidebar(event.state.showMobileSidebar);
       setMobileSidebarDragPx(0);
       setSelectedAgentId(event.state.selectedAgentId);
+      setFocusedMessageId(event.state.focusedMessageId ?? null);
       setShowSearchModal(event.state.activeModal === "search");
       setShowActivityFeedModal(event.state.activeModal === "activity");
       setShowSavedModal(event.state.activeModal === "saved");
@@ -2596,7 +2632,6 @@ function App() {
         name,
         agentIds: agentIds.length > 0 ? agentIds : undefined,
       });
-      await refresh(true, shouldReturnToMobileHome ? undefined : result.channelId);
     } catch (err) {
       const message = errorMessage(err, "create_channel failed");
       if (isDuplicateChannelNameError(message)) {
@@ -2616,15 +2651,40 @@ function App() {
     setNewChannelAgentIds(new Set());
     setShowCreateChannelModal(false);
     createChannelOpenedFromMobileHomeRef.current = false;
+    // Optimistically insert the new channel so navigation is instant instead of
+    // waiting on a full `bootstrap` reload. The backend already emits a
+    // `channel_created` refresh event, and we also kick a background refresh
+    // below to reconcile ordering / membership.
+    if (result.channelId) {
+      const channelId = result.channelId;
+      const optimisticChannel: Channel = {
+        id: channelId,
+        name,
+        description: "",
+        kind: "channel",
+        dm_agent_id: null,
+        unread_count: 0,
+      };
+      // Track it so any in-flight/subsequent `refresh()` re-merges the channel
+      // instead of clobbering it back to the old list (and fallback-navigating
+      // away). It self-evicts once an authoritative bootstrap includes it.
+      optimisticChannelsRef.current.set(channelId, optimisticChannel);
+      // A `bootstrap` dispatched before create committed must not overwrite the
+      // optimistic insert with a stale channel list when it lands.
+      invalidatePendingRefreshResult();
+      setData((current) => {
+        if (!current || current.channels.some((item) => item.id === channelId)) return current;
+        return { ...current, channels: [...current.channels, optimisticChannel] };
+      });
+    }
     if (shouldReturnToMobileHome) {
       returnToMobileHome();
-      return;
-    }
-    if (result.channelId) {
+    } else if (result.channelId) {
       setActiveChannelId(result.channelId);
       setShowMobileSidebar(false);
       openThread(null, result.channelId);
     }
+    requestRefresh();
   }
 
   async function saveChannel() {
@@ -2790,6 +2850,7 @@ function App() {
 
   function selectChannel(channelId: string) {
     const nextChannel = data?.channels.find((item) => item.id === channelId) ?? null;
+    historyFocusedMessageIdRef.current = null;
     setSelectedAgentId(null);
     setActiveChannelId(channelId);
     setShowMobileSidebar(false);
@@ -2800,6 +2861,7 @@ function App() {
   }
 
   function openThread(threadId: string | null, channelId = activeChannelId) {
+    historyFocusedMessageIdRef.current = null;
     setActiveThreadId(threadId);
     rememberChannelThread(channelId, threadId);
     setFocusedMessageId(null);
@@ -2861,6 +2923,33 @@ function App() {
     if (canNavigateForward()) {
       window.history.forward();
     }
+  }
+
+  function pushReferenceMessageHistory(originMessageId: string, targetMessageId: string) {
+    if (isMobileViewport() || !appHistoryReadyRef.current) return;
+    const existingState = window.history.state;
+    if (!isAppHistoryState(existingState)) return;
+    const originState = {
+      ...buildAppHistoryState(existingState.index),
+      focusedMessageId: originMessageId,
+    };
+    window.history.replaceState(originState, "");
+    const targetState = {
+      ...buildAppHistoryState(existingState.index + 1),
+      focusedMessageId: targetMessageId,
+    };
+    window.history.pushState(targetState, "");
+    historyFocusedMessageIdRef.current = targetMessageId;
+    setAppHistoryPosition(targetState.index, targetState.index);
+    lastAppHistoryKeyRef.current = appHistoryKey(targetState);
+  }
+
+  function navigateToReferencedMessage(originMessageId: string, targetMessageId: string) {
+    pushReferenceMessageHistory(originMessageId, targetMessageId);
+    setFocusedMessageId(null);
+    window.requestAnimationFrame(() => {
+      setFocusedMessageId(targetMessageId);
+    });
   }
 
   function openMobileSidebarFromContent() {
@@ -3946,6 +4035,7 @@ function App() {
         openAgentDetail={(agent) => setSelectedAgentId(agent.id)}
         openArtifact={openArtifact}
         openWorkItem={openWorkItem}
+        onReferenceMessageJump={navigateToReferencedMessage}
         shareBaseUrl={shareBaseUrl}
         savedMessageIds={savedMessageIds}
         focusedMessageId={focusedMessageId}
@@ -4008,6 +4098,7 @@ function App() {
           openAgentDetail={(agent) => setSelectedAgentId(agent.id)}
           openArtifact={openArtifact}
           openWorkItem={openWorkItem}
+          onReferenceMessageJump={navigateToReferencedMessage}
           onLocateRoot={revealThreadRootInChannel}
           shareBaseUrl={shareBaseUrl}
           savedMessageIds={savedMessageIds}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2952,6 +2952,24 @@ function App() {
     });
   }
 
+  function navigateToReferencedThread(originMessageId: string, threadId: string) {
+    // Record the chip's source message in the current history entry before we
+    // switch threads, so Lantor's built-in back button returns to the message
+    // that contained the chip (the thread switch itself pushes the target entry).
+    if (!isMobileViewport() && appHistoryReadyRef.current) {
+      const existingState = window.history.state;
+      if (isAppHistoryState(existingState)) {
+        const originState = {
+          ...buildAppHistoryState(existingState.index),
+          focusedMessageId: originMessageId,
+        };
+        window.history.replaceState(originState, "");
+        lastAppHistoryKeyRef.current = appHistoryKey(originState);
+      }
+    }
+    revealThread(threadId);
+  }
+
   function openMobileSidebarFromContent() {
     setMobileSidebarFocus("home");
     if (isMobileViewport()) {
@@ -4002,6 +4020,7 @@ function App() {
         activeTab={activeTab}
         activeRoot={activeRoot}
         rootMessages={rootMessages}
+        messages={data.messages}
         threadReplyCounts={threadReplyCounts}
         threadUnreadCounts={threadUnreadCounts}
         threadReplySummaries={threadReplySummaries}
@@ -4036,6 +4055,7 @@ function App() {
         openArtifact={openArtifact}
         openWorkItem={openWorkItem}
         onReferenceMessageJump={navigateToReferencedMessage}
+        onReferenceThreadJump={navigateToReferencedThread}
         shareBaseUrl={shareBaseUrl}
         savedMessageIds={savedMessageIds}
         focusedMessageId={focusedMessageId}
@@ -4099,6 +4119,8 @@ function App() {
           openArtifact={openArtifact}
           openWorkItem={openWorkItem}
           onReferenceMessageJump={navigateToReferencedMessage}
+          onReferenceThreadJump={navigateToReferencedThread}
+          messages={data.messages}
           onLocateRoot={revealThreadRootInChannel}
           shareBaseUrl={shareBaseUrl}
           savedMessageIds={savedMessageIds}

--- a/src/message-references.ts
+++ b/src/message-references.ts
@@ -1,0 +1,65 @@
+export type MessageReferenceKind = "message" | "thread";
+
+export type ParsedMessageReference = {
+  key: string;
+  kind: MessageReferenceKind;
+  id: string;
+  token: string;
+};
+
+export type MessageReference = {
+  kind: MessageReferenceKind;
+  id: string;
+  token: string;
+};
+
+export type ResolvedMessageReference = MessageReference & {
+  message: import("./types").Message | null;
+  channel: import("./types").Channel | null;
+  replyCount: number | null;
+};
+
+export const MESSAGE_REFERENCE_PATTERN = /\[\[(message|thread):([0-9a-fA-F-]{8,36})\]\]/g;
+
+export function messageReferenceToken(kind: MessageReferenceKind, id: string) {
+  return `[[${kind}:${id}]]`;
+}
+
+export function appendMessageReferenceToken(text: string, kind: MessageReferenceKind, id: string) {
+  const token = messageReferenceToken(kind, id);
+  if (text.includes(token)) return text;
+  const trimmedEnd = text.trimEnd();
+  return `${trimmedEnd}${trimmedEnd ? "\n" : ""}${token}\n`;
+}
+
+export function parseMessageReferences(text: string): ParsedMessageReference[] {
+  return Array.from(text.matchAll(MESSAGE_REFERENCE_PATTERN), (match, index) => ({
+    key: `${match[0]}:${index}`,
+    kind: match[1].toLowerCase() as MessageReferenceKind,
+    id: match[2],
+    token: match[0],
+  }));
+}
+
+export function removeMessageReferenceToken(text: string, token: string) {
+  return text.replace(token, "").replace(/\n{3,}/g, "\n\n").trimStart();
+}
+
+export function withoutMessageReferenceTokens(text: string) {
+  return text.replace(MESSAGE_REFERENCE_PATTERN, "").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+export function resolveMessageReference(
+  reference: MessageReference,
+  messages: import("./types").Message[],
+  channels: import("./types").Channel[],
+): ResolvedMessageReference {
+  const message = reference.kind === "thread"
+    ? messages.find((item) => item.id === reference.id) ?? null
+    : messages.find((item) => item.id === reference.id) ?? null;
+  const channel = message ? channels.find((item) => item.id === message.channel_id) ?? null : null;
+  const replyCount = reference.kind === "thread"
+    ? messages.filter((item) => item.thread_root_id === reference.id).length
+    : null;
+  return { ...reference, message, channel, replyCount };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -5347,14 +5347,14 @@ mark {
 }
 
 .composer-reference-token {
-  display: inline-block;
-  margin: 0 1px;
-  padding: 0 6px;
-  border-radius: 8px;
+  /* Width-neutral highlight only: no padding / margin / inline-block /
+     font-weight change, so the overlay keeps the exact glyph advance of the
+     underlying textarea text and the caret stays aligned. box-shadow and
+     border-radius do not affect layout width. */
+  border-radius: 4px;
   background: rgba(10, 132, 255, 0.12);
   box-shadow: inset 0 0 0 1px rgba(10, 132, 255, 0.24);
   color: var(--accent);
-  font-weight: 700;
 }
 
 .composer-reference-token.thread {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2957,6 +2957,297 @@ button,
   color: var(--accent);
 }
 
+.message-reference-stack,
+.message-reference-preview-list {
+  display: grid;
+  gap: 7px;
+  width: min(100%, 560px);
+}
+
+.message-reference-stack.composer,
+.message-reference-preview-list {
+  width: 100%;
+}
+
+.message-reference-stack-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+  padding: 0 2px;
+  color: var(--muted);
+  font-size: var(--type-size-caption);
+  font-weight: var(--type-weight-semibold);
+  line-height: 18px;
+}
+
+.message-reference-stack-summary span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.message-reference-stack-summary button,
+.message-reference-stack-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  min-width: max-content;
+  height: 26px;
+  padding: 0 8px;
+  border: 1px solid rgba(10, 132, 255, 0.16);
+  border-radius: 7px;
+  background: rgba(10, 132, 255, 0.07);
+  color: var(--accent);
+  font-size: var(--type-size-caption);
+  font-weight: var(--type-weight-semibold);
+}
+
+.message-reference-stack-summary button:hover,
+.message-reference-stack-toggle:hover {
+  border-color: rgba(10, 132, 255, 0.3);
+  background: rgba(10, 132, 255, 0.11);
+}
+
+.message-reference-stack-toggle {
+  width: 100%;
+  min-width: 0;
+}
+
+.message-reference-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  max-width: 100%;
+  min-height: 50px;
+  padding: 9px 10px 9px 12px;
+  overflow: hidden;
+  border: 1px solid rgba(30, 111, 201, 0.22);
+  border-radius: 8px;
+  background:
+    linear-gradient(90deg, rgba(10, 132, 255, 0.09), rgba(10, 132, 255, 0) 34%),
+    rgba(255, 255, 255, 0.74);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.82) inset,
+    0 7px 22px rgba(31, 42, 68, 0.08);
+  color: var(--ink);
+  text-align: left;
+}
+
+.message-reference-card[role="button"] {
+  cursor: pointer;
+}
+
+.message-reference-card[role="button"]:hover {
+  border-color: rgba(30, 111, 201, 0.38);
+  background:
+    linear-gradient(90deg, rgba(10, 132, 255, 0.12), rgba(10, 132, 255, 0) 38%),
+    rgba(255, 255, 255, 0.92);
+}
+
+.message-reference-card[role="button"]:focus-visible {
+  border-color: rgba(10, 132, 255, 0.5);
+  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.14);
+  outline: none;
+}
+
+.message-reference-card.thread {
+  border-color: rgba(88, 86, 214, 0.25);
+  background:
+    linear-gradient(90deg, rgba(88, 86, 214, 0.11), rgba(88, 86, 214, 0) 36%),
+    rgba(255, 255, 255, 0.74);
+}
+
+.message-reference-card.compact {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: baseline;
+  gap: 5px;
+  width: auto;
+  min-width: 0;
+  max-width: min(100%, 360px);
+  min-height: 0;
+  margin: 0 2px;
+  padding: 2px 7px 2px 5px;
+  border-color: rgba(10, 132, 255, 0.28);
+  border-radius: 6px;
+  background: rgba(10, 132, 255, 0.12);
+  box-shadow: none;
+  color: var(--ink-primary);
+  line-height: 20px;
+}
+
+.message-reference-card.compact.thread {
+  border-color: rgba(88, 86, 214, 0.3);
+  background: rgba(88, 86, 214, 0.13);
+}
+
+.message-reference-card.compact[role="button"]:hover {
+  border-color: rgba(10, 132, 255, 0.42);
+  background: rgba(10, 132, 255, 0.18);
+}
+
+.message-reference-card.compact.thread[role="button"]:hover {
+  border-color: rgba(88, 86, 214, 0.45);
+  background: rgba(88, 86, 214, 0.19);
+}
+
+.message-reference-card.missing {
+  border-style: dashed;
+  border-color: rgba(142, 142, 147, 0.38);
+  background: rgba(142, 142, 147, 0.08);
+}
+
+.message-reference-rail {
+  position: absolute;
+  top: 10px;
+  bottom: 10px;
+  left: 0;
+  width: 3px;
+  border-radius: 0 99px 99px 0;
+  background: var(--accent);
+}
+
+.message-reference-card.thread .message-reference-rail {
+  background: #5856d6;
+}
+
+.message-reference-icon {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 1px solid rgba(10, 132, 255, 0.18);
+  border-radius: 8px;
+  background: rgba(10, 132, 255, 0.1);
+  color: var(--accent);
+}
+
+.message-reference-card.thread .message-reference-icon {
+  border-color: rgba(88, 86, 214, 0.2);
+  background: rgba(88, 86, 214, 0.11);
+  color: #5856d6;
+}
+
+.message-reference-card.compact .message-reference-icon {
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+}
+
+.message-reference-inline-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  max-width: 100%;
+  font-size: var(--type-size-caption);
+  line-height: 16px;
+}
+
+.message-reference-inline-copy strong {
+  flex: 0 0 auto;
+  font-size: var(--type-size-caption);
+  font-weight: var(--type-weight-bold);
+}
+
+.message-reference-inline-copy span {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.message-reference-copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.message-reference-title,
+.message-reference-kicker {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  color: var(--muted);
+  font-size: var(--type-size-caption);
+  line-height: 16px;
+}
+
+.message-reference-title strong,
+.message-reference-kicker strong {
+  flex: 0 0 auto;
+  color: var(--ink-primary);
+  font-size: var(--type-size-meta);
+  font-weight: var(--type-weight-bold);
+}
+
+.message-reference-title span,
+.message-reference-title em,
+.message-reference-kicker span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.message-reference-title em {
+  color: #7b8089;
+  font-style: normal;
+}
+
+.message-reference-preview {
+  display: flex;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ink);
+  font-size: var(--type-size-body);
+  line-height: 19px;
+}
+
+.message-reference-preview b {
+  flex: 0 0 auto;
+  font-weight: var(--type-weight-bold);
+}
+
+.message-reference-preview span,
+.message-reference-card.compact .message-reference-preview {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.message-reference-remove {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--muted);
+}
+
+.message-reference-remove:hover {
+  border-color: rgba(20, 23, 31, 0.12);
+  background: rgba(20, 23, 31, 0.06);
+  color: var(--ink);
+}
+
+.message-reference-channel {
+  display: none;
+}
+
 .system-message {
   margin: 2px 22px;
   padding: 0;
@@ -4293,6 +4584,79 @@ mark {
   background: var(--surface-menu-overlay);
 }
 
+:root[data-theme="dark"] .message-reference-card {
+  border-color: rgba(96, 165, 250, 0.28);
+  background:
+    linear-gradient(90deg, rgba(96, 165, 250, 0.16), rgba(96, 165, 250, 0) 38%),
+    rgba(25, 29, 36, 0.78);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset,
+    0 12px 28px rgba(0, 0, 0, 0.18);
+}
+
+:root[data-theme="dark"] .message-reference-card[role="button"]:hover {
+  border-color: rgba(96, 165, 250, 0.44);
+  background:
+    linear-gradient(90deg, rgba(96, 165, 250, 0.2), rgba(96, 165, 250, 0) 40%),
+    rgba(31, 36, 45, 0.92);
+}
+
+:root[data-theme="dark"] .message-reference-card.compact {
+  border-color: rgba(96, 165, 250, 0.34);
+  background: rgba(96, 165, 250, 0.16);
+  box-shadow: none;
+}
+
+:root[data-theme="dark"] .message-reference-card.compact[role="button"]:hover {
+  border-color: rgba(96, 165, 250, 0.48);
+  background: rgba(96, 165, 250, 0.22);
+}
+
+:root[data-theme="dark"] .message-reference-card.thread {
+  border-color: rgba(139, 136, 255, 0.34);
+  background:
+    linear-gradient(90deg, rgba(139, 136, 255, 0.18), rgba(139, 136, 255, 0) 38%),
+    rgba(25, 29, 36, 0.78);
+}
+
+:root[data-theme="dark"] .message-reference-card.compact.thread {
+  border-color: rgba(139, 136, 255, 0.42);
+  background: rgba(139, 136, 255, 0.18);
+}
+
+:root[data-theme="dark"] .message-reference-card.compact.thread[role="button"]:hover {
+  border-color: rgba(139, 136, 255, 0.54);
+  background: rgba(139, 136, 255, 0.24);
+}
+
+:root[data-theme="dark"] .message-reference-card.thread .message-reference-icon {
+  border-color: rgba(139, 136, 255, 0.25);
+  background: rgba(139, 136, 255, 0.14);
+  color: #9b99ff;
+}
+
+:root[data-theme="dark"] .message-reference-stack-summary button,
+:root[data-theme="dark"] .message-reference-stack-toggle {
+  border-color: rgba(96, 165, 250, 0.24);
+  background: rgba(96, 165, 250, 0.12);
+  color: #9dccff;
+}
+
+:root[data-theme="dark"] .message-reference-stack-summary button:hover,
+:root[data-theme="dark"] .message-reference-stack-toggle:hover {
+  border-color: rgba(96, 165, 250, 0.38);
+  background: rgba(96, 165, 250, 0.18);
+}
+
+:root[data-theme="dark"] .message-reference-title em {
+  color: #a5adba;
+}
+
+:root[data-theme="dark"] .message-reference-remove:hover {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
+}
+
 :root[data-theme="dark"] .app select {
   color-scheme: dark;
 }
@@ -4960,6 +5324,61 @@ mark {
   outline: none;
 }
 
+.composer-reference-input {
+  position: relative;
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--control-border);
+  border-radius: 18px;
+  background: var(--bg-input);
+}
+
+.composer-reference-overlay {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  padding: 14px 15px;
+  border: 1px solid transparent;
+  color: var(--ink-primary);
+  font: inherit;
+  overflow-wrap: anywhere;
+  pointer-events: none;
+  white-space: pre-wrap;
+}
+
+.composer-reference-token {
+  display: inline-block;
+  margin: 0 1px;
+  padding: 0 6px;
+  border-radius: 8px;
+  background: rgba(10, 132, 255, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(10, 132, 255, 0.24);
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.composer-reference-token.thread {
+  background: rgba(111, 66, 193, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(111, 66, 193, 0.24);
+  color: #6f42c1;
+}
+
+.composer-reference-input textarea {
+  position: relative;
+  z-index: 1;
+  border-color: transparent;
+  background: transparent;
+}
+
+.composer-reference-input.has-reference-token textarea {
+  color: transparent;
+}
+
+.composer-reference-input:focus-within {
+  border-color: rgba(10, 132, 255, 0.42);
+  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.08);
+}
+
 .composer textarea::placeholder,
 .reply-composer textarea::placeholder {
   color: var(--ink-placeholder);
@@ -4984,6 +5403,11 @@ mark {
 .reply-composer textarea:focus {
   border-color: rgba(10, 132, 255, 0.42);
   box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.08);
+}
+
+.composer-reference-input textarea:focus {
+  border-color: transparent;
+  box-shadow: none;
 }
 
 .composer textarea:disabled,
@@ -5757,6 +6181,14 @@ body.resizing-column * {
   min-height: 44px;
   padding: 12px 14px;
   border-radius: var(--radius-lg);
+}
+
+.composer-reference-input {
+  border-radius: var(--radius-lg);
+}
+
+.composer-reference-overlay {
+  padding: 12px 14px;
 }
 
 .agent-drawer {
@@ -9996,6 +10428,19 @@ body.resizing-column * {
     font-size: var(--type-size-control);
     line-height: 20px;
     overflow-y: auto;
+  }
+
+  .composer .composer-reference-input,
+  .reply-composer .composer-reference-input {
+    grid-area: input;
+    border-radius: 14px;
+  }
+
+  .composer .composer-reference-overlay,
+  .reply-composer .composer-reference-overlay {
+    padding: 7px 13px;
+    font-size: var(--type-size-control);
+    line-height: 20px;
   }
 
   .composer-actions,

--- a/src/styles.css
+++ b/src/styles.css
@@ -3104,6 +3104,65 @@ button,
   background: rgba(142, 142, 147, 0.08);
 }
 
+.message-reference-hovercard {
+  z-index: 120;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: max-content;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle, rgba(20, 23, 31, 0.12));
+  border-radius: var(--radius-lg, 14px);
+  background: var(--bg-panel-strong, #fff);
+  box-shadow:
+    0 12px 32px rgba(20, 23, 31, 0.16),
+    0 2px 8px rgba(20, 23, 31, 0.08);
+  animation: message-reference-hovercard-in 120ms ease;
+}
+
+@keyframes message-reference-hovercard-in {
+  from { opacity: 0; transform: translateY(-2px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.message-reference-hovercard-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.message-reference-hovercard-head strong {
+  flex: 0 0 auto;
+  color: var(--accent);
+  font-size: var(--type-size-meta, 12px);
+  font-weight: 700;
+}
+
+.message-reference-hovercard.thread .message-reference-hovercard-head strong {
+  color: #6f42c1;
+}
+
+.message-reference-hovercard-head span {
+  overflow: hidden;
+  color: var(--ink-muted, #6b7280);
+  font-size: var(--type-size-caption, 11px);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.message-reference-hovercard-body {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  color: var(--ink-primary, #14171f);
+  font-size: var(--type-size-control, 13px);
+  line-height: 1.45;
+  white-space: pre-line;
+  word-break: break-word;
+}
+
 .message-reference-rail {
   position: absolute;
   top: 10px;


### PR DESCRIPTION
Consolidates the reference-chip work that was previously spread across parallel builds by @Bugen / @Dylan / @admin into a single reviewable branch. One implementer (Bugen), reviewers welcome — no more parallel edits/ports.

## What's included (4 changes, all reviewed against `main`@4de146d)

**Feature — reference chips**
- `[[message:id]]` / `[[thread:id]]` tokens render as compact inline chips with a special background in message bodies (no more large reference cards).
- Composer shows the raw token as a short overlay chip (`Message 4c34dae6` / `Thread …`); the underlying text keeps the full token for copy / send / agent parsing.
- Message action menu can insert/copy a message or thread reference.

**Fix 1 — no bottom-yank on activity refresh**
Clicking a chip jumps to the target and stops auto-follow, so agent-activity refresh no longer pulls the list back to the bottom message.

**Fix 2 — built-in back button returns to source**
Chip jump records the source message in the current history entry (`replaceState`) and pushes the target as a new entry, so Lantor's top-left back button returns to the message containing the chip; forward re-enters the target. `focusedMessageId` is now part of `AppHistoryState` / `appHistoryKey`, restored on `popstate`. Wired for both channel (`Conversation.tsx`) and thread (`ThreadPanel.tsx`).

## Files
`src/main.tsx`, `src/components/{Conversation,ThreadPanel,MessageMarkdown,MessageActionMenu}.tsx`, new `src/components/{ComposerReferenceTextarea,MessageReferenceCard,MessageReferencePreview}.tsx`, new `src/message-references.ts`, `src/hooks/useAutoGrowTextarea.ts`, `src/styles.css`.

## Verification
- `npm run build` passes.
- Test instance: `http://127.0.0.1:8802/` (asset `index-CRXlNToz.js`).

## Review notes
- Base is `main`@4de146d — this branch does **not** include the merged autosize flicker fix `9e67ab1`; the `useAutoGrowTextarea.ts` change here is the composer-overlay sizing, unrelated to that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)