### PR TITLE
feat(perf): add bootstrap and render telemetry

### DIFF
--- a/src-tauri/src/bootstrap.rs
+++ b/src-tauri/src/bootstrap.rs
@@ -1,6 +1,7 @@
 use std::{
     env,
     net::{IpAddr, SocketAddr},
+    time::Instant,
 };
 
 use sqlx::SqlitePool;
@@ -18,7 +19,9 @@ use crate::{
     message_store::{
         load_artifacts, load_messages, load_recent_messages_per_channel, load_saved_messages,
     },
-    models::Bootstrap,
+    models::{
+        Bootstrap, BootstrapPerf, BootstrapPerfCounts, BootstrapPerfOptions, BootstrapPerfPhase,
+    },
     owner_inbox::{load_dismissed_inbox_items, load_read_inbox_items},
     runtime::supervisor::load_supervisor_status,
     task_store::load_tasks,
@@ -50,6 +53,7 @@ pub(crate) async fn load_bootstrap(pool: &SqlitePool, db_url: String) -> Command
         pool,
         db_url,
         BootstrapLoadOptions {
+            runtime: "tauri",
             messages: BootstrapMessageLoad::All,
             include_run_logs: true,
             compact_agent_activities: false,
@@ -66,6 +70,7 @@ pub(crate) async fn load_web_bootstrap(
         pool,
         db_url,
         BootstrapLoadOptions {
+            runtime: "web",
             messages: BootstrapMessageLoad::RecentPerChannel(WEB_BOOTSTRAP_MESSAGES_PER_CHANNEL),
             include_run_logs: false,
             compact_agent_activities: true,
@@ -75,14 +80,48 @@ pub(crate) async fn load_web_bootstrap(
 }
 
 struct BootstrapLoadOptions {
+    runtime: &'static str,
     messages: BootstrapMessageLoad,
     include_run_logs: bool,
     compact_agent_activities: bool,
 }
 
+#[derive(Clone, Copy)]
 enum BootstrapMessageLoad {
     All,
     RecentPerChannel(i64),
+}
+
+impl BootstrapMessageLoad {
+    fn label(self) -> String {
+        match self {
+            BootstrapMessageLoad::All => "All".to_owned(),
+            BootstrapMessageLoad::RecentPerChannel(limit) => format!("RecentPerChannel({limit})"),
+        }
+    }
+}
+
+fn elapsed_ms(start: Instant) -> f64 {
+    start.elapsed().as_secs_f64() * 1000.0
+}
+
+fn push_phase(
+    phases: &mut Vec<BootstrapPerfPhase>,
+    name: &str,
+    started_at: Instant,
+    rows: Option<usize>,
+) {
+    phases.push(BootstrapPerfPhase {
+        name: name.to_owned(),
+        duration_ms: elapsed_ms(started_at),
+        rows,
+    });
+}
+
+fn should_measure_bootstrap_payload() -> bool {
+    env::var("LANTOR_PERF").is_ok_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        || env::var("LANTOR_PERF_PAYLOAD")
+            .is_ok_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
 }
 
 async fn load_bootstrap_with_options(
@@ -90,39 +129,158 @@ async fn load_bootstrap_with_options(
     db_url: String,
     options: BootstrapLoadOptions,
 ) -> CommandResult<Bootstrap> {
+    let total_started_at = Instant::now();
+    let mut phases = Vec::new();
+
+    let started_at = Instant::now();
     let owner_profile = load_owner_profile(pool).await?;
+    push_phase(&mut phases, "owner_profile", started_at, Some(1));
+
+    let started_at = Instant::now();
     let channels = load_channels(pool).await?;
+    push_phase(&mut phases, "channels", started_at, Some(channels.len()));
+
+    let started_at = Instant::now();
     let thread_activities = load_thread_activities(pool).await?;
+    push_phase(
+        &mut phases,
+        "thread_activities",
+        started_at,
+        Some(thread_activities.len()),
+    );
+
+    let started_at = Instant::now();
     let channel_members = load_channel_members(pool).await?;
+    push_phase(
+        &mut phases,
+        "channel_members",
+        started_at,
+        Some(channel_members.len()),
+    );
+
+    let started_at = Instant::now();
     let agents = load_agents(pool).await?;
+    push_phase(&mut phases, "agents", started_at, Some(agents.len()));
+
+    let started_at = Instant::now();
     let messages = match options.messages {
         BootstrapMessageLoad::All => load_messages(pool).await?,
         BootstrapMessageLoad::RecentPerChannel(limit) => {
             load_recent_messages_per_channel(pool, limit).await?
         }
     };
+    push_phase(&mut phases, "messages", started_at, Some(messages.len()));
+
+    let started_at = Instant::now();
     let saved_messages = load_saved_messages(pool).await?;
+    push_phase(
+        &mut phases,
+        "saved_messages",
+        started_at,
+        Some(saved_messages.len()),
+    );
+
+    let started_at = Instant::now();
     let dismissed_inbox_items = load_dismissed_inbox_items(pool).await?;
+    push_phase(
+        &mut phases,
+        "dismissed_inbox_items",
+        started_at,
+        Some(dismissed_inbox_items.len()),
+    );
+
+    let started_at = Instant::now();
     let read_inbox_items = load_read_inbox_items(pool).await?;
+    push_phase(
+        &mut phases,
+        "read_inbox_items",
+        started_at,
+        Some(read_inbox_items.len()),
+    );
+
+    let started_at = Instant::now();
     let artifacts = load_artifacts(pool).await?;
+    push_phase(&mut phases, "artifacts", started_at, Some(artifacts.len()));
+
+    let started_at = Instant::now();
     let tasks = load_tasks(pool).await?;
+    push_phase(&mut phases, "tasks", started_at, Some(tasks.len()));
+
+    let started_at = Instant::now();
     let reminders = load_reminders(pool).await?;
+    push_phase(&mut phases, "reminders", started_at, Some(reminders.len()));
+
+    let started_at = Instant::now();
     let agent_schedules = load_agent_schedules(pool).await?;
+    push_phase(
+        &mut phases,
+        "agent_schedules",
+        started_at,
+        Some(agent_schedules.len()),
+    );
+
+    let started_at = Instant::now();
     let agent_runs = if options.include_run_logs {
         load_agent_runs(pool).await?
     } else {
         load_agent_run_summaries(pool).await?
     };
+    push_phase(
+        &mut phases,
+        "agent_runs",
+        started_at,
+        Some(agent_runs.len()),
+    );
+
+    let started_at = Instant::now();
     let agent_work_items = load_agent_work_items(pool).await?;
+    push_phase(
+        &mut phases,
+        "agent_work_items",
+        started_at,
+        Some(agent_work_items.len()),
+    );
+
+    let started_at = Instant::now();
     let agent_activities = if options.compact_agent_activities {
         load_agent_activity_summaries(pool).await?
     } else {
         load_agent_activities(pool).await?
     };
-    let supervisor = load_supervisor_status(pool).await?;
-    let launch_agent = launch_agent::load_launch_agent_status()?;
+    push_phase(
+        &mut phases,
+        "agent_activities",
+        started_at,
+        Some(agent_activities.len()),
+    );
 
-    Ok(Bootstrap {
+    let started_at = Instant::now();
+    let supervisor = load_supervisor_status(pool).await?;
+    push_phase(&mut phases, "supervisor", started_at, None);
+
+    let started_at = Instant::now();
+    let launch_agent = launch_agent::load_launch_agent_status()?;
+    push_phase(&mut phases, "launch_agent", started_at, None);
+
+    let counts = BootstrapPerfCounts {
+        channels: channels.len(),
+        thread_activities: thread_activities.len(),
+        channel_members: channel_members.len(),
+        agents: agents.len(),
+        messages: messages.len(),
+        saved_messages: saved_messages.len(),
+        dismissed_inbox_items: dismissed_inbox_items.len(),
+        read_inbox_items: read_inbox_items.len(),
+        artifacts: artifacts.len(),
+        tasks: tasks.len(),
+        reminders: reminders.len(),
+        agent_schedules: agent_schedules.len(),
+        agent_runs: agent_runs.len(),
+        agent_work_items: agent_work_items.len(),
+        agent_activities: agent_activities.len(),
+    };
+
+    let mut bootstrap = Bootstrap {
         db_url,
         web_base_url: configured_web_base_url(),
         owner_profile,
@@ -143,5 +301,31 @@ async fn load_bootstrap_with_options(
         agent_activities,
         supervisor,
         launch_agent,
-    })
+        perf: None,
+    };
+
+    let (serialize_ms, payload_bytes) = if should_measure_bootstrap_payload() {
+        let serialize_started_at = Instant::now();
+        let payload_bytes = serde_json::to_vec(&bootstrap)
+            .map(|payload| payload.len())
+            .ok();
+        (Some(elapsed_ms(serialize_started_at)), payload_bytes)
+    } else {
+        (None, None)
+    };
+    bootstrap.perf = Some(BootstrapPerf {
+        options: BootstrapPerfOptions {
+            runtime: options.runtime.to_owned(),
+            message_load: options.messages.label(),
+            include_run_logs: options.include_run_logs,
+            compact_agent_activities: options.compact_agent_activities,
+        },
+        total_ms: elapsed_ms(total_started_at),
+        serialize_ms,
+        payload_bytes,
+        phases,
+        counts,
+    });
+
+    Ok(bootstrap)
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -345,6 +345,50 @@ pub(crate) struct SupervisorCommand {
 }
 
 #[derive(Debug, Serialize)]
+pub(crate) struct BootstrapPerfPhase {
+    pub(crate) name: String,
+    pub(crate) duration_ms: f64,
+    pub(crate) rows: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct BootstrapPerfOptions {
+    pub(crate) runtime: String,
+    pub(crate) message_load: String,
+    pub(crate) include_run_logs: bool,
+    pub(crate) compact_agent_activities: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct BootstrapPerfCounts {
+    pub(crate) channels: usize,
+    pub(crate) thread_activities: usize,
+    pub(crate) channel_members: usize,
+    pub(crate) agents: usize,
+    pub(crate) messages: usize,
+    pub(crate) saved_messages: usize,
+    pub(crate) dismissed_inbox_items: usize,
+    pub(crate) read_inbox_items: usize,
+    pub(crate) artifacts: usize,
+    pub(crate) tasks: usize,
+    pub(crate) reminders: usize,
+    pub(crate) agent_schedules: usize,
+    pub(crate) agent_runs: usize,
+    pub(crate) agent_work_items: usize,
+    pub(crate) agent_activities: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct BootstrapPerf {
+    pub(crate) options: BootstrapPerfOptions,
+    pub(crate) total_ms: f64,
+    pub(crate) serialize_ms: Option<f64>,
+    pub(crate) payload_bytes: Option<usize>,
+    pub(crate) phases: Vec<BootstrapPerfPhase>,
+    pub(crate) counts: BootstrapPerfCounts,
+}
+
+#[derive(Debug, Serialize)]
 pub(crate) struct Bootstrap {
     pub(crate) db_url: String,
     pub(crate) web_base_url: Option<String>,
@@ -366,4 +410,6 @@ pub(crate) struct Bootstrap {
     pub(crate) agent_activities: Vec<AgentActivity>,
     pub(crate) supervisor: SupervisorStatus,
     pub(crate) launch_agent: LaunchAgentStatus,
+    #[serde(rename = "__perf")]
+    pub(crate) perf: Option<BootstrapPerf>,
 }

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -65,6 +65,62 @@ export async function apiInvoke<T>(command: string, args: Record<string, unknown
   return payload as T;
 }
 
+export type ApiInvokeMeasurement = {
+  roundtripMs: number;
+  payloadBytes?: number;
+  parseMs?: number;
+};
+
+export async function apiInvokeMeasured<T>(
+  command: string,
+  args: Record<string, unknown> = {},
+): Promise<{ payload: T; measurement: ApiInvokeMeasurement }> {
+  const startedAt = performance.now();
+  if (isTauriRuntime()) {
+    const payload = await tauriInvoke<T>(command, args);
+    return {
+      payload,
+      measurement: {
+        roundtripMs: performance.now() - startedAt,
+      },
+    };
+  }
+
+  const response = command === "bootstrap"
+    ? await fetch(apiPath("bootstrap"))
+    : await fetch(apiPath(command), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(args),
+    });
+
+  const contentType = response.headers.get("content-type") || "";
+  const rawPayload = await response.text();
+  const roundtripMs = performance.now() - startedAt;
+  const payloadBytes = new TextEncoder().encode(rawPayload).length;
+  const parseStartedAt = performance.now();
+  const payload = contentType.includes("application/json")
+    ? JSON.parse(rawPayload)
+    : rawPayload;
+  const parseMs = performance.now() - parseStartedAt;
+  if (!response.ok) {
+    const message = typeof payload === "object" && payload && "message" in payload
+      ? String((payload as { message: unknown }).message)
+      : String(payload || `${command} failed`);
+    throw new Error(message);
+  }
+  return {
+    payload: payload as T,
+    measurement: {
+      roundtripMs,
+      payloadBytes,
+      parseMs,
+    },
+  };
+}
+
 export async function subscribeBackendEvents(handler: (payload: string) => void): Promise<UnlistenFn> {
   if (isTauriRuntime()) {
     return tauriListen<string>(UI_REFRESH_EVENT, (event) => handler(event.payload));

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,5 +1,6 @@
 import { Image, Monitor, Moon, Sun, Type } from "lucide-react";
 import { Modal } from "./Modal";
+import { usePerfSnapshot, type PerfCause, type PerfPhaseMetrics } from "../perf";
 
 export type ThemePreference = "auto" | "light" | "dark";
 export type ChatTextSize = "compact" | "default" | "large" | "xlarge";
@@ -49,6 +50,30 @@ const FONT_PRESET_OPTIONS: Array<{
   { value: "space-grotesk", label: "Space Grotesk", detail: "New · Space Mono code" },
 ];
 
+const PERF_CAUSES: PerfCause[] = ["full-refresh", "message-upsert", "activity-flush"];
+
+function formatMs(value?: number) {
+  if (value === undefined) return "n/a";
+  if (value >= 100) return `${Math.round(value)} ms`;
+  return `${value.toFixed(1)} ms`;
+}
+
+function formatBytes(value?: number) {
+  if (value === undefined) return "n/a";
+  if (value >= 1024 * 1024) return `${(value / 1024 / 1024).toFixed(2)} MB`;
+  if (value >= 1024) return `${Math.round(value / 1024)} KB`;
+  return `${value} B`;
+}
+
+function phaseSummary(phases: PerfPhaseMetrics) {
+  return [
+    `B ${formatMs(phases.backendMs)}`,
+    `T ${formatMs(phases.transportMs)}`,
+    `P ${formatMs(phases.parseApplyMs ?? phases.applyMs)}`,
+    `R ${formatMs(phases.commitMs)}`,
+  ].join(" · ");
+}
+
 export function SettingsModal({
   open,
   themePreference,
@@ -61,6 +86,8 @@ export function SettingsModal({
   onShowImageThumbnailsChange,
   onClose,
 }: SettingsModalProps) {
+  const perf = usePerfSnapshot();
+  const latestSample = perf.samples[0] ?? null;
   return (
     <Modal open={open} title="Settings" onClose={onClose} width={560}>
       <section className="settings-panel">
@@ -150,6 +177,34 @@ export function SettingsModal({
             />
           </label>
           <p className="settings-hint">When disabled, images appear as compact attachment rows and still open in preview when clicked.</p>
+        </fieldset>
+        <fieldset className="settings-fieldset settings-perf-fieldset">
+          <legend>Performance</legend>
+          <div className="settings-perf-grid">
+            {PERF_CAUSES.map((cause) => {
+              const item = perf.summary[cause];
+              return (
+                <div className="settings-perf-card" key={cause}>
+                  <strong>{cause}</strong>
+                  <small>{item.count} samples</small>
+                  <span>{phaseSummary(item.p50)}</span>
+                  <span>p95 {phaseSummary(item.p95)}</span>
+                </div>
+              );
+            })}
+          </div>
+          {latestSample ? (
+            <div className="settings-perf-latest">
+              <span>Latest</span>
+              <strong>{latestSample.cause}</strong>
+              <small>
+                {phaseSummary(latestSample.phases)} · payload {formatBytes(latestSample.transportPayloadBytes ?? latestSample.payloadBytes)}
+              </small>
+            </div>
+          ) : (
+            <p className="settings-hint">No samples yet. Run a refresh or wait for activity updates.</p>
+          )}
+          <p className="settings-hint">Recent samples are also available at window.__LANTOR_PERF__. Enable production sampling with ?lantorPerf or localStorage lantor:perf=1. Web payload bytes are decoded response bytes; Tauri transport includes IPC deserialization.</p>
         </fieldset>
       </section>
     </Modal>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,7 +14,7 @@ import {
 } from "react";
 import { createRoot } from "react-dom/client";
 import { Bookmark, Home, Inbox, Search } from "lucide-react";
-import { apiInvoke, completeStartupSplash, isTauriRuntime, subscribeBackendEvents } from "./apiClient";
+import { apiInvoke, apiInvokeMeasured, completeStartupSplash, isTauriRuntime, subscribeBackendEvents } from "./apiClient";
 import { APP_DISPLAY_NAME } from "./branding";
 import { AgentDetailDrawer } from "./components/AgentDetailDrawer";
 import type { AgentPerformance } from "./components/AgentDetailDrawer";
@@ -61,6 +61,13 @@ import {
   ThreadReplySummary,
 } from "./types";
 import { agentRequestSourceLabel, buildPresetCommand, firstLines, formatTime, visibleChannelDescription } from "./ui-utils";
+import {
+  createPerfDraft,
+  initPerfTelemetry,
+  recordPerfCommit,
+  shouldEnablePerfTelemetry,
+  waitForPerfCommit,
+} from "./perf";
 import "@fontsource-variable/space-grotesk";
 import "@fontsource/space-mono/400.css";
 import "@fontsource/space-mono/700.css";
@@ -111,6 +118,15 @@ const recordBenchCommit: ProfilerOnRenderCallback = (id, phase, actualDuration, 
     startTime,
     commitTime,
   });
+};
+
+initPerfTelemetry();
+
+const recordAppCommit: ProfilerOnRenderCallback = (id, phase, actualDuration, baseDuration, startTime, commitTime) => {
+  recordPerfCommit(actualDuration, commitTime);
+  if (shouldEnableBenchProfiler()) {
+    recordBenchCommit(id, phase, actualDuration, baseDuration, startTime, commitTime);
+  }
 };
 
 const ACTIVITY_PHASE_LABELS: Record<string, string> = {
@@ -940,11 +956,42 @@ function App() {
   }
 
   async function refresh(includeOptimistic = true, preferredActiveChannelId?: string) {
+    const perf = shouldEnablePerfTelemetry() ? createPerfDraft("full-refresh") : null;
     const refreshInvalidation = refreshInvalidationRef.current;
-    const next = normalizeBootstrap(await apiInvoke<Bootstrap>("bootstrap"));
+    const { payload, measurement } = perf
+      ? await apiInvokeMeasured<Bootstrap>("bootstrap")
+      : { payload: await apiInvoke<Bootstrap>("bootstrap"), measurement: null };
+    const backendMs = payload.__perf?.total_ms;
+    if (perf && measurement) {
+      perf.backend = payload.__perf;
+      perf.payloadBytes = payload.__perf?.payload_bytes ?? undefined;
+      perf.transportPayloadBytes = measurement.payloadBytes;
+      perf.labels = {
+        messageLoad: payload.__perf?.options.message_load ?? null,
+        includeRunLogs: payload.__perf?.options.include_run_logs ?? null,
+        compactAgentActivities: payload.__perf?.options.compact_agent_activities ?? null,
+        payloadBytesKind: measurement.payloadBytes === undefined ? "tauri-estimated" : "decoded-response",
+        tauriTransportIncludesDeserialize: isTauriRuntime(),
+      };
+      perf.phases.backendMs = backendMs;
+      perf.phases.transportMs = measurement.roundtripMs - (backendMs ?? 0);
+      perf.phases.parseMs = measurement.parseMs;
+    }
+    const applyStartedAt = performance.now();
+    const next = normalizeBootstrap(payload);
     const refreshed = withPendingSavedToggles(
       includeOptimistic ? withOptimisticChannels(withOptimisticMessages(next)) : next,
     );
+    if (perf) {
+      perf.counts = {
+        channels: refreshed.channels.length,
+        messages: refreshed.messages.length,
+        agentRuns: refreshed.agent_runs.length,
+        agentActivities: refreshed.agent_activities.length,
+        artifacts: refreshed.artifacts.length,
+        tasks: refreshed.tasks.length,
+      };
+    }
     setData((current) => {
       if (!current || refreshInvalidation === refreshInvalidationRef.current) return refreshed;
       const refreshedMessageIds = new Set(refreshed.messages.map((message) => message.id));
@@ -971,6 +1018,12 @@ function App() {
       if (prev && rootIds.has(prev)) return prev;
       return null;
     });
+    const applyEndedAt = performance.now();
+    if (perf) {
+      perf.phases.applyMs = applyEndedAt - applyStartedAt;
+      perf.phases.parseApplyMs = (measurement?.parseMs ?? 0) + perf.phases.applyMs;
+      waitForPerfCommit(perf, applyEndedAt);
+    }
   }
 
   function refreshWithError(fallback: string) {
@@ -1003,8 +1056,10 @@ function App() {
   }
 
   function applyMessageUpsert(message: Message) {
+    const perf = shouldEnablePerfTelemetry() ? createPerfDraft("message-upsert") : null;
     messageDeltaBufferRef.current.delete(message.id);
     invalidatePendingRefreshResult();
+    const applyStartedAt = performance.now();
     setData((current) => {
       if (!current) {
         requestRefresh(`Failed to refresh ${APP_DISPLAY_NAME} state after message update`);
@@ -1016,6 +1071,12 @@ function App() {
         : [...current.messages, message];
       return { ...current, messages: sortedMessages(messages) };
     });
+    const applyEndedAt = performance.now();
+    if (perf) {
+      perf.counts.updatedMessages = 1;
+      perf.phases.applyMs = applyEndedAt - applyStartedAt;
+      waitForPerfCommit(perf, applyEndedAt);
+    }
   }
 
   function withOptimisticChannels(next: Bootstrap): Bootstrap {
@@ -1204,10 +1265,12 @@ function App() {
     const activityBuffer = ephemeralActivityBufferRef.current;
     const runBuffer = ephemeralRunBufferRef.current;
     if (activityBuffer.size === 0 && runBuffer.size === 0) return;
+    const perf = shouldEnablePerfTelemetry() ? createPerfDraft("activity-flush") : null;
     const activities = Array.from(activityBuffer.values());
     const runs = Array.from(runBuffer.values());
     ephemeralActivityBufferRef.current = new Map();
     ephemeralRunBufferRef.current = new Map();
+    const applyStartedAt = performance.now();
     setData((current) => {
       if (!current) {
         requestRefresh(`Failed to refresh ${APP_DISPLAY_NAME} state after buffered updates`);
@@ -1239,6 +1302,13 @@ function App() {
       }
       return { ...current, agent_activities: nextActivities, agent_runs: nextRuns };
     });
+    const applyEndedAt = performance.now();
+    if (perf) {
+      perf.counts.updatedActivities = activities.length;
+      perf.counts.updatedRuns = runs.length;
+      perf.phases.applyMs = applyEndedAt - applyStartedAt;
+      waitForPerfCommit(perf, applyEndedAt);
+    }
   }
 
   function scheduleEphemeralFlush() {
@@ -4357,7 +4427,7 @@ const app = (
 );
 
 createRoot(document.getElementById("root")!).render(
-  shouldEnableBenchProfiler()
-    ? <Profiler id="LantorApp" onRender={recordBenchCommit}>{app}</Profiler>
+  shouldEnablePerfTelemetry() || shouldEnableBenchProfiler()
+    ? <Profiler id="LantorApp" onRender={recordAppCommit}>{app}</Profiler>
     : app,
 );

--- a/src/perf.ts
+++ b/src/perf.ts
@@ -1,0 +1,255 @@
+import { useEffect, useState } from "react";
+import type { Bootstrap } from "./types";
+
+export type PerfCause = "full-refresh" | "message-upsert" | "activity-flush";
+
+export type PerfPhaseMetrics = {
+  backendMs?: number;
+  transportMs?: number;
+  parseMs?: number;
+  applyMs?: number;
+  parseApplyMs?: number;
+  commitMs?: number;
+  renderActualMs?: number;
+  totalMs?: number;
+};
+
+export type PerfCounts = {
+  messages?: number;
+  agentRuns?: number;
+  agentActivities?: number;
+  artifacts?: number;
+  tasks?: number;
+  channels?: number;
+  updatedMessages?: number;
+  updatedActivities?: number;
+  updatedRuns?: number;
+  longTasks?: number;
+};
+
+export type PerfSample = {
+  id: number;
+  cause: PerfCause;
+  runtime: "tauri" | "web";
+  startedAt: number;
+  recordedAt: number;
+  phases: PerfPhaseMetrics;
+  counts: PerfCounts;
+  backend?: Bootstrap["__perf"];
+  payloadBytes?: number;
+  transportPayloadBytes?: number;
+  labels?: Record<string, string | number | boolean | null>;
+  longTasks: Array<{ startTime: number; durationMs: number }>;
+};
+
+type PendingCommit = Omit<PerfSample, "recordedAt" | "longTasks"> & {
+  commitFrom: number;
+};
+
+export type PerfSnapshot = {
+  samples: PerfSample[];
+  summary: Record<PerfCause, {
+    count: number;
+    p50: PerfPhaseMetrics;
+    p95: PerfPhaseMetrics;
+  }>;
+};
+
+const MAX_SAMPLES = 50;
+const PENDING_COMMIT_MAX_AGE_MS = 2000;
+const PERF_STORAGE_KEY = "lantor:perf";
+let nextSampleId = 1;
+let samples: PerfSample[] = [];
+let pendingCommits: PendingCommit[] = [];
+let longTasks: Array<{ startTime: number; durationMs: number }> = [];
+const subscribers = new Set<() => void>();
+
+function runtime(): "tauri" | "web" {
+  return typeof window !== "undefined" && Boolean(window.__TAURI_INTERNALS__) ? "tauri" : "web";
+}
+
+function isDevBuild() {
+  return Boolean((import.meta as unknown as { env?: { DEV?: boolean } }).env?.DEV);
+}
+
+export function shouldEnablePerfTelemetry() {
+  if (typeof window === "undefined") return false;
+  const params = new URLSearchParams(window.location.search);
+  return params.has("lantorPerf")
+    || window.localStorage.getItem(PERF_STORAGE_KEY) === "1"
+    || isDevBuild();
+}
+
+function notify() {
+  for (const subscriber of subscribers) subscriber();
+}
+
+function percentile(values: number[], percentileValue: number) {
+  if (values.length === 0) return undefined;
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.min(sorted.length - 1, Math.floor((sorted.length - 1) * percentileValue));
+  return sorted[index];
+}
+
+function summarizePhases(items: PerfSample[], percentileValue: number): PerfPhaseMetrics {
+  const keys: Array<keyof PerfPhaseMetrics> = [
+    "backendMs",
+    "transportMs",
+    "parseMs",
+    "applyMs",
+    "parseApplyMs",
+    "commitMs",
+    "renderActualMs",
+    "totalMs",
+  ];
+  const summary: PerfPhaseMetrics = {};
+  for (const key of keys) {
+    const values = items
+      .map((sample) => sample.phases[key])
+      .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
+    const value = percentile(values, percentileValue);
+    if (value !== undefined) summary[key] = value;
+  }
+  return summary;
+}
+
+function snapshot(): PerfSnapshot {
+  const summary = {} as PerfSnapshot["summary"];
+  for (const cause of ["full-refresh", "message-upsert", "activity-flush"] as const) {
+    const items = samples.filter((sample) => sample.cause === cause);
+    summary[cause] = {
+      count: items.length,
+      p50: summarizePhases(items, 0.5),
+      p95: summarizePhases(items, 0.95),
+    };
+  }
+  return { samples, summary };
+}
+
+function publishSample(sample: PerfSample) {
+  samples = [sample, ...samples].slice(0, MAX_SAMPLES);
+  notify();
+}
+
+export function createPerfDraft(cause: PerfCause): PendingCommit {
+  return {
+    id: nextSampleId++,
+    cause,
+    runtime: runtime(),
+    startedAt: performance.now(),
+    commitFrom: performance.now(),
+    phases: {},
+    counts: {},
+  };
+}
+
+export function completePerfWithoutCommit(draft: PendingCommit) {
+  const now = performance.now();
+  publishSample({
+    ...draft,
+    recordedAt: now,
+    phases: {
+      ...draft.phases,
+      totalMs: draft.phases.totalMs ?? now - draft.startedAt,
+    },
+    longTasks: recentLongTasks(draft.startedAt, now),
+  });
+}
+
+export function waitForPerfCommit(draft: PendingCommit, commitFrom = performance.now()) {
+  discardExpiredPendingCommits(commitFrom);
+  pendingCommits = [...pendingCommits, { ...draft, commitFrom }].slice(-MAX_SAMPLES);
+}
+
+export function recordPerfCommit(actualDuration: number, commitTime: number) {
+  discardExpiredPendingCommits(commitTime);
+  if (pendingCommits.length === 0) return;
+  const drafts = pendingCommits;
+  pendingCommits = [];
+  for (const draft of drafts) {
+    publishSample({
+      ...draft,
+      recordedAt: commitTime,
+      phases: {
+        ...draft.phases,
+        commitMs: Math.max(0, commitTime - draft.commitFrom),
+        renderActualMs: actualDuration,
+        totalMs: commitTime - draft.startedAt,
+      },
+      counts: {
+        ...draft.counts,
+        longTasks: recentLongTasks(draft.startedAt, commitTime).length,
+      },
+      longTasks: recentLongTasks(draft.startedAt, commitTime),
+    });
+  }
+}
+
+function discardExpiredPendingCommits(now = performance.now()) {
+  pendingCommits = pendingCommits.filter((draft) => now - draft.commitFrom <= PENDING_COMMIT_MAX_AGE_MS);
+}
+
+function recentLongTasks(startedAt: number, endedAt: number) {
+  return longTasks.filter((task) => task.startTime >= startedAt - 5 && task.startTime <= endedAt + 5);
+}
+
+export function initPerfTelemetry() {
+  if (typeof window === "undefined") return;
+  if (!window.__LANTOR_PERF__) {
+    window.__LANTOR_PERF__ = {
+      samples: () => samples,
+      latest: () => samples[0] ?? null,
+      summary: () => snapshot().summary,
+      reset: () => {
+        samples = [];
+        pendingCommits = [];
+        longTasks = [];
+        notify();
+      },
+    };
+  }
+  if (!shouldEnablePerfTelemetry()) return;
+  if (!("PerformanceObserver" in window)) return;
+  try {
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        longTasks = [
+          { startTime: entry.startTime, durationMs: entry.duration },
+          ...longTasks,
+        ].slice(0, 100);
+      }
+    });
+    observer.observe({ entryTypes: ["longtask"] });
+  } catch {
+    // Some runtimes expose PerformanceObserver but not longtask.
+  }
+}
+
+export function subscribePerfSamples(subscriber: () => void) {
+  subscribers.add(subscriber);
+  return () => {
+    subscribers.delete(subscriber);
+  };
+}
+
+export function getPerfSnapshot() {
+  return snapshot();
+}
+
+export function usePerfSnapshot() {
+  const [value, setValue] = useState(getPerfSnapshot);
+  useEffect(() => subscribePerfSamples(() => setValue(getPerfSnapshot())), []);
+  return value;
+}
+
+declare global {
+  interface Window {
+    __TAURI_INTERNALS__?: unknown;
+    __LANTOR_PERF__?: {
+      samples: () => PerfSample[];
+      latest: () => PerfSample | null;
+      summary: () => PerfSnapshot["summary"];
+      reset: () => void;
+    };
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -6784,6 +6784,57 @@ body.resizing-column * {
   margin-top: 8px;
 }
 
+.settings-perf-fieldset {
+  margin-top: 8px;
+}
+
+.settings-perf-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.settings-perf-card {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-strong);
+}
+
+.settings-perf-card strong,
+.settings-perf-latest strong {
+  overflow: hidden;
+  color: var(--ink);
+  font-size: var(--type-size-meta);
+  font-weight: var(--type-weight-semibold);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-perf-card small,
+.settings-perf-card span,
+.settings-perf-latest span,
+.settings-perf-latest small {
+  color: var(--muted);
+  font-size: var(--type-size-caption);
+  line-height: 1.35;
+}
+
+.settings-perf-latest {
+  display: grid;
+  grid-template-columns: auto minmax(0, auto) minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+  min-width: 0;
+  padding: 9px 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
 .settings-toggle-row {
   display: flex;
   align-items: center;

--- a/src/types.ts
+++ b/src/types.ts
@@ -296,6 +296,41 @@ export type Bootstrap = {
   agent_activities: AgentActivity[];
   supervisor: SupervisorStatus;
   launch_agent: LaunchAgentStatus;
+  __perf?: BootstrapPerf;
+};
+
+export type BootstrapPerf = {
+  options: {
+    runtime: string;
+    message_load: string;
+    include_run_logs: boolean;
+    compact_agent_activities: boolean;
+  };
+  total_ms: number;
+  serialize_ms: number | null;
+  payload_bytes: number | null;
+  phases: Array<{
+    name: string;
+    duration_ms: number;
+    rows: number | null;
+  }>;
+  counts: {
+    channels: number;
+    thread_activities: number;
+    channel_members: number;
+    agents: number;
+    messages: number;
+    saved_messages: number;
+    dismissed_inbox_items: number;
+    read_inbox_items: number;
+    artifacts: number;
+    tasks: number;
+    reminders: number;
+    agent_schedules: number;
+    agent_runs: number;
+    agent_work_items: number;
+    agent_activities: number;
+  };
 };
 
 export type SearchScope = "all" | "messages" | "channels" | "tasks" | "agents" | "activity" | "artifacts";


### PR DESCRIPTION
## PR A — Perf metrics (measure-first, not the optimization itself)

Adds a lightweight, unified **web + app** perf telemetry layer so we can attribute jank instead of guessing. This is the "scale before dieting" PR — later bootstrap throttling / activity-store split / task #9 render isolation all get measured against the same instrument.

> **Stacked on `reference-chips` (#153).** Base is set to that branch so this PR shows only the single perf commit `46154f0`. Merge/rebase #153 first.

### What it adds (four-segment + attribution model)
- **B. backend** — per-query durations, row counts, serialize time, payload bytes on `load_bootstrap` / web bootstrap, tagged with load strategy (`All` vs `RecentPerChannel(80)`, run_logs/activities compact flags). Delivered via optional `__perf` response field.
- **T. transport** — `apiInvoke` roundtrip minus B, measured **separately for Tauri IPC vs HTTP** (not folded into total).
- **P. parse+apply** — around `normalizeBootstrap` + `setData`.
- **R. commit** — first React commit after `setData` (`<Profiler>`).
- **`cause` label** — every sample tagged `full-refresh` / `message-upsert` / `activity-flush` (the key to attribution).
- **longtask** — `PerformanceObserver` captures >50ms tasks, correlated to the latest `cause`.
- Carriers: bounded in-memory ring buffer, `window.__LANTOR_PERF__`, lightweight Settings perf panel. **No DB writes.**

### Metrics must not create jank (review-gated)
- Backend payload serialize/bytes is **opt-in** (`LANTOR_PERF=1` / `LANTOR_PERF_PAYLOAD=1`) — default no longer double-serializes the bootstrap hot path.
- Frontend `<Profiler>` is **gated** (`?lantorPerf` / `localStorage lantor:perf=1` / dev build) — off means no measured path.
- Overlay reads from an independent subscription; closed → no subscriber → doesn't touch the main render tree.

### Review status (Bugen)
Reviewed against the 5 acceptance criteria; both blocking items (default double-serialize, default Profiler overhead) fixed in `46154f0`. **Approve.**

Known open calibration detail (non-blocking, follow-up commit): T-segment isn't fully aligned across ends — web `roundtripMs` excludes `JSON.parse` (counted separately as `parseMs`) while Tauri `roundtripMs` includes IPC deserialization. Note this when comparing app vs web T directly.

### Verification
- `npm run build` ✅
- `cargo check` ✅
- `npm run lint:css-tokens` fails only on the pre-existing reference-chip/composer raw-color baseline, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
