### PR TITLE
perf(activity): reduce message rerenders on activity flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,26 +62,25 @@ desktop window:
 npm run web:dev
 ```
 
-This builds the web bundle, starts the same local SQLite database, supervisor,
-reminder worker, event pruning, and web server, then serves Lantor at
-`http://127.0.0.1:8787/` by default. Set `LANTOR_WEB_BIND` to choose another
-bind address, for example `LANTOR_WEB_BIND=127.0.0.1:8787 npm run web:dev` for
-loopback-only access.
+This starts the same local SQLite database, supervisor, reminder worker, event
+pruning, and web server, then starts the Vite dev server with hot reload. Open
+`http://127.0.0.1:5173/` for the web UI; Vite proxies `/api` and `/api/events`
+to the local backend. Frontend changes hot-update in the browser, and
+`src-tauri` backend changes restart the web backend automatically.
 
-For frontend hot reload in browser-only development, run two terminals:
+To verify the built/static web path instead of the hot-reload dev path:
 
 ```bash
-# Terminal 1: local backend and API/SSE server, no desktop window
-npm run web:backend
-
-# Terminal 2: Vite frontend with /api proxied to the backend above
-npm run dev
+npm run web:serve
 ```
 
-Open `http://127.0.0.1:5173/` for the hot-reload UI. The Vite dev server
-proxies `/api` and `/api/events` to `http://127.0.0.1:8787/` by default. If
-the backend uses a non-default bind, set `LANTOR_WEB_BIND` in both terminals
-or set `LANTOR_WEB_PROXY_TARGET=http://127.0.0.1:<port>` for the Vite terminal.
+`web:serve` builds the web bundle and serves Lantor from the backend at
+`http://127.0.0.1:8787/` by default, without hot reload. Set `LANTOR_WEB_BIND`
+to choose another bind address, for example
+`LANTOR_WEB_BIND=127.0.0.1:8787 npm run web:serve` for loopback-only access.
+If the backend uses a non-default bind during development, set
+`LANTOR_WEB_BIND` and `LANTOR_WEB_PROXY_TARGET=http://127.0.0.1:<port>` so Vite
+proxies to the correct backend.
 
 Do not run `npm run tauri:dev` and `npm run web:dev` / `npm run web:backend`
 at the same time against the same SQLite database. Use one backend-owning
@@ -171,10 +170,9 @@ shares the same SQLite database and attachment store. There is still no
 separate hosted Lantor service in the path.
 
 If you do not need the desktop window, run `npm run web:dev` instead. Web-only
-mode starts the same local backend and serves the same browser UI, but skips
-the Tauri window and desktop-only event listener. Browser refreshes continue
-to use the web SSE stream. During frontend development, use `npm run
-web:backend` plus `npm run dev` for Vite hot reload.
+mode starts the same local backend and serves the same browser UI through Vite
+hot reload, but skips the Tauri window and desktop-only event listener. Browser
+refreshes continue to use the web SSE stream.
 
 ## Mobile
 
@@ -251,9 +249,10 @@ npm run build                                              # frontend bundle
 cargo check --manifest-path src-tauri/Cargo.toml           # rust typecheck
 cargo test  --manifest-path src-tauri/Cargo.toml --no-run  # compile tests
 npm run tauri:dev                                          # desktop app
-npm run web:dev                                            # built web UI + backend, no desktop window
-npm run web:backend                                        # backend only for Vite hot reload
-npm run dev                                                # Vite frontend; proxies /api to web backend
+npm run web:dev                                            # web UI + backend with hot reload
+npm run web:serve                                          # built web UI + backend, no hot reload
+npm run web:backend                                        # backend only
+npm run dev                                                # Vite frontend only; proxies /api to web backend
 ```
 
 Composer input latency benchmarks live in

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "vite --host 127.0.0.1",
     "web:backend": "cargo run --manifest-path src-tauri/Cargo.toml -- --web-only",
-    "web:dev": "npm run build && npm run web:backend",
+    "web:serve": "npm run build && npm run web:backend",
+    "web:dev": "node scripts/web-dev.mjs",
     "build": "tsc && vite build",
     "build:bench": "tsc && vite build --mode bench",
     "bench:composer": "node bench/composer-input-latency.mjs",

--- a/scripts/web-dev.mjs
+++ b/scripts/web-dev.mjs
@@ -1,0 +1,101 @@
+import { spawn } from "node:child_process";
+import { watch } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const restartDelayMs = 250;
+const vitePort = process.env.LANTOR_WEB_VITE_PORT || "5173";
+
+let backend = null;
+let vite = null;
+let shuttingDown = false;
+let restartTimer = null;
+let backendRestarting = false;
+
+function spawnProcess(name, command, args) {
+  const child = spawn(command, args, {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: "inherit",
+  });
+
+  child.on("exit", (code, signal) => {
+    if (!shuttingDown) {
+      console.log(`[web:dev] ${name} exited with ${signal ?? code}`);
+    }
+  });
+
+  return child;
+}
+
+function startBackend() {
+  backend = spawnProcess("backend", "cargo", [
+    "run",
+    "--manifest-path",
+    "src-tauri/Cargo.toml",
+    "--",
+    "--web-only",
+  ]);
+}
+
+function startVite() {
+  vite = spawnProcess("vite", "npm", ["run", "dev", "--", "--host", "127.0.0.1", "--port", vitePort]);
+}
+
+function stopProcess(child) {
+  if (!child || child.killed) return;
+  child.kill("SIGTERM");
+}
+
+function restartBackend() {
+  if (shuttingDown) return;
+  clearTimeout(restartTimer);
+  restartTimer = setTimeout(() => {
+    if (backendRestarting) return;
+    backendRestarting = true;
+    console.log("[web:dev] restarting backend after src-tauri change");
+    const currentBackend = backend;
+    if (!currentBackend || currentBackend.killed) {
+      startBackend();
+      backendRestarting = false;
+      return;
+    }
+    currentBackend.once("exit", () => {
+      if (!shuttingDown) startBackend();
+      backendRestarting = false;
+    });
+    stopProcess(currentBackend);
+  }, restartDelayMs);
+}
+
+function shutdown(signal) {
+  shuttingDown = true;
+  clearTimeout(restartTimer);
+  stopProcess(vite);
+  stopProcess(backend);
+  process.once("exit", () => {});
+  setTimeout(() => process.exit(signal === "SIGINT" ? 130 : 143), 100);
+}
+
+startBackend();
+startVite();
+
+const watchedPaths = [
+  join(repoRoot, "src-tauri", "src"),
+  join(repoRoot, "src-tauri", "Cargo.toml"),
+  join(repoRoot, "src-tauri", "tauri.conf.json"),
+];
+
+const watchers = watchedPaths.flatMap((path) => {
+  try {
+    return [watch(path, { recursive: true }, restartBackend)];
+  } catch (err) {
+    console.warn(`[web:dev] unable to watch ${path}: ${err.message}`);
+    return [];
+  }
+});
+
+process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("exit", () => watchers.forEach((watcher) => watcher.close()));

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -15,7 +15,7 @@ import {
   Trash2,
   UserPlus,
 } from "lucide-react";
-import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type FocusEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type TextareaHTMLAttributes, type WheelEvent as ReactWheelEvent } from "react";
+import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type FocusEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type TextareaHTMLAttributes, type WheelEvent as ReactWheelEvent } from "react";
 import { useAutoGrowTextarea } from "../hooks/useAutoGrowTextarea";
 import { useMentionPicker } from "../hooks/useMentionPicker";
 import { useMobileViewport } from "../hooks/useMobileViewport";
@@ -95,6 +95,38 @@ type ConversationProps = {
   showImageThumbnails: boolean;
   onToggleMessageSaved: (message: Message, saved: boolean) => void;
 };
+
+type ConversationMessageBodyProps = {
+  message: Message;
+  messages: Message[];
+  channels: Channel[];
+  onReferenceOpen: (sourceMessage: Message, reference: ResolvedMessageReference) => void;
+  onLocalAgentLink: (handle: string) => void;
+};
+
+function ConversationMessageBody({
+  message,
+  messages,
+  channels,
+  onReferenceOpen,
+  onLocalAgentLink,
+}: ConversationMessageBodyProps) {
+  const handleOpenReference = useCallback((reference: ResolvedMessageReference) => {
+    onReferenceOpen(message, reference);
+  }, [message, onReferenceOpen]);
+
+  if (!message.body.trim()) return null;
+  return (
+    <MessageMarkdown
+      body={message.body}
+      messages={messages}
+      channels={channels}
+      onOpenReference={handleOpenReference}
+      onLocalAgentLink={onLocalAgentLink}
+      scrollKey={`message:${message.id}`}
+    />
+  );
+}
 
 type MessageMenuState = {
   x: number;
@@ -283,10 +315,10 @@ export function Conversation({
   const channelActionsRef = useRef<HTMLDivElement | null>(null);
   const isDm = channel?.kind === "dm";
   const dmAgent = isDm ? agents.find((agent) => agent.id === channel?.dm_agent_id) ?? null : null;
-  function openLinkedAgentDetail(handle: string) {
+  const openLinkedAgentDetail = useCallback((handle: string) => {
     const agent = agents.find((candidate) => candidate.handle.toLowerCase() === handle.toLowerCase());
     if (agent) openAgentDetail(agent);
-  }
+  }, [agents, openAgentDetail]);
   const activeReplyProgressByRoot = useMemo<Record<string, ReturnType<typeof activeProgressByAgent>>>(() => {
     if (!channel) return {};
     return Object.fromEntries(
@@ -383,25 +415,23 @@ export function Conversation({
     ));
   }
 
-  function handleReferenceOpen(sourceMessage: Message, reference: ResolvedMessageReference) {
+  const handleReferenceOpen = useCallback((sourceMessage: Message, reference: ResolvedMessageReference) => {
     if (reference.kind === "thread") {
       onReferenceThreadJump(sourceMessage.id, reference.id);
       return;
     }
     onReferenceMessageJump(sourceMessage.id, reference.id);
     targetRootMessageIntoView(reference.id);
-  }
+  }, [onReferenceMessageJump, onReferenceThreadJump]);
 
   function renderMessageBody(message: Message) {
-    if (!message.body.trim()) return null;
     return (
-      <MessageMarkdown
-        body={message.body}
+      <ConversationMessageBody
+        message={message}
         messages={messages}
         channels={channels}
-        onOpenReference={(reference) => handleReferenceOpen(message, reference)}
+        onReferenceOpen={handleReferenceOpen}
         onLocalAgentLink={openLinkedAgentDetail}
-        scrollKey={`message:${message.id}`}
       />
     );
   }

--- a/src/components/MessageMarkdown.tsx
+++ b/src/components/MessageMarkdown.tsx
@@ -2,6 +2,7 @@ import {
   Children,
   ReactNode,
   isValidElement,
+  memo,
   type MouseEvent,
   type PointerEvent,
   type UIEvent,
@@ -209,7 +210,7 @@ function MarkdownTableScroll({ children, scrollKey }: { children?: ReactNode; sc
   );
 }
 
-export function MessageMarkdown({
+export const MessageMarkdown = memo(function MessageMarkdown({
   body,
   onLocalAgentLink,
   messages,
@@ -270,4 +271,11 @@ export function MessageMarkdown({
       </ReactMarkdown>
     </div>
   );
-}
+}, (prev, next) => (
+  prev.body === next.body
+  && prev.messages === next.messages
+  && prev.channels === next.channels
+  && prev.onOpenReference === next.onOpenReference
+  && prev.onLocalAgentLink === next.onLocalAgentLink
+  && prev.scrollKey === next.scrollKey
+));

--- a/src/components/ThreadPanel.tsx
+++ b/src/components/ThreadPanel.tsx
@@ -1,5 +1,5 @@
 import { ArrowDown, ArrowLeft, Bookmark, CheckCircle2, Crosshair, FileImage, Hash, Maximize2, MessageSquare, Minimize2, Paperclip, Quote, RotateCcw, Send, X } from "lucide-react";
-import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type TextareaHTMLAttributes, type WheelEvent as ReactWheelEvent } from "react";
+import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type TextareaHTMLAttributes, type WheelEvent as ReactWheelEvent } from "react";
 import { useAutoGrowTextarea } from "../hooks/useAutoGrowTextarea";
 import { useMentionPicker } from "../hooks/useMentionPicker";
 import { useMobileViewport } from "../hooks/useMobileViewport";
@@ -116,6 +116,38 @@ type ThreadPanelProps = {
   onResizeStart: (event: ReactPointerEvent<HTMLButtonElement>) => void;
 };
 
+type ThreadMessageBodyProps = {
+  message: Message;
+  messages: Message[];
+  channels: Channel[];
+  onReferenceOpen: (sourceMessage: Message, reference: ResolvedMessageReference) => void;
+  onLocalAgentLink: (handle: string) => void;
+};
+
+function ThreadMessageBody({
+  message,
+  messages,
+  channels,
+  onReferenceOpen,
+  onLocalAgentLink,
+}: ThreadMessageBodyProps) {
+  const handleOpenReference = useCallback((reference: ResolvedMessageReference) => {
+    onReferenceOpen(message, reference);
+  }, [message, onReferenceOpen]);
+
+  if (!message.body.trim()) return null;
+  return (
+    <MessageMarkdown
+      body={message.body}
+      messages={messages}
+      channels={channels}
+      onOpenReference={handleOpenReference}
+      onLocalAgentLink={onLocalAgentLink}
+      scrollKey={`message:${message.id}`}
+    />
+  );
+}
+
 type MessageMenuState = {
   x: number;
   y: number;
@@ -218,10 +250,10 @@ export function ThreadPanel({
   const threadScrollMetricsRef = useRef({ scrollHeight: 0, scrollTop: 0, clientHeight: 0 });
   const threadScrollStateByThreadRef = useRef<Map<string, ThreadScrollState>>(new Map());
   const threadScrollAnchorRef = useRef<ThreadScrollAnchor | null>(null);
-  function openLinkedAgentDetail(handle: string) {
+  const openLinkedAgentDetail = useCallback((handle: string) => {
     const agent = agents.find((candidate) => candidate.handle.toLowerCase() === handle.toLowerCase());
     if (agent) openAgentDetail(agent);
-  }
+  }, [agents, openAgentDetail]);
   const isDm = channel?.kind === "dm";
   const dmAgent = isDm ? agents.find((agent) => agent.id === channel?.dm_agent_id) ?? null : null;
   const rootAgent = activeRoot ? agentForMessageSender(activeRoot, agents) : null;
@@ -279,7 +311,7 @@ export function ThreadPanel({
     ));
   }
 
-  function handleReferenceOpen(sourceMessage: Message, reference: ResolvedMessageReference) {
+  const handleReferenceOpen = useCallback((sourceMessage: Message, reference: ResolvedMessageReference) => {
     if (reference.kind === "thread") {
       onReferenceThreadJump(sourceMessage.id, reference.id);
       return;
@@ -288,18 +320,16 @@ export function ThreadPanel({
     if (!target) return;
     onReferenceMessageJump(sourceMessage.id, target.id);
     targetMessageIntoView(target.id);
-  }
+  }, [onReferenceMessageJump, onReferenceThreadJump, threadMessageById]);
 
   function renderMessageBody(message: Message) {
-    if (!message.body.trim()) return null;
     return (
-      <MessageMarkdown
-        body={message.body}
+      <ThreadMessageBody
+        message={message}
         messages={messages}
         channels={channels}
-        onOpenReference={(reference) => handleReferenceOpen(message, reference)}
+        onReferenceOpen={handleReferenceOpen}
         onLocalAgentLink={openLinkedAgentDetail}
-        scrollKey={`message:${message.id}`}
       />
     );
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3054,7 +3054,7 @@ function App() {
     }
   }
 
-  function pushReferenceMessageHistory(originMessageId: string, targetMessageId: string) {
+  const pushReferenceMessageHistory = useCallback((originMessageId: string, targetMessageId: string) => {
     if (isMobileViewport() || !appHistoryReadyRef.current) return;
     const existingState = window.history.state;
     if (!isAppHistoryState(existingState)) return;
@@ -3071,17 +3071,17 @@ function App() {
     historyFocusedMessageIdRef.current = targetMessageId;
     setAppHistoryPosition(targetState.index, targetState.index);
     lastAppHistoryKeyRef.current = appHistoryKey(targetState);
-  }
+  }, [activeChannelId, activeMobileModal, activeTab, activeThreadId, selectedAgentId, showMobileSidebar, showThread]);
 
-  function navigateToReferencedMessage(originMessageId: string, targetMessageId: string) {
+  const navigateToReferencedMessage = useCallback((originMessageId: string, targetMessageId: string) => {
     pushReferenceMessageHistory(originMessageId, targetMessageId);
     setFocusedMessageId(null);
     window.requestAnimationFrame(() => {
       setFocusedMessageId(targetMessageId);
     });
-  }
+  }, [pushReferenceMessageHistory]);
 
-  function navigateToReferencedThread(originMessageId: string, threadId: string) {
+  const navigateToReferencedThread = useCallback((originMessageId: string, threadId: string) => {
     // Record the chip's source message in the current history entry before we
     // switch threads, so Lantor's built-in back button returns to the message
     // that contained the chip (the thread switch itself pushes the target entry).
@@ -3097,7 +3097,11 @@ function App() {
       }
     }
     revealThread(threadId);
-  }
+  }, [activeChannelId, activeMobileModal, activeTab, activeThreadId, selectedAgentId, showMobileSidebar, showThread]);
+
+  const openConversationAgentDetail = useCallback((agent: Agent) => {
+    setSelectedAgentId(agent.id);
+  }, []);
 
   function openMobileSidebarFromContent() {
     setMobileSidebarFocus("home");
@@ -4180,7 +4184,7 @@ function App() {
           attachments: current.attachments.filter((item) => item.id !== id),
         }))}
         sendRootMessage={sendRootMessage}
-        openAgentDetail={(agent) => setSelectedAgentId(agent.id)}
+        openAgentDetail={openConversationAgentDetail}
         openArtifact={openArtifact}
         openWorkItem={openWorkItem}
         onReferenceMessageJump={navigateToReferencedMessage}
@@ -4244,7 +4248,7 @@ function App() {
             attachments: current.attachments.filter((item) => item.id !== id),
           }))}
           sendReply={sendReply}
-          openAgentDetail={(agent) => setSelectedAgentId(agent.id)}
+          openAgentDetail={openConversationAgentDetail}
           openArtifact={openArtifact}
           openWorkItem={openWorkItem}
           onReferenceMessageJump={navigateToReferencedMessage}


### PR DESCRIPTION
## Summary
- memoize rendered message markdown so activity-only parent updates can bail out
- stabilize reference jump and local agent-link callbacks passed through Conversation and ThreadPanel
- keep the PR scoped to activity-flush render pressure; bootstrap loading limits remain a separate follow-up

## Validation
- npm run build

## Review notes
This targets `cause=activity-flush` R/longtask pressure from callback churn. After enabling `?lantorPerf`, compare activity-flush samples before/after for React commit duration and longtask count.