### PR TITLE
fix(sidebar): scroll the whole left rail together

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -854,6 +854,10 @@ button,
   position: relative;
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
   border-right: 1px solid var(--line);
   background: var(--sidebar);
   box-shadow: var(--surface-sidebar-edge);
@@ -910,13 +914,10 @@ button,
 
 .sidebar-sections {
   display: flex;
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   min-height: 0;
   flex-direction: column;
-  overflow-x: hidden;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  scrollbar-gutter: stable;
+  overflow: visible;
 }
 
 .workspace {


### PR DESCRIPTION
## What

Make the entire left sidebar a single scroll region instead of pinning the `Channels` header.

Moves the scroll container from `.sidebar-sections` up to `.sidebar`, so **Search / Activity / Saved / Channels / channel list / DMs / Agents** all scroll together. The earlier sticky-header approach is dropped.

## Why

Original request was to pin the `Channels` header; Martin then reversed direction — nothing should be pinned, the whole sidebar should scroll as one.

## Changes

- `src/styles.css`:
  - `.sidebar`: add `overflow-y: auto` + `overflow-x: hidden` + `overscroll-behavior: contain` + `scrollbar-gutter: stable`.
  - `.sidebar-sections`: `flex: 1 1 auto → 0 0 auto`, remove its own overflow/scroll, set `overflow: visible`.

## Verification

- `npm run build` passes
- `npm run lint:css-tokens` passes
- Local preview + Playwright confirm top region and section titles scroll together with the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)