### PR TITLE
Add Linux service and web startup readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,16 @@
 # Lantor creates this SQLite database automatically on first start.
 # Default on macOS: sqlite://~/Library/Application Support/Lantor/lantor.sqlite
 # Default on Linux: sqlite://~/.local/share/lantor/lantor.sqlite
+# Linux keeps using ~/Library/Application Support/Lantor/lantor.sqlite when
+# that legacy main-branch database already exists.
 # LANTOR_DATABASE_URL=sqlite://~/Library/Application Support/Lantor/lantor.sqlite
 # `DATABASE_URL` is honored as a fallback only when it is also a sqlite: URL.
 
 # Override where copied message attachments are stored.
 # Default on macOS: ~/Library/Application Support/Lantor/attachments
 # Default on Linux: ~/.local/share/lantor/attachments
+# Linux keeps using ~/Library/Application Support/Lantor/attachments when that
+# legacy attachment directory already exists.
 # LANTOR_ATTACHMENT_DIR=/Users/you/Library/Application Support/Lantor/attachments
 
 # Browser/Tailscale access defaults to 0.0.0.0:8787. Override to 127.0.0.1:8787

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,12 @@
 # Lantor creates this SQLite database automatically on first start.
-# Default: sqlite://~/Library/Application Support/Lantor/lantor.sqlite
+# Default on macOS: sqlite://~/Library/Application Support/Lantor/lantor.sqlite
+# Default on Linux: sqlite://~/.local/share/lantor/lantor.sqlite
 # LANTOR_DATABASE_URL=sqlite://~/Library/Application Support/Lantor/lantor.sqlite
 # `DATABASE_URL` is honored as a fallback only when it is also a sqlite: URL.
 
 # Override where copied message attachments are stored.
-# Default: ~/Library/Application Support/Lantor/attachments
+# Default on macOS: ~/Library/Application Support/Lantor/attachments
+# Default on Linux: ~/.local/share/lantor/attachments
 # LANTOR_ATTACHMENT_DIR=/Users/you/Library/Application Support/Lantor/attachments
 
 # Browser/Tailscale access defaults to 0.0.0.0:8787. Override to 127.0.0.1:8787

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
             libgtk-3-dev \
             libwebkit2gtk-4.1-dev \
             libayatana-appindicator3-dev \
+            libfuse2 \
             librsvg2-dev \
             patchelf \
             pkg-config
@@ -55,3 +56,6 @@ jobs:
 
       - name: Test Tauri backend
         run: cargo test --manifest-path src-tauri/Cargo.toml
+
+      - name: Build Linux AppImage
+        run: npm run tauri:build -- --bundles appimage

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ reminders, artifacts, and attachments so they can coordinate real coding work.
 The important part is where it runs. Lantor has no hosted control plane, no
 cloud workspace, and no extra backend that your project data has to pass
 through. The desktop app, supervisor, SQLite database, attachments, chat
-history, agent profiles, and agent workspaces all live on your Mac. Your
+history, agent profiles, and agent workspaces all live on your machine. Your
 context is local SQLite and files you can inspect, back up, or extract.
 
 Use it when terminal tabs stop being enough: keep multiple agents warm,
@@ -35,7 +35,10 @@ for intent, threads for durable context, and tasks for execution.
 
 ## Quickstart
 
-Lantor is a native macOS desktop app. Install Node 20+ and Rust first:
+Lantor is a native desktop app for macOS and Linux. Install Node 20+ and Rust
+first.
+
+On macOS:
 
 ```bash
 brew install node
@@ -46,6 +49,16 @@ source "$HOME/.cargo/env"
 If Rust or Tauri reports missing Apple compiler or linker tools, run
 `xcode-select --install` and launch again.
 
+On Debian/Ubuntu Linux:
+
+```bash
+sudo apt update
+sudo apt install -y nodejs npm curl build-essential pkg-config libssl-dev \
+  libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source "$HOME/.cargo/env"
+```
+
 Clone and launch the app:
 
 ```bash
@@ -55,7 +68,7 @@ npm install
 npm run tauri:dev
 ```
 
-To run only the browser UI and local backend, without opening the macOS
+To run only the browser UI and local backend, without opening the native
 desktop window:
 
 ```bash
@@ -110,14 +123,15 @@ When the desktop app opens, add your first agent:
    back into the right thread.
 
 SQLite state lives at
-`~/Library/Application Support/Lantor/lantor.sqlite`, attachments live under
-`~/Library/Application Support/Lantor/attachments/`, and migrations run
+`~/Library/Application Support/Lantor/lantor.sqlite` on macOS or
+`~/.local/share/lantor/lantor.sqlite` on Linux. Attachments live under the
+same platform data directory in `attachments/`, and migrations run
 automatically on every start.
 
 ## Why Lantor
 
 - **Local First, privacy.** App, supervisor, SQLite state, attachments, and
-  agent workspaces all run on your Mac.
+  agent workspaces all run on your machine.
 - **You own your context.** Chat history, tasks, artifacts, attachments,
   agent profiles, and each agent's `MEMORY.md` / `notes/` stay on disk.
 - **One human, many agents.** Channels, DMs, threads, tasks, and handoffs are
@@ -133,12 +147,12 @@ automatically on every start.
   process lifecycle, run logs, and structured event ingestion.
 - **Agent collaboration** — task claiming, task/thread handoff, progress
   activity, generated artifacts, and per-agent local memory.
-- **Desktop + mobile access** — native macOS app plus a trusted-network web UI
-  served by the same local process and SQLite database.
+- **Desktop + mobile access** — native macOS/Linux app plus a trusted-network
+  web UI served by the same local process and SQLite database.
 
 ## How it works
 
-Lantor is a native macOS app with a local supervisor. The desktop process
+Lantor is a native desktop app with a local supervisor. The desktop process
 starts the same binary in supervisor mode; that supervisor owns agent process
 launch, stop commands, queued work scheduling, run logs, and structured event
 ingestion.
@@ -161,10 +175,12 @@ Storage stays local:
 
 - **SQLite** — workspace state, messages, tasks, reminders, agents, metadata,
   activity, and usage records.
-- **Attachments** — `~/Library/Application Support/Lantor/attachments/`.
+- **Attachments** — `~/Library/Application Support/Lantor/attachments/` on
+  macOS or `~/.local/share/lantor/attachments/` on Linux.
 - **Agent workspaces** — `~/Library/Application Support/Lantor/agents/<handle>/`
-  by default (you can point each agent at any directory you like), including
-  that agent's `MEMORY.md`, `notes/`, and durable task files.
+  on macOS or `~/.local/share/lantor/agents/<handle>/` on Linux by default
+  (you can point each agent at any directory you like), including that agent's
+  `MEMORY.md`, `notes/`, and durable task files.
 
 The optional mobile web UI is served by the same local desktop process and
 shares the same SQLite database and attachment store. There is still no
@@ -201,9 +217,9 @@ over [Tailscale](https://tailscale.com/).
   />
 </p>
 
-1. Install Tailscale on your Mac and your phone, and sign both into the
+1. Install Tailscale on your Lantor host and your phone, and sign both into the
    same tailnet.
-2. Keep Lantor running on your Mac. The web UI is enabled by default on
+2. Keep Lantor running on the host. The web UI is enabled by default on
    `0.0.0.0:8787`.
 3. From your phone's browser, open:
 
@@ -226,7 +242,7 @@ Defaults work out of the box. The two settings most users care about:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `LANTOR_DATABASE_URL` | `sqlite://~/Library/Application Support/Lantor/lantor.sqlite` | SQLite database URL. |
+| `LANTOR_DATABASE_URL` | macOS: `sqlite://~/Library/Application Support/Lantor/lantor.sqlite`<br>Linux: `sqlite://~/.local/share/lantor/lantor.sqlite` | SQLite database URL. |
 | `LANTOR_WEB_BIND` | `0.0.0.0:8787` | Web UI bind. Use `127.0.0.1:8787` for loopback only, or `off` to disable. |
 
 Advanced options — attachment paths, web public URL, web bundle override,

--- a/README.md
+++ b/README.md
@@ -124,8 +124,10 @@ When the desktop app opens, add your first agent:
 
 SQLite state lives at
 `~/Library/Application Support/Lantor/lantor.sqlite` on macOS or
-`~/.local/share/lantor/lantor.sqlite` on Linux. Attachments live under the
-same platform data directory in `attachments/`, and migrations run
+`~/.local/share/lantor/lantor.sqlite` on Linux. Linux keeps using the legacy
+`~/Library/Application Support/Lantor/lantor.sqlite` path when that database
+already exists, so existing main-branch data remains visible. Attachments live
+under the same platform data directory in `attachments/`, and migrations run
 automatically on every start.
 
 ## Why Lantor
@@ -176,10 +178,12 @@ Storage stays local:
 - **SQLite** — workspace state, messages, tasks, reminders, agents, metadata,
   activity, and usage records.
 - **Attachments** — `~/Library/Application Support/Lantor/attachments/` on
-  macOS or `~/.local/share/lantor/attachments/` on Linux.
+  macOS or `~/.local/share/lantor/attachments/` on Linux. Linux keeps the
+  legacy Application Support attachment path when it already exists.
 - **Agent workspaces** — `~/Library/Application Support/Lantor/agents/<handle>/`
   on macOS or `~/.local/share/lantor/agents/<handle>/` on Linux by default
-  (you can point each agent at any directory you like), including that agent's
+  (or the active data directory when using a legacy Linux database). You can
+  point each agent at any directory you like, including that agent's
   `MEMORY.md`, `notes/`, and durable task files.
 
 The optional mobile web UI is served by the same local desktop process and
@@ -242,7 +246,7 @@ Defaults work out of the box. The two settings most users care about:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `LANTOR_DATABASE_URL` | macOS: `sqlite://~/Library/Application Support/Lantor/lantor.sqlite`<br>Linux: `sqlite://~/.local/share/lantor/lantor.sqlite` | SQLite database URL. |
+| `LANTOR_DATABASE_URL` | macOS: `sqlite://~/Library/Application Support/Lantor/lantor.sqlite`<br>Linux: `sqlite://~/.local/share/lantor/lantor.sqlite`, unless the legacy main-branch database already exists | SQLite database URL. |
 | `LANTOR_WEB_BIND` | `0.0.0.0:8787` | Web UI bind. Use `127.0.0.1:8787` for loopback only, or `off` to disable. |
 
 Advanced options — attachment paths, web public URL, web bundle override,

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -54,7 +54,8 @@ Inbox, workspace, and memory commands default to the current agent. Use
 ## Agent Memory
 
 Each agent has a persistent working directory. By default Lantor uses
-`~/Library/Application Support/Lantor/agents/<handle>/`, but the agent profile
+`~/Library/Application Support/Lantor/agents/<handle>/` on macOS and
+`~/.local/share/lantor/agents/<handle>/` on Linux, but the agent profile
 can point at any directory you prefer. On first launch Lantor seeds the
 directory with `MEMORY.md` and a `notes/` subdirectory.
 

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -55,7 +55,9 @@ Inbox, workspace, and memory commands default to the current agent. Use
 
 Each agent has a persistent working directory. By default Lantor uses
 `~/Library/Application Support/Lantor/agents/<handle>/` on macOS and
-`~/.local/share/lantor/agents/<handle>/` on Linux, but the agent profile
+`~/.local/share/lantor/agents/<handle>/` on Linux. If Linux is using an
+existing legacy main-branch database under `~/Library/Application Support`,
+new agent workspaces default under that same data directory. The agent profile
 can point at any directory you prefer. On first launch Lantor seeds the
 directory with `MEMORY.md` and a `notes/` subdirectory.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ also appear in [`.env.example`](../.env.example).
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `LANTOR_DATABASE_URL` | macOS: `sqlite://~/Library/Application Support/Lantor/lantor.sqlite`<br>Linux: `sqlite://~/.local/share/lantor/lantor.sqlite` | SQLite database URL used by both the desktop process and the web server. `DATABASE_URL` is honored as a fallback only when it is also a `sqlite:` URL. |
+| `LANTOR_DATABASE_URL` | macOS: `sqlite://~/Library/Application Support/Lantor/lantor.sqlite`<br>Linux: `sqlite://~/.local/share/lantor/lantor.sqlite`, unless the legacy main-branch database already exists | SQLite database URL used by both the desktop process and the web server. `DATABASE_URL` is honored as a fallback only when it is also a `sqlite:` URL. |
 | `LANTOR_WEB_BIND` | `0.0.0.0:8787` | Address the embedded web/SSE server binds to. Set to `127.0.0.1:8787` to stay loopback-only, or `off` / `none` to disable the browser UI entirely. |
 
 ## Web UI
@@ -22,7 +22,7 @@ also appear in [`.env.example`](../.env.example).
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `LANTOR_ATTACHMENT_DIR` | macOS: `~/Library/Application Support/Lantor/attachments`<br>Linux: `~/.local/share/lantor/attachments` | Disk location where Lantor copies inbound message attachments. Point this at an alternative volume if you want attachments stored elsewhere. |
+| `LANTOR_ATTACHMENT_DIR` | macOS: `~/Library/Application Support/Lantor/attachments`<br>Linux: `~/.local/share/lantor/attachments`, unless the legacy main-branch attachment directory already exists | Disk location where Lantor copies inbound message attachments. Point this at an alternative volume if you want attachments stored elsewhere. |
 
 ## Runtime tuning
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ also appear in [`.env.example`](../.env.example).
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `LANTOR_DATABASE_URL` | `sqlite://~/Library/Application Support/Lantor/lantor.sqlite` | SQLite database URL used by both the desktop process and the web server. `DATABASE_URL` is honored as a fallback only when it is also a `sqlite:` URL. |
+| `LANTOR_DATABASE_URL` | macOS: `sqlite://~/Library/Application Support/Lantor/lantor.sqlite`<br>Linux: `sqlite://~/.local/share/lantor/lantor.sqlite` | SQLite database URL used by both the desktop process and the web server. `DATABASE_URL` is honored as a fallback only when it is also a `sqlite:` URL. |
 | `LANTOR_WEB_BIND` | `0.0.0.0:8787` | Address the embedded web/SSE server binds to. Set to `127.0.0.1:8787` to stay loopback-only, or `off` / `none` to disable the browser UI entirely. |
 
 ## Web UI
@@ -22,7 +22,7 @@ also appear in [`.env.example`](../.env.example).
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `LANTOR_ATTACHMENT_DIR` | `~/Library/Application Support/Lantor/attachments` | Disk location where Lantor copies inbound message attachments. Point this at an alternative volume if you want attachments stored outside `~/Library`. |
+| `LANTOR_ATTACHMENT_DIR` | macOS: `~/Library/Application Support/Lantor/attachments`<br>Linux: `~/.local/share/lantor/attachments` | Disk location where Lantor copies inbound message attachments. Point this at an alternative volume if you want attachments stored elsewhere. |
 
 ## Runtime tuning
 

--- a/docs/web-access.md
+++ b/docs/web-access.md
@@ -37,7 +37,7 @@ the chat surface needs, including:
 - inbox dismissal and read state, channel read state
 - reminders (completing) and tasks (status, title, claim)
 - cancelling and retrying agent work
-- installing and uninstalling the supervisor background service
+- installing and uninstalling the web background service
 - opening agent DMs
 - reading artifacts and attachment preview
 - agent workspace listing and file preview
@@ -46,10 +46,12 @@ the chat surface needs, including:
 Live refresh is delivered over an SSE stream at `/api/events`. Desktop Tauri
 still uses native IPC for the same operations.
 
-## Supervisor Service
+## Web Background Service
 
-The Runtime panel can install a user background service. On macOS this is a
-LaunchAgent at:
+The Runtime panel can install a background service that runs Lantor in
+`--web-only` mode. That starts the browser UI and shared background workers,
+including the local supervisor, without opening the desktop window. On macOS
+this is a LaunchAgent at:
 
 ```text
 ~/Library/LaunchAgents/local.lantor.supervisor.plist
@@ -61,6 +63,11 @@ On Linux this is a systemd user unit at:
 ~/.config/systemd/user/local.lantor.supervisor.service
 ```
 
-That lets macOS keep the `--supervisor` process alive via `launchctl`, and
-Linux keep it alive via `systemctl --user`. Uninstall removes the service file
-and unloads the service.
+That lets macOS keep the web service alive via `launchctl`, and Linux keep it
+alive via `systemctl --user` or, on WSL when the user bus is unavailable, a
+system-level `systemctl` unit. Uninstall removes the service file and unloads
+the service.
+
+On WSL, the systemd service starts when that WSL distro starts. To make it run
+after Windows login without manually opening WSL first, add a Windows Task
+Scheduler entry that starts the distro, for example with `wsl.exe -d <distro>`.

--- a/docs/web-access.md
+++ b/docs/web-access.md
@@ -9,13 +9,13 @@ npm run build
 npm run tauri:dev
 ```
 
-Then open the Mac's Tailscale address from the other device:
+Then open the host machine's Tailscale address from the other device:
 
 ```text
 http://<mac-tailscale-ip>:8787/
 ```
 
-Loopback requests from the same Mac can use:
+Loopback requests from the same machine can use:
 
 ```text
 http://127.0.0.1:8787/
@@ -37,7 +37,7 @@ the chat surface needs, including:
 - inbox dismissal and read state, channel read state
 - reminders (completing) and tasks (status, title, claim)
 - cancelling and retrying agent work
-- installing and uninstalling the supervisor LaunchAgent
+- installing and uninstalling the supervisor background service
 - opening agent DMs
 - reading artifacts and attachment preview
 - agent workspace listing and file preview
@@ -46,13 +46,21 @@ the chat surface needs, including:
 Live refresh is delivered over an SSE stream at `/api/events`. Desktop Tauri
 still uses native IPC for the same operations.
 
-## Supervisor LaunchAgent
+## Supervisor Service
 
-The Runtime panel can install a user LaunchAgent at:
+The Runtime panel can install a user background service. On macOS this is a
+LaunchAgent at:
 
 ```text
 ~/Library/LaunchAgents/local.lantor.supervisor.plist
 ```
 
-That lets macOS keep the `--supervisor` process alive via `launchctl`.
-Uninstall removes the plist and unloads the service.
+On Linux this is a systemd user unit at:
+
+```text
+~/.config/systemd/user/local.lantor.supervisor.service
+```
+
+That lets macOS keep the `--supervisor` process alive via `launchctl`, and
+Linux keep it alive via `systemctl --user`. Uninstall removes the service file
+and unloads the service.

--- a/src-tauri/gen/schemas/linux-schema.json
+++ b/src-tauri/gen/schemas/linux-schema.json
@@ -1,0 +1,2292 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CapabilityFile",
+  "description": "Capability formats accepted in a capability file.",
+  "anyOf": [
+    {
+      "description": "A single capability.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Capability"
+        }
+      ]
+    },
+    {
+      "description": "A list of capabilities.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Capability"
+      }
+    },
+    {
+      "description": "A list of capabilities.",
+      "type": "object",
+      "required": [
+        "capabilities"
+      ],
+      "properties": {
+        "capabilities": {
+          "description": "The list of capabilities.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Capability"
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "Capability": {
+      "description": "A grouping and boundary mechanism developers can use to isolate access to the IPC layer.\n\nIt controls application windows' and webviews' fine grained access to the Tauri core, application, or plugin commands. If a webview or its window is not matching any capability then it has no access to the IPC layer at all.\n\nThis can be done to create groups of windows, based on their required system access, which can reduce impact of frontend vulnerabilities in less privileged windows. Windows can be added to a capability by exact name (e.g. `main-window`) or glob patterns like `*` or `admin-*`. A Window can have none, one, or multiple associated capabilities.\n\n## Example\n\n```json { \"identifier\": \"main-user-files-write\", \"description\": \"This capability allows the `main` window on macOS and Windows access to `filesystem` write related commands and `dialog` commands to enable programmatic access to files selected by the user.\", \"windows\": [ \"main\" ], \"permissions\": [ \"core:default\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] }, ], \"platforms\": [\"macOS\",\"windows\"] } ```",
+      "type": "object",
+      "required": [
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "Identifier of the capability.\n\n## Example\n\n`main-user-files-write`",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of what the capability is intended to allow on associated windows.\n\nIt should contain a description of what the grouped permissions should allow.\n\n## Example\n\nThis capability allows the `main` window access to `filesystem` write related commands and `dialog` commands to enable programmatic access to files selected by the user.",
+          "default": "",
+          "type": "string"
+        },
+        "remote": {
+          "description": "Configure remote URLs that can use the capability permissions.\n\nThis setting is optional and defaults to not being set, as our default use case is that the content is served from our local application.\n\n:::caution Make sure you understand the security implications of providing remote sources with local system access. :::\n\n## Example\n\n```json { \"urls\": [\"https://*.mydomain.dev\"] } ```",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CapabilityRemote"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "local": {
+          "description": "Whether this capability is enabled for local app URLs or not. Defaults to `true`.",
+          "default": true,
+          "type": "boolean"
+        },
+        "windows": {
+          "description": "List of windows that are affected by this capability. Can be a glob pattern.\n\nIf a window label matches any of the patterns in this list, the capability will be enabled on all the webviews of that window, regardless of the value of [`Self::webviews`].\n\nOn multiwebview windows, prefer specifying [`Self::webviews`] and omitting [`Self::windows`] for a fine grained access control.\n\n## Example\n\n`[\"main\"]`",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "webviews": {
+          "description": "List of webviews that are affected by this capability. Can be a glob pattern.\n\nThe capability will be enabled on all the webviews whose label matches any of the patterns in this list, regardless of whether the webview's window label matches a pattern in [`Self::windows`].\n\n## Example\n\n`[\"sub-webview-one\", \"sub-webview-two\"]`",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permissions": {
+          "description": "List of permissions attached to this capability.\n\nMust include the plugin name as prefix in the form of `${plugin-name}:${permission-name}`. For commands directly implemented in the application itself only `${permission-name}` is required.\n\n## Example\n\n```json [ \"core:default\", \"shell:allow-open\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] } ] ```",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionEntry"
+          },
+          "uniqueItems": true
+        },
+        "platforms": {
+          "description": "Limit which target platforms this capability applies to.\n\nBy default all platforms are targeted.\n\n## Example\n\n`[\"macOS\",\"windows\"]`",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "CapabilityRemote": {
+      "description": "Configuration for remote URLs that are associated with the capability.",
+      "type": "object",
+      "required": [
+        "urls"
+      ],
+      "properties": {
+        "urls": {
+          "description": "Remote domains this capability refers to using the [URLPattern standard](https://urlpattern.spec.whatwg.org/).\n\n## Examples\n\n- \"https://*.mydomain.dev\": allows subdomains of mydomain.dev - \"https://mydomain.dev/api/*\": allows any subpath of mydomain.dev/api",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionEntry": {
+      "description": "An entry for a permission value in a [`Capability`] can be either a raw permission [`Identifier`] or an object that references a permission and extends its scope.",
+      "anyOf": [
+        {
+          "description": "Reference a permission or permission set by identifier.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Identifier"
+            }
+          ]
+        },
+        {
+          "description": "Reference a permission or permission set by identifier and extends its scope.",
+          "type": "object",
+          "allOf": [
+            {
+              "properties": {
+                "identifier": {
+                  "description": "Identifier of the permission or permission set.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Identifier"
+                    }
+                  ]
+                },
+                "allow": {
+                  "description": "Data that defines what is allowed by the scope.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "$ref": "#/definitions/Value"
+                  }
+                },
+                "deny": {
+                  "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "$ref": "#/definitions/Value"
+                  }
+                }
+              }
+            }
+          ],
+          "required": [
+            "identifier"
+          ]
+        }
+      ]
+    },
+    "Identifier": {
+      "description": "Permission identifier",
+      "oneOf": [
+        {
+          "description": "Default core plugins set.\n#### This default permission set includes:\n\n- `core:path:default`\n- `core:event:default`\n- `core:window:default`\n- `core:webview:default`\n- `core:app:default`\n- `core:image:default`\n- `core:resources:default`\n- `core:menu:default`\n- `core:tray:default`",
+          "type": "string",
+          "const": "core:default",
+          "markdownDescription": "Default core plugins set.\n#### This default permission set includes:\n\n- `core:path:default`\n- `core:event:default`\n- `core:window:default`\n- `core:webview:default`\n- `core:app:default`\n- `core:image:default`\n- `core:resources:default`\n- `core:menu:default`\n- `core:tray:default`"
+        },
+        {
+          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-supports-multiple-windows`",
+          "type": "string",
+          "const": "core:app:default",
+          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-supports-multiple-windows`"
+        },
+        {
+          "description": "Enables the app_hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-app-hide",
+          "markdownDescription": "Enables the app_hide command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the app_show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-app-show",
+          "markdownDescription": "Enables the app_show command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the bundle_type command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-bundle-type",
+          "markdownDescription": "Enables the bundle_type command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the default_window_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-default-window-icon",
+          "markdownDescription": "Enables the default_window_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the fetch_data_store_identifiers command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-fetch-data-store-identifiers",
+          "markdownDescription": "Enables the fetch_data_store_identifiers command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the identifier command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-identifier",
+          "markdownDescription": "Enables the identifier command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the name command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-name",
+          "markdownDescription": "Enables the name command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the register_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-register-listener",
+          "markdownDescription": "Enables the register_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_data_store command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-remove-data-store",
+          "markdownDescription": "Enables the remove_data_store command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-remove-listener",
+          "markdownDescription": "Enables the remove_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_app_theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-set-app-theme",
+          "markdownDescription": "Enables the set_app_theme command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_dock_visibility command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-set-dock-visibility",
+          "markdownDescription": "Enables the set_dock_visibility command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the supports_multiple_windows command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-supports-multiple-windows",
+          "markdownDescription": "Enables the supports_multiple_windows command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the tauri_version command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-tauri-version",
+          "markdownDescription": "Enables the tauri_version command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the version command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-version",
+          "markdownDescription": "Enables the version command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the app_hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-app-hide",
+          "markdownDescription": "Denies the app_hide command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the app_show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-app-show",
+          "markdownDescription": "Denies the app_show command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the bundle_type command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-bundle-type",
+          "markdownDescription": "Denies the bundle_type command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the default_window_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-default-window-icon",
+          "markdownDescription": "Denies the default_window_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the fetch_data_store_identifiers command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-fetch-data-store-identifiers",
+          "markdownDescription": "Denies the fetch_data_store_identifiers command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the identifier command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-identifier",
+          "markdownDescription": "Denies the identifier command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the name command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-name",
+          "markdownDescription": "Denies the name command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the register_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-register-listener",
+          "markdownDescription": "Denies the register_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_data_store command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-remove-data-store",
+          "markdownDescription": "Denies the remove_data_store command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-remove-listener",
+          "markdownDescription": "Denies the remove_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_app_theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-set-app-theme",
+          "markdownDescription": "Denies the set_app_theme command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_dock_visibility command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-set-dock-visibility",
+          "markdownDescription": "Denies the set_dock_visibility command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the supports_multiple_windows command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-supports-multiple-windows",
+          "markdownDescription": "Denies the supports_multiple_windows command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the tauri_version command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-tauri-version",
+          "markdownDescription": "Denies the tauri_version command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the version command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-version",
+          "markdownDescription": "Denies the version command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-listen`\n- `allow-unlisten`\n- `allow-emit`\n- `allow-emit-to`",
+          "type": "string",
+          "const": "core:event:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-listen`\n- `allow-unlisten`\n- `allow-emit`\n- `allow-emit-to`"
+        },
+        {
+          "description": "Enables the emit command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:allow-emit",
+          "markdownDescription": "Enables the emit command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the emit_to command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:allow-emit-to",
+          "markdownDescription": "Enables the emit_to command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the listen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:allow-listen",
+          "markdownDescription": "Enables the listen command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the unlisten command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:allow-unlisten",
+          "markdownDescription": "Enables the unlisten command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the emit command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:deny-emit",
+          "markdownDescription": "Denies the emit command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the emit_to command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:deny-emit-to",
+          "markdownDescription": "Denies the emit_to command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the listen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:deny-listen",
+          "markdownDescription": "Denies the listen command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the unlisten command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:event:deny-unlisten",
+          "markdownDescription": "Denies the unlisten command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-from-bytes`\n- `allow-from-path`\n- `allow-rgba`\n- `allow-size`",
+          "type": "string",
+          "const": "core:image:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-from-bytes`\n- `allow-from-path`\n- `allow-rgba`\n- `allow-size`"
+        },
+        {
+          "description": "Enables the from_bytes command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-from-bytes",
+          "markdownDescription": "Enables the from_bytes command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the from_path command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-from-path",
+          "markdownDescription": "Enables the from_path command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-new",
+          "markdownDescription": "Enables the new command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the rgba command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-rgba",
+          "markdownDescription": "Enables the rgba command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:allow-size",
+          "markdownDescription": "Enables the size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the from_bytes command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-from-bytes",
+          "markdownDescription": "Denies the from_bytes command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the from_path command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-from-path",
+          "markdownDescription": "Denies the from_path command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-new",
+          "markdownDescription": "Denies the new command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the rgba command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-rgba",
+          "markdownDescription": "Denies the rgba command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:image:deny-size",
+          "markdownDescription": "Denies the size command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-append`\n- `allow-prepend`\n- `allow-insert`\n- `allow-remove`\n- `allow-remove-at`\n- `allow-items`\n- `allow-get`\n- `allow-popup`\n- `allow-create-default`\n- `allow-set-as-app-menu`\n- `allow-set-as-window-menu`\n- `allow-text`\n- `allow-set-text`\n- `allow-is-enabled`\n- `allow-set-enabled`\n- `allow-set-accelerator`\n- `allow-set-as-windows-menu-for-nsapp`\n- `allow-set-as-help-menu-for-nsapp`\n- `allow-is-checked`\n- `allow-set-checked`\n- `allow-set-icon`",
+          "type": "string",
+          "const": "core:menu:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-append`\n- `allow-prepend`\n- `allow-insert`\n- `allow-remove`\n- `allow-remove-at`\n- `allow-items`\n- `allow-get`\n- `allow-popup`\n- `allow-create-default`\n- `allow-set-as-app-menu`\n- `allow-set-as-window-menu`\n- `allow-text`\n- `allow-set-text`\n- `allow-is-enabled`\n- `allow-set-enabled`\n- `allow-set-accelerator`\n- `allow-set-as-windows-menu-for-nsapp`\n- `allow-set-as-help-menu-for-nsapp`\n- `allow-is-checked`\n- `allow-set-checked`\n- `allow-set-icon`"
+        },
+        {
+          "description": "Enables the append command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-append",
+          "markdownDescription": "Enables the append command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the create_default command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-create-default",
+          "markdownDescription": "Enables the create_default command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-get",
+          "markdownDescription": "Enables the get command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the insert command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-insert",
+          "markdownDescription": "Enables the insert command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_checked command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-is-checked",
+          "markdownDescription": "Enables the is_checked command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-is-enabled",
+          "markdownDescription": "Enables the is_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the items command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-items",
+          "markdownDescription": "Enables the items command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-new",
+          "markdownDescription": "Enables the new command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the popup command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-popup",
+          "markdownDescription": "Enables the popup command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the prepend command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-prepend",
+          "markdownDescription": "Enables the prepend command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-remove",
+          "markdownDescription": "Enables the remove command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_at command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-remove-at",
+          "markdownDescription": "Enables the remove_at command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_accelerator command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-accelerator",
+          "markdownDescription": "Enables the set_accelerator command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_as_app_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-as-app-menu",
+          "markdownDescription": "Enables the set_as_app_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_as_help_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-as-help-menu-for-nsapp",
+          "markdownDescription": "Enables the set_as_help_menu_for_nsapp command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_as_window_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-as-window-menu",
+          "markdownDescription": "Enables the set_as_window_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_as_windows_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-as-windows-menu-for-nsapp",
+          "markdownDescription": "Enables the set_as_windows_menu_for_nsapp command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_checked command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-checked",
+          "markdownDescription": "Enables the set_checked command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-enabled",
+          "markdownDescription": "Enables the set_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-icon",
+          "markdownDescription": "Enables the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_text command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-set-text",
+          "markdownDescription": "Enables the set_text command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the text command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:allow-text",
+          "markdownDescription": "Enables the text command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the append command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-append",
+          "markdownDescription": "Denies the append command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create_default command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-create-default",
+          "markdownDescription": "Denies the create_default command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-get",
+          "markdownDescription": "Denies the get command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the insert command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-insert",
+          "markdownDescription": "Denies the insert command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_checked command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-is-checked",
+          "markdownDescription": "Denies the is_checked command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-is-enabled",
+          "markdownDescription": "Denies the is_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the items command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-items",
+          "markdownDescription": "Denies the items command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-new",
+          "markdownDescription": "Denies the new command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the popup command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-popup",
+          "markdownDescription": "Denies the popup command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the prepend command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-prepend",
+          "markdownDescription": "Denies the prepend command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-remove",
+          "markdownDescription": "Denies the remove command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_at command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-remove-at",
+          "markdownDescription": "Denies the remove_at command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_accelerator command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-accelerator",
+          "markdownDescription": "Denies the set_accelerator command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_as_app_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-as-app-menu",
+          "markdownDescription": "Denies the set_as_app_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_as_help_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-as-help-menu-for-nsapp",
+          "markdownDescription": "Denies the set_as_help_menu_for_nsapp command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_as_window_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-as-window-menu",
+          "markdownDescription": "Denies the set_as_window_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_as_windows_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-as-windows-menu-for-nsapp",
+          "markdownDescription": "Denies the set_as_windows_menu_for_nsapp command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_checked command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-checked",
+          "markdownDescription": "Denies the set_checked command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-enabled",
+          "markdownDescription": "Denies the set_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-icon",
+          "markdownDescription": "Denies the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_text command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-set-text",
+          "markdownDescription": "Denies the set_text command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the text command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:menu:deny-text",
+          "markdownDescription": "Denies the text command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-resolve-directory`\n- `allow-resolve`\n- `allow-normalize`\n- `allow-join`\n- `allow-dirname`\n- `allow-extname`\n- `allow-basename`\n- `allow-is-absolute`",
+          "type": "string",
+          "const": "core:path:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-resolve-directory`\n- `allow-resolve`\n- `allow-normalize`\n- `allow-join`\n- `allow-dirname`\n- `allow-extname`\n- `allow-basename`\n- `allow-is-absolute`"
+        },
+        {
+          "description": "Enables the basename command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-basename",
+          "markdownDescription": "Enables the basename command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the dirname command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-dirname",
+          "markdownDescription": "Enables the dirname command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the extname command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-extname",
+          "markdownDescription": "Enables the extname command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_absolute command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-is-absolute",
+          "markdownDescription": "Enables the is_absolute command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the join command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-join",
+          "markdownDescription": "Enables the join command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the normalize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-normalize",
+          "markdownDescription": "Enables the normalize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the resolve command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-resolve",
+          "markdownDescription": "Enables the resolve command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the resolve_directory command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:allow-resolve-directory",
+          "markdownDescription": "Enables the resolve_directory command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the basename command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-basename",
+          "markdownDescription": "Denies the basename command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the dirname command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-dirname",
+          "markdownDescription": "Denies the dirname command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the extname command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-extname",
+          "markdownDescription": "Denies the extname command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_absolute command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-is-absolute",
+          "markdownDescription": "Denies the is_absolute command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the join command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-join",
+          "markdownDescription": "Denies the join command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the normalize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-normalize",
+          "markdownDescription": "Denies the normalize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the resolve command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-resolve",
+          "markdownDescription": "Denies the resolve command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the resolve_directory command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:path:deny-resolve-directory",
+          "markdownDescription": "Denies the resolve_directory command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-close`",
+          "type": "string",
+          "const": "core:resources:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-close`"
+        },
+        {
+          "description": "Enables the close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:resources:allow-close",
+          "markdownDescription": "Enables the close command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:resources:deny-close",
+          "markdownDescription": "Denies the close command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-icon-with-as-template`\n- `allow-set-show-menu-on-left-click`",
+          "type": "string",
+          "const": "core:tray:default",
+          "markdownDescription": "Default permissions for the plugin, which enables all commands.\n#### This default permission set includes:\n\n- `allow-new`\n- `allow-get-by-id`\n- `allow-remove-by-id`\n- `allow-set-icon`\n- `allow-set-menu`\n- `allow-set-tooltip`\n- `allow-set-title`\n- `allow-set-visible`\n- `allow-set-temp-dir-path`\n- `allow-set-icon-as-template`\n- `allow-set-icon-with-as-template`\n- `allow-set-show-menu-on-left-click`"
+        },
+        {
+          "description": "Enables the get_by_id command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-get-by-id",
+          "markdownDescription": "Enables the get_by_id command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-new",
+          "markdownDescription": "Enables the new command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_by_id command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-remove-by-id",
+          "markdownDescription": "Enables the remove_by_id command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-icon",
+          "markdownDescription": "Enables the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_icon_as_template command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-icon-as-template",
+          "markdownDescription": "Enables the set_icon_as_template command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_icon_with_as_template command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-icon-with-as-template",
+          "markdownDescription": "Enables the set_icon_with_as_template command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-menu",
+          "markdownDescription": "Enables the set_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_show_menu_on_left_click command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-show-menu-on-left-click",
+          "markdownDescription": "Enables the set_show_menu_on_left_click command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_temp_dir_path command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-temp-dir-path",
+          "markdownDescription": "Enables the set_temp_dir_path command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-title",
+          "markdownDescription": "Enables the set_title command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_tooltip command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-tooltip",
+          "markdownDescription": "Enables the set_tooltip command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:allow-set-visible",
+          "markdownDescription": "Enables the set_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_by_id command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-get-by-id",
+          "markdownDescription": "Denies the get_by_id command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the new command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-new",
+          "markdownDescription": "Denies the new command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_by_id command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-remove-by-id",
+          "markdownDescription": "Denies the remove_by_id command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-icon",
+          "markdownDescription": "Denies the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_icon_as_template command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-icon-as-template",
+          "markdownDescription": "Denies the set_icon_as_template command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_icon_with_as_template command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-icon-with-as-template",
+          "markdownDescription": "Denies the set_icon_with_as_template command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_menu command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-menu",
+          "markdownDescription": "Denies the set_menu command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_show_menu_on_left_click command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-show-menu-on-left-click",
+          "markdownDescription": "Denies the set_show_menu_on_left_click command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_temp_dir_path command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-temp-dir-path",
+          "markdownDescription": "Denies the set_temp_dir_path command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-title",
+          "markdownDescription": "Denies the set_title command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_tooltip command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-tooltip",
+          "markdownDescription": "Denies the set_tooltip command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:tray:deny-set-visible",
+          "markdownDescription": "Denies the set_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-webviews`\n- `allow-webview-position`\n- `allow-webview-size`\n- `allow-internal-toggle-devtools`",
+          "type": "string",
+          "const": "core:webview:default",
+          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-webviews`\n- `allow-webview-position`\n- `allow-webview-size`\n- `allow-internal-toggle-devtools`"
+        },
+        {
+          "description": "Enables the clear_all_browsing_data command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-clear-all-browsing-data",
+          "markdownDescription": "Enables the clear_all_browsing_data command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the create_webview command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-create-webview",
+          "markdownDescription": "Enables the create_webview command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the create_webview_window command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-create-webview-window",
+          "markdownDescription": "Enables the create_webview_window command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_all_webviews command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-get-all-webviews",
+          "markdownDescription": "Enables the get_all_webviews command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the internal_toggle_devtools command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-internal-toggle-devtools",
+          "markdownDescription": "Enables the internal_toggle_devtools command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the print command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-print",
+          "markdownDescription": "Enables the print command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the reparent command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-reparent",
+          "markdownDescription": "Enables the reparent command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_auto_resize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-auto-resize",
+          "markdownDescription": "Enables the set_webview_auto_resize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_background_color command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-background-color",
+          "markdownDescription": "Enables the set_webview_background_color command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_focus command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-focus",
+          "markdownDescription": "Enables the set_webview_focus command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-position",
+          "markdownDescription": "Enables the set_webview_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-size",
+          "markdownDescription": "Enables the set_webview_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_webview_zoom command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-set-webview-zoom",
+          "markdownDescription": "Enables the set_webview_zoom command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-close",
+          "markdownDescription": "Enables the webview_close command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-hide",
+          "markdownDescription": "Enables the webview_hide command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-position",
+          "markdownDescription": "Enables the webview_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-show",
+          "markdownDescription": "Enables the webview_show command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:allow-webview-size",
+          "markdownDescription": "Enables the webview_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the clear_all_browsing_data command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-clear-all-browsing-data",
+          "markdownDescription": "Denies the clear_all_browsing_data command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create_webview command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-create-webview",
+          "markdownDescription": "Denies the create_webview command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create_webview_window command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-create-webview-window",
+          "markdownDescription": "Denies the create_webview_window command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_all_webviews command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-get-all-webviews",
+          "markdownDescription": "Denies the get_all_webviews command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the internal_toggle_devtools command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-internal-toggle-devtools",
+          "markdownDescription": "Denies the internal_toggle_devtools command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the print command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-print",
+          "markdownDescription": "Denies the print command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the reparent command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-reparent",
+          "markdownDescription": "Denies the reparent command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_auto_resize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-auto-resize",
+          "markdownDescription": "Denies the set_webview_auto_resize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_background_color command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-background-color",
+          "markdownDescription": "Denies the set_webview_background_color command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_focus command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-focus",
+          "markdownDescription": "Denies the set_webview_focus command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-position",
+          "markdownDescription": "Denies the set_webview_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-size",
+          "markdownDescription": "Denies the set_webview_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_webview_zoom command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-set-webview-zoom",
+          "markdownDescription": "Denies the set_webview_zoom command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-close",
+          "markdownDescription": "Denies the webview_close command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-hide",
+          "markdownDescription": "Denies the webview_hide command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-position",
+          "markdownDescription": "Denies the webview_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-show",
+          "markdownDescription": "Denies the webview_show command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:webview:deny-webview-size",
+          "markdownDescription": "Denies the webview_size command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-activity-name`\n- `allow-scene-identifier`\n- `allow-internal-toggle-maximize`",
+          "type": "string",
+          "const": "core:window:default",
+          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-get-all-windows`\n- `allow-scale-factor`\n- `allow-inner-position`\n- `allow-outer-position`\n- `allow-inner-size`\n- `allow-outer-size`\n- `allow-is-fullscreen`\n- `allow-is-minimized`\n- `allow-is-maximized`\n- `allow-is-focused`\n- `allow-is-decorated`\n- `allow-is-resizable`\n- `allow-is-maximizable`\n- `allow-is-minimizable`\n- `allow-is-closable`\n- `allow-is-visible`\n- `allow-is-enabled`\n- `allow-title`\n- `allow-current-monitor`\n- `allow-primary-monitor`\n- `allow-monitor-from-point`\n- `allow-available-monitors`\n- `allow-cursor-position`\n- `allow-theme`\n- `allow-is-always-on-top`\n- `allow-activity-name`\n- `allow-scene-identifier`\n- `allow-internal-toggle-maximize`"
+        },
+        {
+          "description": "Enables the activity_name command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-activity-name",
+          "markdownDescription": "Enables the activity_name command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the available_monitors command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-available-monitors",
+          "markdownDescription": "Enables the available_monitors command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the center command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-center",
+          "markdownDescription": "Enables the center command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-close",
+          "markdownDescription": "Enables the close command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the create command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-create",
+          "markdownDescription": "Enables the create command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the current_monitor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-current-monitor",
+          "markdownDescription": "Enables the current_monitor command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-cursor-position",
+          "markdownDescription": "Enables the cursor_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the destroy command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-destroy",
+          "markdownDescription": "Enables the destroy command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_all_windows command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-get-all-windows",
+          "markdownDescription": "Enables the get_all_windows command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-hide",
+          "markdownDescription": "Enables the hide command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the inner_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-inner-position",
+          "markdownDescription": "Enables the inner_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the inner_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-inner-size",
+          "markdownDescription": "Enables the inner_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the internal_toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-internal-toggle-maximize",
+          "markdownDescription": "Enables the internal_toggle_maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_always_on_top command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-always-on-top",
+          "markdownDescription": "Enables the is_always_on_top command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_closable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-closable",
+          "markdownDescription": "Enables the is_closable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_decorated command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-decorated",
+          "markdownDescription": "Enables the is_decorated command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-enabled",
+          "markdownDescription": "Enables the is_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_focused command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-focused",
+          "markdownDescription": "Enables the is_focused command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-fullscreen",
+          "markdownDescription": "Enables the is_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-maximizable",
+          "markdownDescription": "Enables the is_maximizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_maximized command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-maximized",
+          "markdownDescription": "Enables the is_maximized command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-minimizable",
+          "markdownDescription": "Enables the is_minimizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_minimized command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-minimized",
+          "markdownDescription": "Enables the is_minimized command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_resizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-resizable",
+          "markdownDescription": "Enables the is_resizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-is-visible",
+          "markdownDescription": "Enables the is_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-maximize",
+          "markdownDescription": "Enables the maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the minimize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-minimize",
+          "markdownDescription": "Enables the minimize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the monitor_from_point command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-monitor-from-point",
+          "markdownDescription": "Enables the monitor_from_point command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the outer_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-outer-position",
+          "markdownDescription": "Enables the outer_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the outer_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-outer-size",
+          "markdownDescription": "Enables the outer_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the primary_monitor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-primary-monitor",
+          "markdownDescription": "Enables the primary_monitor command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the request_user_attention command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-request-user-attention",
+          "markdownDescription": "Enables the request_user_attention command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the scale_factor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-scale-factor",
+          "markdownDescription": "Enables the scale_factor command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the scene_identifier command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-scene-identifier",
+          "markdownDescription": "Enables the scene_identifier command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_always_on_bottom command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-always-on-bottom",
+          "markdownDescription": "Enables the set_always_on_bottom command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_always_on_top command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-always-on-top",
+          "markdownDescription": "Enables the set_always_on_top command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_background_color command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-background-color",
+          "markdownDescription": "Enables the set_background_color command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_badge_count command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-badge-count",
+          "markdownDescription": "Enables the set_badge_count command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_badge_label command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-badge-label",
+          "markdownDescription": "Enables the set_badge_label command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_closable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-closable",
+          "markdownDescription": "Enables the set_closable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_content_protected command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-content-protected",
+          "markdownDescription": "Enables the set_content_protected command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_cursor_grab command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-cursor-grab",
+          "markdownDescription": "Enables the set_cursor_grab command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_cursor_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-cursor-icon",
+          "markdownDescription": "Enables the set_cursor_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-cursor-position",
+          "markdownDescription": "Enables the set_cursor_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_cursor_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-cursor-visible",
+          "markdownDescription": "Enables the set_cursor_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_decorations command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-decorations",
+          "markdownDescription": "Enables the set_decorations command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_effects command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-effects",
+          "markdownDescription": "Enables the set_effects command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-enabled",
+          "markdownDescription": "Enables the set_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_focus command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-focus",
+          "markdownDescription": "Enables the set_focus command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_focusable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-focusable",
+          "markdownDescription": "Enables the set_focusable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-fullscreen",
+          "markdownDescription": "Enables the set_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-icon",
+          "markdownDescription": "Enables the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_ignore_cursor_events command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-ignore-cursor-events",
+          "markdownDescription": "Enables the set_ignore_cursor_events command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_max_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-max-size",
+          "markdownDescription": "Enables the set_max_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-maximizable",
+          "markdownDescription": "Enables the set_maximizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_min_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-min-size",
+          "markdownDescription": "Enables the set_min_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-minimizable",
+          "markdownDescription": "Enables the set_minimizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_overlay_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-overlay-icon",
+          "markdownDescription": "Enables the set_overlay_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-position",
+          "markdownDescription": "Enables the set_position command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_progress_bar command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-progress-bar",
+          "markdownDescription": "Enables the set_progress_bar command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_resizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-resizable",
+          "markdownDescription": "Enables the set_resizable command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_shadow command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-shadow",
+          "markdownDescription": "Enables the set_shadow command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_simple_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-simple-fullscreen",
+          "markdownDescription": "Enables the set_simple_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-size",
+          "markdownDescription": "Enables the set_size command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_size_constraints command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-size-constraints",
+          "markdownDescription": "Enables the set_size_constraints command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_skip_taskbar command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-skip-taskbar",
+          "markdownDescription": "Enables the set_skip_taskbar command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-theme",
+          "markdownDescription": "Enables the set_theme command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-title",
+          "markdownDescription": "Enables the set_title command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_title_bar_style command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-title-bar-style",
+          "markdownDescription": "Enables the set_title_bar_style command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_visible_on_all_workspaces command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-set-visible-on-all-workspaces",
+          "markdownDescription": "Enables the set_visible_on_all_workspaces command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-show",
+          "markdownDescription": "Enables the show command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the start_dragging command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-start-dragging",
+          "markdownDescription": "Enables the start_dragging command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the start_resize_dragging command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-start-resize-dragging",
+          "markdownDescription": "Enables the start_resize_dragging command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-theme",
+          "markdownDescription": "Enables the theme command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-title",
+          "markdownDescription": "Enables the title command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-toggle-maximize",
+          "markdownDescription": "Enables the toggle_maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the unmaximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-unmaximize",
+          "markdownDescription": "Enables the unmaximize command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the unminimize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:allow-unminimize",
+          "markdownDescription": "Enables the unminimize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the activity_name command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-activity-name",
+          "markdownDescription": "Denies the activity_name command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the available_monitors command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-available-monitors",
+          "markdownDescription": "Denies the available_monitors command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the center command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-center",
+          "markdownDescription": "Denies the center command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the close command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-close",
+          "markdownDescription": "Denies the close command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-create",
+          "markdownDescription": "Denies the create command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the current_monitor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-current-monitor",
+          "markdownDescription": "Denies the current_monitor command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-cursor-position",
+          "markdownDescription": "Denies the cursor_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the destroy command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-destroy",
+          "markdownDescription": "Denies the destroy command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_all_windows command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-get-all-windows",
+          "markdownDescription": "Denies the get_all_windows command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-hide",
+          "markdownDescription": "Denies the hide command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the inner_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-inner-position",
+          "markdownDescription": "Denies the inner_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the inner_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-inner-size",
+          "markdownDescription": "Denies the inner_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the internal_toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-internal-toggle-maximize",
+          "markdownDescription": "Denies the internal_toggle_maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_always_on_top command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-always-on-top",
+          "markdownDescription": "Denies the is_always_on_top command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_closable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-closable",
+          "markdownDescription": "Denies the is_closable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_decorated command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-decorated",
+          "markdownDescription": "Denies the is_decorated command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-enabled",
+          "markdownDescription": "Denies the is_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_focused command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-focused",
+          "markdownDescription": "Denies the is_focused command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-fullscreen",
+          "markdownDescription": "Denies the is_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-maximizable",
+          "markdownDescription": "Denies the is_maximizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_maximized command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-maximized",
+          "markdownDescription": "Denies the is_maximized command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-minimizable",
+          "markdownDescription": "Denies the is_minimizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_minimized command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-minimized",
+          "markdownDescription": "Denies the is_minimized command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_resizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-resizable",
+          "markdownDescription": "Denies the is_resizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-is-visible",
+          "markdownDescription": "Denies the is_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-maximize",
+          "markdownDescription": "Denies the maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the minimize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-minimize",
+          "markdownDescription": "Denies the minimize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the monitor_from_point command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-monitor-from-point",
+          "markdownDescription": "Denies the monitor_from_point command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the outer_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-outer-position",
+          "markdownDescription": "Denies the outer_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the outer_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-outer-size",
+          "markdownDescription": "Denies the outer_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the primary_monitor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-primary-monitor",
+          "markdownDescription": "Denies the primary_monitor command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the request_user_attention command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-request-user-attention",
+          "markdownDescription": "Denies the request_user_attention command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the scale_factor command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-scale-factor",
+          "markdownDescription": "Denies the scale_factor command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the scene_identifier command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-scene-identifier",
+          "markdownDescription": "Denies the scene_identifier command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_always_on_bottom command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-always-on-bottom",
+          "markdownDescription": "Denies the set_always_on_bottom command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_always_on_top command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-always-on-top",
+          "markdownDescription": "Denies the set_always_on_top command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_background_color command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-background-color",
+          "markdownDescription": "Denies the set_background_color command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_badge_count command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-badge-count",
+          "markdownDescription": "Denies the set_badge_count command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_badge_label command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-badge-label",
+          "markdownDescription": "Denies the set_badge_label command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_closable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-closable",
+          "markdownDescription": "Denies the set_closable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_content_protected command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-content-protected",
+          "markdownDescription": "Denies the set_content_protected command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_cursor_grab command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-cursor-grab",
+          "markdownDescription": "Denies the set_cursor_grab command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_cursor_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-cursor-icon",
+          "markdownDescription": "Denies the set_cursor_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-cursor-position",
+          "markdownDescription": "Denies the set_cursor_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_cursor_visible command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-cursor-visible",
+          "markdownDescription": "Denies the set_cursor_visible command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_decorations command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-decorations",
+          "markdownDescription": "Denies the set_decorations command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_effects command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-effects",
+          "markdownDescription": "Denies the set_effects command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-enabled",
+          "markdownDescription": "Denies the set_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_focus command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-focus",
+          "markdownDescription": "Denies the set_focus command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_focusable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-focusable",
+          "markdownDescription": "Denies the set_focusable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-fullscreen",
+          "markdownDescription": "Denies the set_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-icon",
+          "markdownDescription": "Denies the set_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_ignore_cursor_events command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-ignore-cursor-events",
+          "markdownDescription": "Denies the set_ignore_cursor_events command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_max_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-max-size",
+          "markdownDescription": "Denies the set_max_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-maximizable",
+          "markdownDescription": "Denies the set_maximizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_min_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-min-size",
+          "markdownDescription": "Denies the set_min_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-minimizable",
+          "markdownDescription": "Denies the set_minimizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_overlay_icon command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-overlay-icon",
+          "markdownDescription": "Denies the set_overlay_icon command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_position command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-position",
+          "markdownDescription": "Denies the set_position command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_progress_bar command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-progress-bar",
+          "markdownDescription": "Denies the set_progress_bar command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_resizable command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-resizable",
+          "markdownDescription": "Denies the set_resizable command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_shadow command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-shadow",
+          "markdownDescription": "Denies the set_shadow command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_simple_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-simple-fullscreen",
+          "markdownDescription": "Denies the set_simple_fullscreen command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_size command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-size",
+          "markdownDescription": "Denies the set_size command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_size_constraints command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-size-constraints",
+          "markdownDescription": "Denies the set_size_constraints command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_skip_taskbar command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-skip-taskbar",
+          "markdownDescription": "Denies the set_skip_taskbar command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-theme",
+          "markdownDescription": "Denies the set_theme command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-title",
+          "markdownDescription": "Denies the set_title command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_title_bar_style command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-title-bar-style",
+          "markdownDescription": "Denies the set_title_bar_style command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_visible_on_all_workspaces command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-set-visible-on-all-workspaces",
+          "markdownDescription": "Denies the set_visible_on_all_workspaces command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the show command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-show",
+          "markdownDescription": "Denies the show command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the start_dragging command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-start-dragging",
+          "markdownDescription": "Denies the start_dragging command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the start_resize_dragging command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-start-resize-dragging",
+          "markdownDescription": "Denies the start_resize_dragging command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the theme command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-theme",
+          "markdownDescription": "Denies the theme command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the title command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-title",
+          "markdownDescription": "Denies the title command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-toggle-maximize",
+          "markdownDescription": "Denies the toggle_maximize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the unmaximize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-unmaximize",
+          "markdownDescription": "Denies the unmaximize command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the unminimize command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:window:deny-unminimize",
+          "markdownDescription": "Denies the unminimize command without any pre-configured scope."
+        }
+      ]
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src-tauri/src/attachments.rs
+++ b/src-tauri/src/attachments.rs
@@ -6,7 +6,7 @@ use std::{
 use serde::Deserialize;
 use uuid::Uuid;
 
-use crate::{app::CommandResult, models::AttachmentUpload};
+use crate::{app::CommandResult, models::AttachmentUpload, platform_paths::default_attachment_dir};
 
 pub(crate) const ATTACHMENT_SIZE_LIMIT: usize = 25 * 1024 * 1024;
 
@@ -112,12 +112,7 @@ fn attachment_root_dir() -> CommandResult<PathBuf> {
     if let Ok(path) = env::var("LANTOR_ATTACHMENT_DIR") {
         return Ok(PathBuf::from(path));
     }
-    let home = env::var("HOME").map_err(|_| "HOME is not set".to_owned())?;
-    Ok(PathBuf::from(home)
-        .join("Library")
-        .join("Application Support")
-        .join("Lantor")
-        .join("attachments"))
+    Ok(default_attachment_dir())
 }
 
 fn attachment_extension(original_name: &str) -> String {

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -9,30 +9,20 @@ use sqlx::{
     Row, SqlitePool,
 };
 
-use crate::app::{to_string, CommandResult};
 use crate::usage::backfill_agent_run_usage_from_logs;
+use crate::{
+    app::{to_string, CommandResult},
+    platform_paths::default_database_url,
+};
 
-const DEFAULT_DATABASE_URL: &str = "sqlite://~/Library/Application Support/Lantor/lantor.sqlite";
-
-pub(crate) fn expand_home_path(value: &str) -> String {
-    let value = value.trim();
-    if value == "~" {
-        return env::var("HOME").unwrap_or_else(|_| value.to_owned());
-    }
-    if let Some(rest) = value.strip_prefix("~/") {
-        if let Ok(home) = env::var("HOME") {
-            return PathBuf::from(home).join(rest).to_string_lossy().to_string();
-        }
-    }
-    value.to_owned()
-}
+pub(crate) use crate::platform_paths::expand_home_path;
 
 pub(crate) fn db_url() -> String {
     let configured = env::var("LANTOR_DATABASE_URL").unwrap_or_else(|_| {
         env::var("DATABASE_URL")
             .ok()
             .filter(|url| url.trim_start().starts_with("sqlite:"))
-            .unwrap_or_else(|| DEFAULT_DATABASE_URL.to_owned())
+            .unwrap_or_else(default_database_url)
     });
     if let Some(path) = configured.strip_prefix("sqlite://") {
         return format!("sqlite://{}", expand_home_path(path));

--- a/src-tauri/src/launch_agent.rs
+++ b/src-tauri/src/launch_agent.rs
@@ -218,6 +218,27 @@ mod platform_service {
     const UNIT_NAME: &str = "local.lantor.supervisor.service";
 
     pub(crate) fn load_status() -> CommandResult<LaunchAgentStatus> {
+        if should_use_system_service() {
+            return load_system_status();
+        }
+        load_user_status()
+    }
+
+    pub(crate) fn install(database_url: &str) -> CommandResult<LaunchAgentStatus> {
+        if should_use_system_service() {
+            return install_system(database_url);
+        }
+        install_user(database_url)
+    }
+
+    pub(crate) fn uninstall() -> CommandResult<LaunchAgentStatus> {
+        if should_use_system_service() || systemd_system_unit_path().exists() {
+            return uninstall_system();
+        }
+        uninstall_user()
+    }
+
+    fn load_user_status() -> CommandResult<LaunchAgentStatus> {
         let unit_path = systemd_user_unit_path()?;
         let installed = unit_path.exists();
         let loaded = StdCommand::new("systemctl")
@@ -234,7 +255,7 @@ mod platform_service {
         })
     }
 
-    pub(crate) fn install(database_url: &str) -> CommandResult<LaunchAgentStatus> {
+    fn install_user(database_url: &str) -> CommandResult<LaunchAgentStatus> {
         let unit_path = systemd_user_unit_path()?;
         let exe_path = env::current_exe().map_err(to_string)?;
         let log_dir = systemd_log_dir()?;
@@ -252,10 +273,10 @@ mod platform_service {
         run_systemctl(&["--user", "daemon-reload"])?;
         run_systemctl(&["--user", "enable", "--now", UNIT_NAME])?;
 
-        load_status()
+        load_user_status()
     }
 
-    pub(crate) fn uninstall() -> CommandResult<LaunchAgentStatus> {
+    fn uninstall_user() -> CommandResult<LaunchAgentStatus> {
         let _ = StdCommand::new("systemctl")
             .args(["--user", "disable", "--now", UNIT_NAME])
             .output();
@@ -264,7 +285,83 @@ mod platform_service {
             .args(["--user", "daemon-reload"])
             .output();
 
-        load_status()
+        load_user_status()
+    }
+
+    fn load_system_status() -> CommandResult<LaunchAgentStatus> {
+        let unit_path = systemd_system_unit_path();
+        let installed = unit_path.exists();
+        let loaded = StdCommand::new("systemctl")
+            .args(["is-active", "--quiet", UNIT_NAME])
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false);
+
+        Ok(LaunchAgentStatus {
+            label: SERVICE_LABEL.to_owned(),
+            plist_path: unit_path.to_string_lossy().to_string(),
+            installed,
+            loaded,
+        })
+    }
+
+    fn install_system(database_url: &str) -> CommandResult<LaunchAgentStatus> {
+        let unit_path = systemd_system_unit_path();
+        let exe_path = env::current_exe().map_err(to_string)?;
+        let user = service_user()?;
+        let unit = render_systemd_system_unit(&exe_path, database_url, &user);
+        let staging_path = systemd_system_unit_staging_path()?;
+
+        if let Some(parent) = staging_path.parent() {
+            fs::create_dir_all(parent).map_err(to_string)?;
+        }
+        fs::write(&staging_path, unit).map_err(to_string)?;
+
+        run_sudo_or_command_hint(
+            &[
+                "install",
+                "-m",
+                "0644",
+                staging_path.to_string_lossy().as_ref(),
+                unit_path.to_string_lossy().as_ref(),
+            ],
+            &format!(
+                "sudo install -m 0644 {} {}",
+                shell_quote(&staging_path.to_string_lossy()),
+                shell_quote(&unit_path.to_string_lossy())
+            ),
+        )?;
+        run_sudo_or_command_hint(
+            &["systemctl", "daemon-reload"],
+            "sudo systemctl daemon-reload",
+        )?;
+        run_sudo_or_command_hint(
+            &["systemctl", "enable", "--now", UNIT_NAME],
+            &format!("sudo systemctl enable --now {UNIT_NAME}"),
+        )?;
+
+        load_system_status()
+    }
+
+    fn uninstall_system() -> CommandResult<LaunchAgentStatus> {
+        let unit_path = systemd_system_unit_path();
+        if unit_path.exists() {
+            run_sudo_or_command_hint(
+                &["systemctl", "disable", "--now", UNIT_NAME],
+                &format!("sudo systemctl disable --now {UNIT_NAME}"),
+            )?;
+        }
+        if unit_path.exists() {
+            run_sudo_or_command_hint(
+                &["rm", "-f", unit_path.to_string_lossy().as_ref()],
+                &format!("sudo rm -f {}", shell_quote(&unit_path.to_string_lossy())),
+            )?;
+        }
+        let _ = StdCommand::new("sudo")
+            .args(["-n", "systemctl", "daemon-reload"])
+            .output();
+
+        load_system_status()
     }
 
     fn systemd_user_unit_path() -> CommandResult<PathBuf> {
@@ -287,6 +384,43 @@ mod platform_service {
         Ok(state_home.join("lantor"))
     }
 
+    fn systemd_system_unit_path() -> PathBuf {
+        PathBuf::from("/etc/systemd/system").join(UNIT_NAME)
+    }
+
+    fn systemd_system_unit_staging_path() -> CommandResult<PathBuf> {
+        Ok(systemd_log_dir()?.join(UNIT_NAME))
+    }
+
+    fn should_use_system_service() -> bool {
+        is_wsl() && !user_systemctl_available()
+    }
+
+    fn is_wsl() -> bool {
+        let marker = fs::read_to_string("/proc/sys/kernel/osrelease")
+            .or_else(|_| fs::read_to_string("/proc/version"))
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        marker.contains("microsoft") || marker.contains("wsl")
+    }
+
+    fn user_systemctl_available() -> bool {
+        StdCommand::new("systemctl")
+            .args(["--user", "show-environment"])
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    }
+
+    fn service_user() -> CommandResult<String> {
+        env::var("USER")
+            .or_else(|_| env::var("LOGNAME"))
+            .map(|value| value.trim().to_owned())
+            .ok()
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| "cannot determine current user for systemd service".to_owned())
+    }
+
     fn run_systemctl(args: &[&str]) -> CommandResult<()> {
         let output = StdCommand::new("systemctl")
             .args(args)
@@ -301,6 +435,30 @@ mod platform_service {
         Err(format!(
             "systemctl {} failed: {}{}",
             args.join(" "),
+            stderr.trim(),
+            if stdout.trim().is_empty() {
+                String::new()
+            } else {
+                format!(" {}", stdout.trim())
+            }
+        ))
+    }
+
+    fn run_sudo_or_command_hint(args: &[&str], command_hint: &str) -> CommandResult<()> {
+        let output = StdCommand::new("sudo")
+            .arg("-n")
+            .args(args)
+            .output()
+            .map_err(to_string)?;
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Err(format!(
+            "system service install requires sudo. Run this in a WSL terminal, then try again: {}. sudo failed: {}{}",
+            command_hint,
             stderr.trim(),
             if stdout.trim().is_empty() {
                 String::new()
@@ -335,6 +493,29 @@ WantedBy=default.target
         )
     }
 
+    fn render_systemd_system_unit(exe_path: &Path, database_url: &str, user: &str) -> String {
+        format!(
+            r#"[Unit]
+Description=Lantor supervisor
+After=default.target
+
+[Service]
+Type=simple
+User={}
+ExecStart={} --supervisor
+Environment={}
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+"#,
+            systemd_quote(user),
+            systemd_quote(&exe_path.to_string_lossy()),
+            systemd_quote(&format!("LANTOR_DATABASE_URL={database_url}")),
+        )
+    }
+
     fn systemd_quote(value: &str) -> String {
         let escaped = value
             .replace('\\', "\\\\")
@@ -342,6 +523,10 @@ WantedBy=default.target
             .replace('$', "\\$")
             .replace('`', "\\`");
         format!("\"{escaped}\"")
+    }
+
+    fn shell_quote(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "'\\''"))
     }
 }
 

--- a/src-tauri/src/launch_agent.rs
+++ b/src-tauri/src/launch_agent.rs
@@ -9,7 +9,7 @@ use crate::{
     models::LaunchAgentStatus,
 };
 
-const LAUNCH_AGENT_LABEL: &str = "local.lantor.supervisor";
+const SERVICE_LABEL: &str = "local.lantor.supervisor";
 
 pub(crate) fn spawn_supervisor_process(database_url: &str) {
     let Ok(exe) = env::current_exe() else {
@@ -30,67 +30,19 @@ pub(crate) fn spawn_supervisor_process(database_url: &str) {
 }
 
 pub(crate) fn load_launch_agent_status() -> CommandResult<LaunchAgentStatus> {
-    let plist_path = launch_agent_plist_path()?;
-    let installed = plist_path.exists();
-    let loaded = launch_agent_domain()
-        .map(|domain| {
-            StdCommand::new("launchctl")
-                .arg("print")
-                .arg(launch_agent_service_target(&domain))
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status()
-                .map(|status| status.success())
-                .unwrap_or(false)
-        })
-        .unwrap_or(false);
-
-    Ok(LaunchAgentStatus {
-        label: LAUNCH_AGENT_LABEL.to_owned(),
-        plist_path: plist_path.to_string_lossy().to_string(),
-        installed,
-        loaded,
-    })
+    platform_service::load_status()
 }
 
 pub(crate) fn install_supervisor_service(database_url: &str) -> CommandResult<LaunchAgentStatus> {
-    let plist_path = launch_agent_plist_path()?;
-    let exe_path = env::current_exe().map_err(to_string)?;
-    let plist = render_launch_agent_plist(&exe_path, database_url);
-
-    if let Some(parent) = plist_path.parent() {
-        fs::create_dir_all(parent).map_err(to_string)?;
-    }
-    fs::write(&plist_path, plist).map_err(to_string)?;
-
-    let domain = launch_agent_domain()?;
-    let service = launch_agent_service_target(&domain);
-    let _ = StdCommand::new("launchctl")
-        .arg("bootout")
-        .arg(&service)
-        .output();
-
-    run_launchctl(&["bootstrap", &domain, &plist_path.to_string_lossy()])?;
-    run_launchctl(&["kickstart", "-k", &service])?;
-
-    load_launch_agent_status()
+    platform_service::install(database_url)
 }
 
 pub(crate) fn uninstall_supervisor_service() -> CommandResult<LaunchAgentStatus> {
-    let domain = launch_agent_domain()?;
-    let service = launch_agent_service_target(&domain);
-    let _ = StdCommand::new("launchctl")
-        .arg("bootout")
-        .arg(&service)
-        .output();
-
-    remove_plist_if_exists(&launch_agent_plist_path()?)?;
-
-    load_launch_agent_status()
+    platform_service::uninstall()
 }
 
-fn remove_plist_if_exists(plist_path: &Path) -> CommandResult<()> {
-    match fs::remove_file(plist_path) {
+fn remove_file_if_exists(path: &Path) -> CommandResult<()> {
+    match fs::remove_file(path) {
         Ok(()) => {}
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
         Err(err) => return Err(err.to_string()),
@@ -98,67 +50,123 @@ fn remove_plist_if_exists(plist_path: &Path) -> CommandResult<()> {
     Ok(())
 }
 
-fn launch_agent_plist_path() -> CommandResult<PathBuf> {
-    launch_agent_plist_path_for_label(LAUNCH_AGENT_LABEL)
-}
+#[cfg(target_os = "macos")]
+mod platform_service {
+    use super::*;
 
-fn launch_agent_plist_path_for_label(label: &str) -> CommandResult<PathBuf> {
-    let home = env::var_os("HOME").ok_or_else(|| "HOME is not set".to_owned())?;
-    Ok(PathBuf::from(home)
-        .join("Library")
-        .join("LaunchAgents")
-        .join(format!("{label}.plist")))
-}
+    pub(crate) fn load_status() -> CommandResult<LaunchAgentStatus> {
+        let plist_path = launch_agent_plist_path()?;
+        let installed = plist_path.exists();
+        let loaded = launch_agent_domain()
+            .map(|domain| {
+                StdCommand::new("launchctl")
+                    .arg("print")
+                    .arg(launch_agent_service_target(&domain))
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status()
+                    .map(|status| status.success())
+                    .unwrap_or(false)
+            })
+            .unwrap_or(false);
 
-fn launch_agent_domain() -> CommandResult<String> {
-    let output = StdCommand::new("id")
-        .arg("-u")
-        .output()
-        .map_err(to_string)?;
-    if !output.status.success() {
-        return Err(String::from_utf8_lossy(&output.stderr).trim().to_owned());
-    }
-    let uid = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    if uid.is_empty() {
-        return Err("failed to resolve current uid".to_owned());
-    }
-    Ok(format!("gui/{uid}"))
-}
-
-fn launch_agent_service_target(domain: &str) -> String {
-    launch_agent_service_target_for_label(domain, LAUNCH_AGENT_LABEL)
-}
-
-fn launch_agent_service_target_for_label(domain: &str, label: &str) -> String {
-    format!("{domain}/{label}")
-}
-
-fn run_launchctl(args: &[&str]) -> CommandResult<()> {
-    let output = StdCommand::new("launchctl")
-        .args(args)
-        .output()
-        .map_err(to_string)?;
-    if output.status.success() {
-        return Ok(());
+        Ok(LaunchAgentStatus {
+            label: SERVICE_LABEL.to_owned(),
+            plist_path: plist_path.to_string_lossy().to_string(),
+            installed,
+            loaded,
+        })
     }
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Err(format!(
-        "launchctl {} failed: {}{}",
-        args.join(" "),
-        stderr.trim(),
-        if stdout.trim().is_empty() {
-            String::new()
-        } else {
-            format!(" {}", stdout.trim())
+    pub(crate) fn install(database_url: &str) -> CommandResult<LaunchAgentStatus> {
+        let plist_path = launch_agent_plist_path()?;
+        let exe_path = env::current_exe().map_err(to_string)?;
+        let plist = render_launch_agent_plist(&exe_path, database_url);
+
+        if let Some(parent) = plist_path.parent() {
+            fs::create_dir_all(parent).map_err(to_string)?;
         }
-    ))
-}
+        fs::write(&plist_path, plist).map_err(to_string)?;
 
-fn render_launch_agent_plist(exe_path: &Path, database_url: &str) -> String {
-    format!(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
+        let domain = launch_agent_domain()?;
+        let service = launch_agent_service_target(&domain);
+        let _ = StdCommand::new("launchctl")
+            .arg("bootout")
+            .arg(&service)
+            .output();
+
+        run_launchctl(&["bootstrap", &domain, &plist_path.to_string_lossy()])?;
+        run_launchctl(&["kickstart", "-k", &service])?;
+
+        load_status()
+    }
+
+    pub(crate) fn uninstall() -> CommandResult<LaunchAgentStatus> {
+        let domain = launch_agent_domain()?;
+        let service = launch_agent_service_target(&domain);
+        let _ = StdCommand::new("launchctl")
+            .arg("bootout")
+            .arg(&service)
+            .output();
+
+        remove_file_if_exists(&launch_agent_plist_path()?)?;
+
+        load_status()
+    }
+
+    fn launch_agent_plist_path() -> CommandResult<PathBuf> {
+        let home = env::var_os("HOME").ok_or_else(|| "HOME is not set".to_owned())?;
+        Ok(PathBuf::from(home)
+            .join("Library")
+            .join("LaunchAgents")
+            .join(format!("{SERVICE_LABEL}.plist")))
+    }
+
+    fn launch_agent_domain() -> CommandResult<String> {
+        let output = StdCommand::new("id")
+            .arg("-u")
+            .output()
+            .map_err(to_string)?;
+        if !output.status.success() {
+            return Err(String::from_utf8_lossy(&output.stderr).trim().to_owned());
+        }
+        let uid = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        if uid.is_empty() {
+            return Err("failed to resolve current uid".to_owned());
+        }
+        Ok(format!("gui/{uid}"))
+    }
+
+    fn launch_agent_service_target(domain: &str) -> String {
+        format!("{domain}/{SERVICE_LABEL}")
+    }
+
+    fn run_launchctl(args: &[&str]) -> CommandResult<()> {
+        let output = StdCommand::new("launchctl")
+            .args(args)
+            .output()
+            .map_err(to_string)?;
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Err(format!(
+            "launchctl {} failed: {}{}",
+            args.join(" "),
+            stderr.trim(),
+            if stdout.trim().is_empty() {
+                String::new()
+            } else {
+                format!(" {}", stdout.trim())
+            }
+        ))
+    }
+
+    fn render_launch_agent_plist(exe_path: &Path, database_url: &str) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -185,19 +193,176 @@ fn render_launch_agent_plist(exe_path: &Path, database_url: &str) -> String {
 </dict>
 </plist>
 "#,
-        xml_escape(LAUNCH_AGENT_LABEL),
-        xml_escape(&exe_path.to_string_lossy()),
-        xml_escape(database_url),
-        xml_escape("/tmp/lantor-supervisor.out.log"),
-        xml_escape("/tmp/lantor-supervisor.err.log"),
-    )
+            xml_escape(SERVICE_LABEL),
+            xml_escape(&exe_path.to_string_lossy()),
+            xml_escape(database_url),
+            xml_escape("/tmp/lantor-supervisor.out.log"),
+            xml_escape("/tmp/lantor-supervisor.err.log"),
+        )
+    }
+
+    fn xml_escape(value: &str) -> String {
+        value
+            .replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+            .replace('"', "&quot;")
+            .replace('\'', "&apos;")
+    }
 }
 
-fn xml_escape(value: &str) -> String {
-    value
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
+#[cfg(target_os = "linux")]
+mod platform_service {
+    use super::*;
+
+    const UNIT_NAME: &str = "local.lantor.supervisor.service";
+
+    pub(crate) fn load_status() -> CommandResult<LaunchAgentStatus> {
+        let unit_path = systemd_user_unit_path()?;
+        let installed = unit_path.exists();
+        let loaded = StdCommand::new("systemctl")
+            .args(["--user", "is-active", "--quiet", UNIT_NAME])
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+
+        Ok(LaunchAgentStatus {
+            label: SERVICE_LABEL.to_owned(),
+            plist_path: unit_path.to_string_lossy().to_string(),
+            installed,
+            loaded,
+        })
+    }
+
+    pub(crate) fn install(database_url: &str) -> CommandResult<LaunchAgentStatus> {
+        let unit_path = systemd_user_unit_path()?;
+        let exe_path = env::current_exe().map_err(to_string)?;
+        let log_dir = systemd_log_dir()?;
+
+        if let Some(parent) = unit_path.parent() {
+            fs::create_dir_all(parent).map_err(to_string)?;
+        }
+        fs::create_dir_all(&log_dir).map_err(to_string)?;
+        fs::write(
+            &unit_path,
+            render_systemd_unit(&exe_path, database_url, &log_dir),
+        )
+        .map_err(to_string)?;
+
+        run_systemctl(&["--user", "daemon-reload"])?;
+        run_systemctl(&["--user", "enable", "--now", UNIT_NAME])?;
+
+        load_status()
+    }
+
+    pub(crate) fn uninstall() -> CommandResult<LaunchAgentStatus> {
+        let _ = StdCommand::new("systemctl")
+            .args(["--user", "disable", "--now", UNIT_NAME])
+            .output();
+        remove_file_if_exists(&systemd_user_unit_path()?)?;
+        let _ = StdCommand::new("systemctl")
+            .args(["--user", "daemon-reload"])
+            .output();
+
+        load_status()
+    }
+
+    fn systemd_user_unit_path() -> CommandResult<PathBuf> {
+        let config_home = env::var_os("XDG_CONFIG_HOME")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
+            .ok_or_else(|| "HOME is not set".to_owned())?;
+        Ok(config_home.join("systemd").join("user").join(UNIT_NAME))
+    }
+
+    fn systemd_log_dir() -> CommandResult<PathBuf> {
+        let state_home = env::var_os("XDG_STATE_HOME")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .or_else(|| {
+                env::var_os("HOME").map(|home| PathBuf::from(home).join(".local").join("state"))
+            })
+            .ok_or_else(|| "HOME is not set".to_owned())?;
+        Ok(state_home.join("lantor"))
+    }
+
+    fn run_systemctl(args: &[&str]) -> CommandResult<()> {
+        let output = StdCommand::new("systemctl")
+            .args(args)
+            .output()
+            .map_err(to_string)?;
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Err(format!(
+            "systemctl {} failed: {}{}",
+            args.join(" "),
+            stderr.trim(),
+            if stdout.trim().is_empty() {
+                String::new()
+            } else {
+                format!(" {}", stdout.trim())
+            }
+        ))
+    }
+
+    fn render_systemd_unit(exe_path: &Path, database_url: &str, log_dir: &Path) -> String {
+        format!(
+            r#"[Unit]
+Description=Lantor supervisor
+After=default.target
+
+[Service]
+Type=simple
+ExecStart={} --supervisor
+Environment={}
+Restart=always
+RestartSec=2
+StandardOutput=append:{}
+StandardError=append:{}
+
+[Install]
+WantedBy=default.target
+"#,
+            systemd_quote(&exe_path.to_string_lossy()),
+            systemd_quote(&format!("LANTOR_DATABASE_URL={database_url}")),
+            log_dir.join("supervisor.out.log").to_string_lossy(),
+            log_dir.join("supervisor.err.log").to_string_lossy(),
+        )
+    }
+
+    fn systemd_quote(value: &str) -> String {
+        let escaped = value
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('$', "\\$")
+            .replace('`', "\\`");
+        format!("\"{escaped}\"")
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+mod platform_service {
+    use super::*;
+
+    pub(crate) fn load_status() -> CommandResult<LaunchAgentStatus> {
+        Ok(LaunchAgentStatus {
+            label: SERVICE_LABEL.to_owned(),
+            plist_path: String::new(),
+            installed: false,
+            loaded: false,
+        })
+    }
+
+    pub(crate) fn install(_database_url: &str) -> CommandResult<LaunchAgentStatus> {
+        Err("supervisor service install is only supported on macOS and Linux".to_owned())
+    }
+
+    pub(crate) fn uninstall() -> CommandResult<LaunchAgentStatus> {
+        load_status()
+    }
 }

--- a/src-tauri/src/launch_agent.rs
+++ b/src-tauri/src/launch_agent.rs
@@ -175,7 +175,7 @@ mod platform_service {
   <key>ProgramArguments</key>
   <array>
     <string>{}</string>
-    <string>--supervisor</string>
+    <string>--web-only</string>
   </array>
   <key>EnvironmentVariables</key>
   <dict>
@@ -471,12 +471,12 @@ mod platform_service {
     fn render_systemd_unit(exe_path: &Path, database_url: &str, log_dir: &Path) -> String {
         format!(
             r#"[Unit]
-Description=Lantor supervisor
+Description=Lantor web service
 After=default.target
 
 [Service]
 Type=simple
-ExecStart={} --supervisor
+ExecStart={} --web-only
 Environment={}
 Restart=always
 RestartSec=2
@@ -496,13 +496,13 @@ WantedBy=default.target
     fn render_systemd_system_unit(exe_path: &Path, database_url: &str, user: &str) -> String {
         format!(
             r#"[Unit]
-Description=Lantor supervisor
+Description=Lantor web service
 After=default.target
 
 [Service]
 Type=simple
 User={}
-ExecStart={} --supervisor
+ExecStart={} --web-only
 Environment={}
 Restart=always
 RestartSec=2
@@ -544,7 +544,7 @@ mod platform_service {
     }
 
     pub(crate) fn install(_database_url: &str) -> CommandResult<LaunchAgentStatus> {
-        Err("supervisor service install is only supported on macOS and Linux".to_owned())
+        Err("background service install is only supported on macOS and Linux".to_owned())
     }
 
     pub(crate) fn uninstall() -> CommandResult<LaunchAgentStatus> {

--- a/src-tauri/src/launch_agent.rs
+++ b/src-tauri/src/launch_agent.rs
@@ -222,8 +222,8 @@ mod platform_service {
         let installed = unit_path.exists();
         let loaded = StdCommand::new("systemctl")
             .args(["--user", "is-active", "--quiet", UNIT_NAME])
-            .status()
-            .map(|status| status.success())
+            .output()
+            .map(|output| output.status.success())
             .unwrap_or(false);
 
         Ok(LaunchAgentStatus {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -23,6 +23,7 @@ mod lifecycle_commands;
 mod message_store;
 mod models;
 mod owner_inbox;
+mod platform_paths;
 mod prompts;
 mod runtime;
 mod system_commands;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -86,7 +86,15 @@ use system_commands::{
 use ui_notifications::{spawn_ui_events_pruner, spawn_ui_refresh_listener};
 
 const WINDOW_STATE_FILE: &str = "window-state.json";
+
+#[cfg(target_os = "linux")]
+const MIN_RESTORED_WINDOW_WIDTH: f64 = 960.0;
+#[cfg(target_os = "linux")]
+const MIN_RESTORED_WINDOW_HEIGHT: f64 = 640.0;
+
+#[cfg(not(target_os = "linux"))]
 const MIN_RESTORED_WINDOW_WIDTH: f64 = 1180.0;
+#[cfg(not(target_os = "linux"))]
 const MIN_RESTORED_WINDOW_HEIGHT: f64 = 760.0;
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -330,6 +338,13 @@ pub fn run() {
             spawn_shared_background_workers(reminder_pool.clone(), database_url.clone());
             if let Some(window) = app.get_webview_window("main") {
                 let _ = window.set_title("Lantor");
+                #[cfg(target_os = "linux")]
+                {
+                    let _ = window.set_min_size(Some(LogicalSize::new(
+                        MIN_RESTORED_WINDOW_WIDTH,
+                        MIN_RESTORED_WINDOW_HEIGHT,
+                    )));
+                }
                 if let Some(path) = window_state_path(app.handle()) {
                     install_window_state_persistence(&window, path);
                 }

--- a/src-tauri/src/platform_paths.rs
+++ b/src-tauri/src/platform_paths.rs
@@ -67,7 +67,7 @@ fn compatible_default_path(xdg_path: PathBuf, legacy_path: Option<PathBuf>) -> P
     let Some(legacy_path) = legacy_path else {
         return xdg_path;
     };
-    if legacy_path.exists() && !xdg_path.exists() {
+    if legacy_path.exists() {
         return legacy_path;
     }
     xdg_path
@@ -168,7 +168,7 @@ mod tests {
     }
 
     #[test]
-    fn compatible_default_path_uses_legacy_only_when_new_path_is_missing() {
+    fn compatible_default_path_uses_legacy_when_present_even_if_new_path_exists() {
         let root = temp_path("compat");
         let xdg_path = root.join("xdg").join("lantor.sqlite");
         let legacy_path = root.join("legacy").join("lantor.sqlite");
@@ -184,7 +184,7 @@ mod tests {
         fs::write(&xdg_path, "").expect("write xdg");
         assert_eq!(
             compatible_default_path(xdg_path.clone(), Some(legacy_path)),
-            xdg_path
+            root.join("legacy").join("lantor.sqlite")
         );
 
         let _ = fs::remove_dir_all(root);

--- a/src-tauri/src/platform_paths.rs
+++ b/src-tauri/src/platform_paths.rs
@@ -6,6 +6,14 @@ fn home_dir() -> Option<PathBuf> {
     env::var_os("HOME").map(PathBuf::from)
 }
 
+fn legacy_app_data_dir() -> Option<PathBuf> {
+    home_dir().map(|home| {
+        home.join("Library")
+            .join("Application Support")
+            .join(APP_DIR_NAME)
+    })
+}
+
 pub(crate) fn expand_home_path(value: &str) -> String {
     let value = value.trim();
     if value == "~" {
@@ -21,11 +29,12 @@ pub(crate) fn expand_home_path(value: &str) -> String {
 
 #[cfg(target_os = "macos")]
 fn default_app_data_dir() -> PathBuf {
-    home_dir()
-        .unwrap_or_else(|| PathBuf::from("~"))
-        .join("Library")
-        .join("Application Support")
-        .join(APP_DIR_NAME)
+    legacy_app_data_dir().unwrap_or_else(|| {
+        PathBuf::from("~")
+            .join("Library")
+            .join("Application Support")
+            .join(APP_DIR_NAME)
+    })
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
@@ -54,15 +63,42 @@ fn default_app_data_dir() -> PathBuf {
         .join(APP_DIR_NAME)
 }
 
-pub(crate) fn default_database_url() -> String {
-    format!(
-        "sqlite://{}",
-        default_app_data_dir()
-            .join("lantor.sqlite")
-            .to_string_lossy()
+fn compatible_default_path(xdg_path: PathBuf, legacy_path: Option<PathBuf>) -> PathBuf {
+    let Some(legacy_path) = legacy_path else {
+        return xdg_path;
+    };
+    if legacy_path.exists() && !xdg_path.exists() {
+        return legacy_path;
+    }
+    xdg_path
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn default_database_path() -> PathBuf {
+    compatible_default_path(
+        default_app_data_dir().join("lantor.sqlite"),
+        legacy_app_data_dir().map(|dir| dir.join("lantor.sqlite")),
     )
 }
 
+#[cfg(not(all(unix, not(target_os = "macos"))))]
+fn default_database_path() -> PathBuf {
+    default_app_data_dir().join("lantor.sqlite")
+}
+
+pub(crate) fn default_database_url() -> String {
+    format!("sqlite://{}", default_database_path().to_string_lossy())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(crate) fn default_attachment_dir() -> PathBuf {
+    compatible_default_path(
+        default_app_data_dir().join("attachments"),
+        legacy_app_data_dir().map(|dir| dir.join("attachments")),
+    )
+}
+
+#[cfg(not(all(unix, not(target_os = "macos"))))]
 pub(crate) fn default_attachment_dir() -> PathBuf {
     default_app_data_dir().join("attachments")
 }
@@ -109,12 +145,48 @@ pub(crate) fn script_shell() -> (PathBuf, Vec<&'static str>) {
 
 #[cfg(test)]
 mod tests {
-    use super::expand_home_path;
+    use super::{compatible_default_path, expand_home_path};
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn temp_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos();
+        std::env::temp_dir().join(format!("lantor-platform-paths-{nanos}-{name}"))
+    }
 
     #[test]
     fn expands_home_prefixes() {
         let home = std::env::var("HOME").expect("HOME should be set for tests");
         assert_eq!(expand_home_path("~"), home);
         assert!(expand_home_path("~/example").ends_with("example"));
+    }
+
+    #[test]
+    fn compatible_default_path_uses_legacy_only_when_new_path_is_missing() {
+        let root = temp_path("compat");
+        let xdg_path = root.join("xdg").join("lantor.sqlite");
+        let legacy_path = root.join("legacy").join("lantor.sqlite");
+
+        fs::create_dir_all(legacy_path.parent().expect("legacy parent")).expect("mkdir legacy");
+        fs::write(&legacy_path, "").expect("write legacy");
+        assert_eq!(
+            compatible_default_path(xdg_path.clone(), Some(legacy_path.clone())),
+            legacy_path
+        );
+
+        fs::create_dir_all(xdg_path.parent().expect("xdg parent")).expect("mkdir xdg");
+        fs::write(&xdg_path, "").expect("write xdg");
+        assert_eq!(
+            compatible_default_path(xdg_path.clone(), Some(legacy_path)),
+            xdg_path
+        );
+
+        let _ = fs::remove_dir_all(root);
     }
 }

--- a/src-tauri/src/platform_paths.rs
+++ b/src-tauri/src/platform_paths.rs
@@ -1,0 +1,80 @@
+use std::{env, path::PathBuf};
+
+const APP_DIR_NAME: &str = "Lantor";
+
+fn home_dir() -> Option<PathBuf> {
+    env::var_os("HOME").map(PathBuf::from)
+}
+
+pub(crate) fn expand_home_path(value: &str) -> String {
+    let value = value.trim();
+    if value == "~" {
+        return env::var("HOME").unwrap_or_else(|_| value.to_owned());
+    }
+    if let Some(rest) = value.strip_prefix("~/") {
+        if let Some(home) = home_dir() {
+            return home.join(rest).to_string_lossy().to_string();
+        }
+    }
+    value.to_owned()
+}
+
+#[cfg(target_os = "macos")]
+fn default_app_data_dir() -> PathBuf {
+    home_dir()
+        .unwrap_or_else(|| PathBuf::from("~"))
+        .join("Library")
+        .join("Application Support")
+        .join(APP_DIR_NAME)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn default_app_data_dir() -> PathBuf {
+    env::var_os("XDG_DATA_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| home_dir().map(|home| home.join(".local").join("share")))
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(APP_DIR_NAME.to_ascii_lowercase())
+}
+
+#[cfg(windows)]
+fn default_app_data_dir() -> PathBuf {
+    env::var_os("APPDATA")
+        .map(PathBuf::from)
+        .or_else(|| home_dir().map(|home| home.join("AppData").join("Roaming")))
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(APP_DIR_NAME)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn default_app_data_dir() -> PathBuf {
+    home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(APP_DIR_NAME)
+}
+
+pub(crate) fn default_database_url() -> String {
+    format!(
+        "sqlite://{}",
+        default_app_data_dir()
+            .join("lantor.sqlite")
+            .to_string_lossy()
+    )
+}
+
+pub(crate) fn default_attachment_dir() -> PathBuf {
+    default_app_data_dir().join("attachments")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expand_home_path;
+
+    #[test]
+    fn expands_home_prefixes() {
+        let home = std::env::var("HOME").expect("HOME should be set for tests");
+        assert_eq!(expand_home_path("~"), home);
+        assert!(expand_home_path("~/example").ends_with("example"));
+    }
+}

--- a/src-tauri/src/platform_paths.rs
+++ b/src-tauri/src/platform_paths.rs
@@ -67,6 +67,46 @@ pub(crate) fn default_attachment_dir() -> PathBuf {
     default_app_data_dir().join("attachments")
 }
 
+fn executable_exists(path: &str) -> bool {
+    std::fs::metadata(path)
+        .map(|metadata| metadata.is_file())
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn script_shell() -> (PathBuf, Vec<&'static str>) {
+    (PathBuf::from("/bin/zsh"), vec!["-lc"])
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(crate) fn script_shell() -> (PathBuf, Vec<&'static str>) {
+    if let Some(shell) = env::var_os("SHELL").and_then(|value| {
+        let path = PathBuf::from(value);
+        let name = path.file_name()?.to_str()?;
+        matches!(name, "bash" | "zsh").then_some(path)
+    }) {
+        if executable_exists(&shell.to_string_lossy()) {
+            return (shell, vec!["-lc"]);
+        }
+    }
+
+    if executable_exists("/bin/bash") {
+        return (PathBuf::from("/bin/bash"), vec!["-lc"]);
+    }
+
+    (PathBuf::from("/bin/sh"), vec!["-c"])
+}
+
+#[cfg(windows)]
+pub(crate) fn script_shell() -> (PathBuf, Vec<&'static str>) {
+    (PathBuf::from("cmd"), vec!["/C"])
+}
+
+#[cfg(not(any(unix, windows)))]
+pub(crate) fn script_shell() -> (PathBuf, Vec<&'static str>) {
+    (PathBuf::from("sh"), vec!["-c"])
+}
+
 #[cfg(test)]
 mod tests {
     use super::expand_home_path;

--- a/src-tauri/src/runtime/codex.rs
+++ b/src-tauri/src/runtime/codex.rs
@@ -38,6 +38,7 @@ use crate::usage::{record_run_usage, usage_from_runtime_event};
 use crate::{
     app::{to_string, CommandResult},
     build_steer_followup_prompt, load_inbox_wake_items_for_work_item,
+    platform_paths::script_shell,
 };
 
 mod protocol;
@@ -356,9 +357,10 @@ async fn spawn_warm_codex_runtime(
     context_rotate_threshold: i64,
 ) -> CommandResult<Arc<WarmCodexRuntime>> {
     let cwd = effective_codex_cwd(working_directory)?;
-    let mut command = Command::new("/bin/zsh");
+    let (shell, shell_args) = script_shell();
+    let mut command = Command::new(shell);
     command
-        .arg("-lc")
+        .args(shell_args)
         .arg("exec codex app-server --listen stdio:// -c 'notify=[]'");
     apply_agent_environment_variables(&mut command, environment_variables)?;
     configure_agent_identity_env(&mut command, agent_id, handle);

--- a/src-tauri/src/runtime/process.rs
+++ b/src-tauri/src/runtime/process.rs
@@ -23,6 +23,7 @@ use crate::{
     app::{to_string, CommandResult},
     db::db_url,
     mark_task_after_work_item_finished,
+    platform_paths::script_shell,
 };
 
 const LANTOR_CONTEXT_TOOL_ENV: &str = "LANTOR_CONTEXT_TOOL";
@@ -603,8 +604,9 @@ pub(crate) async fn start_process_agent(
     )
     .await?;
 
-    let mut command = Command::new("/bin/zsh");
-    command.arg("-lc").arg(&command_text);
+    let (shell, shell_args) = script_shell();
+    let mut command = Command::new(shell);
+    command.args(shell_args).arg(&command_text);
     apply_agent_environment_variables(&mut command, &environment_variables)?;
     configure_agent_identity_env(&mut command, agent_id, &handle);
     configure_agent_context_tool_env(&mut command);

--- a/src-tauri/src/system_commands.rs
+++ b/src-tauri/src/system_commands.rs
@@ -8,6 +8,7 @@ use crate::{
     app::{to_string, CommandResult},
     db::expand_home_path,
     models::RuntimeCheck,
+    platform_paths::script_shell,
 };
 use tauri::Manager;
 
@@ -178,8 +179,9 @@ fn editor_command_candidates() -> [&'static str; 3] {
 fn resolve_editor_command(command: &str) -> String {
     // GUI apps launched by Finder do not always inherit the shell PATH.
     let script = format!("command -v {command}");
-    let output = StdCommand::new("/bin/zsh")
-        .arg("-lc")
+    let (shell, shell_args) = script_shell();
+    let output = StdCommand::new(shell)
+        .args(shell_args)
         .arg(script)
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -396,8 +398,9 @@ pub(crate) async fn check_runtime_in_env(runtime: String) -> CommandResult<Runti
     let script = format!(
         "if command -v {command} >/dev/null 2>&1; then {command} --version 2>&1 | head -n 1; else echo '{command} not found in PATH' >&2; exit 127; fi"
     );
-    let output = StdCommand::new("/bin/zsh")
-        .arg("-lc")
+    let (shell, shell_args) = script_shell();
+    let output = StdCommand::new(shell)
+        .args(shell_args)
         .arg(script)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src-tauri/src/system_commands.rs
+++ b/src-tauri/src/system_commands.rs
@@ -162,7 +162,13 @@ fn open_link_target_with_system(target: &str) -> CommandResult<()> {
     let status = StdCommand::new("xdg-open")
         .arg(target)
         .status()
-        .map_err(to_string)?;
+        .map_err(|err| {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                "xdg-open not found; install xdg-utils to open links from Lantor".to_owned()
+            } else {
+                err.to_string()
+            }
+        })?;
 
     if status.success() {
         Ok(())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,7 +42,8 @@
       "assetProtocol": {
         "enable": true,
         "scope": [
-          "$HOME/Library/Application Support/Lantor/attachments/**"
+          "$HOME/Library/Application Support/Lantor/attachments/**",
+          "$HOME/.local/share/lantor/attachments/**"
         ]
       }
     }

--- a/src/components/AgentFormModal.tsx
+++ b/src/components/AgentFormModal.tsx
@@ -234,7 +234,7 @@ export function AgentFormModal({
                 <input
                   value={form.workingDirectory}
                   onChange={(event) => onChange({ ...form, workingDirectory: event.target.value })}
-                  placeholder="~/Library/Application Support/Lantor/agents/<handle>"
+                  placeholder="Default agent workspace path"
                 />
               </label>
               {environmentField}
@@ -274,7 +274,7 @@ export function AgentFormModal({
               <input
                 value={form.workingDirectory}
                 onChange={(event) => onChange({ ...form, workingDirectory: event.target.value })}
-                placeholder="~/Library/Application Support/Lantor/agents/<handle>"
+                placeholder="Default agent workspace path"
               />
               <small>{APP_DISPLAY_NAME} loads MEMORY.md from this directory as persistent context when the agent runs.</small>
             </label>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,4 +1,5 @@
-import { Image, Monitor, Moon, Sun, Type } from "lucide-react";
+import { Image, Monitor, Moon, ServerCog, Sun, Type } from "lucide-react";
+import type { LaunchAgentStatus, SupervisorStatus } from "../types";
 import { Modal } from "./Modal";
 
 export type ThemePreference = "auto" | "light" | "dark";
@@ -9,9 +10,13 @@ type SettingsModalProps = {
   themePreference: ThemePreference;
   chatTextSize: ChatTextSize;
   showImageThumbnails: boolean;
+  launchAgent: LaunchAgentStatus;
+  supervisor: SupervisorStatus;
   onThemePreferenceChange: (value: ThemePreference) => void;
   onChatTextSizeChange: (value: ChatTextSize) => void;
   onShowImageThumbnailsChange: (value: boolean) => void;
+  onInstallSupervisorService: () => void;
+  onUninstallSupervisorService: () => void;
   onClose: () => void;
 };
 
@@ -42,11 +47,19 @@ export function SettingsModal({
   themePreference,
   chatTextSize,
   showImageThumbnails,
+  launchAgent,
+  supervisor,
   onThemePreferenceChange,
   onChatTextSizeChange,
   onShowImageThumbnailsChange,
+  onInstallSupervisorService,
+  onUninstallSupervisorService,
   onClose,
 }: SettingsModalProps) {
+  const serviceStatus = launchAgent.installed
+    ? launchAgent.loaded ? "Installed and running" : "Installed"
+    : "Not installed";
+
   return (
     <Modal open={open} title="Settings" onClose={onClose} width={560}>
       <section className="settings-panel">
@@ -115,6 +128,25 @@ export function SettingsModal({
             />
           </label>
           <p className="settings-hint">When disabled, images appear as compact attachment rows and still open in preview when clicked.</p>
+        </fieldset>
+        <fieldset className="settings-fieldset settings-service-fieldset">
+          <legend>Background service</legend>
+          <div className="settings-service-status">
+            <ServerCog size={17} />
+            <span>
+              <strong>{serviceStatus}</strong>
+              <small>Supervisor: {supervisor.status}{supervisor.pid ? `, pid ${supervisor.pid}` : ""}</small>
+            </span>
+          </div>
+          <div className="settings-service-actions">
+            <button type="button" onClick={onInstallSupervisorService}>
+              {launchAgent.installed ? "Reinstall service" : "Install service"}
+            </button>
+            <button type="button" disabled={!launchAgent.installed} onClick={onUninstallSupervisorService}>
+              Uninstall service
+            </button>
+          </div>
+          <p className="settings-hint">{launchAgent.plist_path}</p>
         </fieldset>
       </section>
     </Modal>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3898,9 +3898,13 @@ function App() {
         themePreference={themePreference}
         chatTextSize={chatTextSize}
         showImageThumbnails={showImageThumbnails}
+        launchAgent={data.launch_agent}
+        supervisor={data.supervisor}
         onThemePreferenceChange={setThemePreference}
         onChatTextSizeChange={setChatTextSize}
         onShowImageThumbnailsChange={setShowImageThumbnails}
+        onInstallSupervisorService={installSupervisorService}
+        onUninstallSupervisorService={uninstallSupervisorService}
         onClose={() => setShowSettingsModal(false)}
       />
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -563,9 +563,24 @@ async function attachmentUploads(attachments: DraftAttachment[]) {
   }));
 }
 
-function defaultAgentWorkspace(handle: string) {
+function dataRootFromSqliteUrl(dbUrl?: string | null) {
+  if (!dbUrl?.startsWith("sqlite:")) return null;
+  const rawPath = dbUrl.startsWith("sqlite://")
+    ? dbUrl.slice("sqlite://".length)
+    : dbUrl.slice("sqlite:".length);
+  const databasePath = rawPath.trim();
+  if (!databasePath || databasePath === ":memory:") return null;
+  const normalized = databasePath.replace(/\/+$/, "");
+  const lastSlash = normalized.lastIndexOf("/");
+  if (lastSlash <= 0) return null;
+  return normalized.slice(0, lastSlash);
+}
+
+function defaultAgentWorkspace(handle: string, dbUrl?: string | null) {
   const normalized = handle.trim().replace(/^@/, "").replace(/[^A-Za-z0-9_-]/g, "-");
   if (!normalized) return "";
+  const dataRoot = dataRootFromSqliteUrl(dbUrl);
+  if (dataRoot) return `${dataRoot}/agents/${normalized}`;
   const platform = navigator.platform.toLowerCase();
   const baseDir = platform.includes("linux")
     ? "~/.local/share/lantor"
@@ -3136,7 +3151,7 @@ function App() {
       handle,
       displayName,
       launchCommand: buildPresetCommand({ ...agentDraft, handle, displayName }),
-      workingDirectory: agentDraft.workingDirectory.trim() || defaultAgentWorkspace(handle),
+      workingDirectory: agentDraft.workingDirectory.trim() || defaultAgentWorkspace(handle, data?.db_url),
     };
     await apiInvoke<string>("create_agent", {
       handle,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -565,7 +565,12 @@ async function attachmentUploads(attachments: DraftAttachment[]) {
 
 function defaultAgentWorkspace(handle: string) {
   const normalized = handle.trim().replace(/^@/, "").replace(/[^A-Za-z0-9_-]/g, "-");
-  return normalized ? `~/Library/Application Support/Lantor/agents/${normalized}` : "";
+  if (!normalized) return "";
+  const platform = navigator.platform.toLowerCase();
+  const baseDir = platform.includes("linux")
+    ? "~/.local/share/lantor"
+    : "~/Library/Application Support/Lantor";
+  return `${baseDir}/agents/${normalized}`;
 }
 
 function newAgentDraft(): AgentForm {

--- a/src/styles.css
+++ b/src/styles.css
@@ -6326,6 +6326,68 @@ body.resizing-column * {
   accent-color: var(--accent);
 }
 
+.settings-service-fieldset {
+  margin-top: 8px;
+}
+
+.settings-service-status {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 11px 12px;
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  background: var(--panel-strong);
+  color: var(--muted);
+}
+
+.settings-service-status > span {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.settings-service-status strong {
+  color: var(--ink);
+  font-size: var(--type-size-body);
+  font-weight: var(--type-weight-semibold);
+}
+
+.settings-service-status small {
+  color: var(--muted);
+  font-size: var(--type-size-caption);
+  line-height: 1.3;
+}
+
+.settings-service-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.settings-service-actions button {
+  min-height: 36px;
+  padding: 8px 12px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel-strong);
+  color: var(--ink);
+  font-weight: var(--type-weight-semibold);
+}
+
+.settings-service-actions button:first-child {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+
+.settings-service-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
 .modal-form {
   display: grid;
   gap: 14px;


### PR DESCRIPTION
## Summary

This PR improves Linux support for running Lantor as a local desktop/web app.

It adds Linux-specific platform paths, Linux Tauri capability schema generation, systemd-based background service installation, and WSL fallback behavior when `systemctl --user` is unavailable.

The background service now starts Lantor in `--web-only` mode so the web UI and shared background workers come up without opening the desktop window. This lets users access Lantor from a browser after the service starts.

## Changes

- Add Linux platform path handling while preserving existing legacy Linux data paths.
- Add Linux Tauri capability schema.
- Add Linux setup/configuration docs and CI AppImage validation.
- Add Runtime settings controls for installing/uninstalling the background service.
- Support Linux systemd user services via `systemctl --user`.
- Fall back to a system-level systemd unit on WSL when the user systemd bus is unavailable.
- Start the installed background service with `--web-only` so browser access is available after startup.
- Improve Linux `xdg-open` error reporting.

## WSL behavior

On WSL, the systemd service starts when the WSL distro starts. If users want Lantor web to start after Windows login without opening WSL manually, they still need a Windows-side startup trigger, such as Task Scheduler launching the distro with `wsl.exe -d <distro>`.

## Testing

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --no-run`
