### PR TITLE
Fix web channel history pagination

### DIFF
--- a/src-tauri/src/bootstrap.rs
+++ b/src-tauri/src/bootstrap.rs
@@ -17,8 +17,10 @@ use crate::{
     domain::{reminders::load_reminders, schedules::load_agent_schedules},
     launch_agent,
     message_store::{
-        load_artifact_summaries, load_artifacts, load_messages, load_recent_messages_per_channel,
+        channel_message_history_from_messages, load_artifact_summaries, load_artifacts,
+        load_messages, load_recent_messages_per_channel,
         load_recent_messages_per_channel_without_artifact_content, load_saved_messages,
+        WEB_BOOTSTRAP_ROOT_MESSAGES_PER_CHANNEL,
     },
     models::{
         Bootstrap, BootstrapPerf, BootstrapPerfCounts, BootstrapPerfOptions, BootstrapPerfPhase,
@@ -28,8 +30,6 @@ use crate::{
     task_store::load_tasks,
     web,
 };
-
-const WEB_BOOTSTRAP_MESSAGES_PER_CHANNEL: i64 = 80;
 
 fn configured_web_base_url() -> Option<String> {
     if let Ok(value) = env::var("LANTOR_WEB_PUBLIC_URL") {
@@ -73,7 +73,9 @@ pub(crate) async fn load_web_bootstrap(
         db_url,
         BootstrapLoadOptions {
             runtime: "web",
-            messages: BootstrapMessageLoad::RecentPerChannel(WEB_BOOTSTRAP_MESSAGES_PER_CHANNEL),
+            messages: BootstrapMessageLoad::RecentPerChannel(
+                WEB_BOOTSTRAP_ROOT_MESSAGES_PER_CHANNEL,
+            ),
             include_run_logs: false,
             compact_agent_activities: true,
             include_artifact_content: false,
@@ -174,6 +176,12 @@ async fn load_bootstrap_with_options(
         }
         BootstrapMessageLoad::RecentPerChannel(limit) => {
             load_recent_messages_per_channel_without_artifact_content(pool, limit).await?
+        }
+    };
+    let channel_message_history = match options.messages {
+        BootstrapMessageLoad::All => Vec::new(),
+        BootstrapMessageLoad::RecentPerChannel(limit) => {
+            channel_message_history_from_messages(&messages, limit)
         }
     };
     push_phase(&mut phases, "messages", started_at, Some(messages.len()));
@@ -300,6 +308,7 @@ async fn load_bootstrap_with_options(
         channel_members,
         agents,
         messages,
+        channel_message_history,
         saved_messages,
         dismissed_inbox_items,
         read_inbox_items,

--- a/src-tauri/src/commands/messages.rs
+++ b/src-tauri/src/commands/messages.rs
@@ -4,10 +4,10 @@ use uuid::Uuid;
 use crate::{
     app::{AppState, CommandResult},
     message_store::{
-        delete_message_in_pool, send_owner_message_in_pool, set_message_saved_in_pool,
-        update_message_in_pool,
+        delete_message_in_pool, load_older_channel_messages as load_older_channel_messages_in_pool,
+        send_owner_message_in_pool, set_message_saved_in_pool, update_message_in_pool,
     },
-    models::{AttachmentUpload, Message},
+    models::{AttachmentUpload, ChannelMessagePage, Message},
 };
 
 #[tauri::command]
@@ -28,6 +28,16 @@ pub(crate) async fn send_message(
         attachments.unwrap_or_default(),
     )
     .await
+}
+
+#[tauri::command]
+pub(crate) async fn load_older_channel_messages(
+    channel_id: Uuid,
+    before_seq: i64,
+    limit: i64,
+    state: State<'_, AppState>,
+) -> CommandResult<ChannelMessagePage> {
+    load_older_channel_messages_in_pool(&state.pool, channel_id, before_seq, limit).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -569,6 +569,8 @@ pub(crate) async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
         "create unique index if not exists channels_dm_unique on channels(dm_agent_id) where kind = 'dm' and dm_agent_id is not null",
         "create unique index if not exists messages_stream_key_unique on messages(stream_key) where stream_key <> ''",
         "create index if not exists messages_seq_idx on messages(seq)",
+        "create index if not exists messages_channel_seq_idx on messages(channel_id, seq desc)",
+        "create index if not exists messages_channel_root_seq_idx on messages(channel_id, seq desc) where thread_root_id is null",
         "create index if not exists messages_channel_created_idx on messages(channel_id, created_at desc)",
         "create index if not exists messages_thread_root_idx on messages(thread_root_id) where thread_root_id is not null",
         "create index if not exists message_attachments_message_id_idx on message_attachments(message_id)",

--- a/src-tauri/src/freshness.rs
+++ b/src-tauri/src/freshness.rs
@@ -744,6 +744,7 @@ async fn render_recent_surface_context(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn freshness_retry_context(
     old_work_item_id: Uuid,
     held_output_id: Uuid,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -66,7 +66,10 @@ use commands::{
         dismiss_inbox_items, mark_all_inbox_read, mark_channel_read, mark_inbox_items_read,
         update_thread_followed,
     },
-    messages::{delete_message, send_message, set_message_saved, update_message},
+    messages::{
+        delete_message, load_older_channel_messages, send_message, set_message_saved,
+        update_message,
+    },
     tasks::{update_task_status, update_task_title},
 };
 use context_tool::run_agent_context_tool;
@@ -364,6 +367,7 @@ pub fn run() {
             download_attachment,
             open_external_url,
             retry_agent_work,
+            load_older_channel_messages,
             send_message,
             set_message_saved,
             set_channel_agent_membership,

--- a/src-tauri/src/message_store.rs
+++ b/src-tauri/src/message_store.rs
@@ -13,8 +13,14 @@ use crate::attachments::{write_attachment_file, ATTACHMENT_SIZE_LIMIT};
 use crate::ui_notifications::{notify_ui_message_upsert, notify_ui_refresh};
 use crate::{
     app::{to_string, CommandResult},
-    models::{Artifact, AttachmentUpload, Message, MessageAttachment, SavedMessage},
+    models::{
+        Artifact, AttachmentUpload, ChannelMessageHistory, ChannelMessagePage, Message,
+        MessageAttachment, SavedMessage,
+    },
 };
+
+pub(crate) const WEB_BOOTSTRAP_ROOT_MESSAGES_PER_CHANNEL: i64 = 80;
+const MAX_OLDER_CHANNEL_ROOT_MESSAGES_PER_PAGE: i64 = 100;
 
 pub(crate) async fn load_messages(pool: &SqlitePool) -> CommandResult<Vec<Message>> {
     load_messages_with_scope(pool, MessageLoadScope::All, true).await
@@ -44,6 +50,151 @@ pub(crate) async fn load_recent_messages_per_channel_without_artifact_content(
     .await
 }
 
+pub(crate) async fn load_older_channel_messages(
+    pool: &SqlitePool,
+    channel_id: Uuid,
+    before_seq: i64,
+    limit: i64,
+) -> CommandResult<ChannelMessagePage> {
+    load_older_channel_messages_with_options(pool, channel_id, before_seq, limit, true).await
+}
+
+pub(crate) async fn load_older_channel_messages_without_artifact_content(
+    pool: &SqlitePool,
+    channel_id: Uuid,
+    before_seq: i64,
+    limit: i64,
+) -> CommandResult<ChannelMessagePage> {
+    load_older_channel_messages_with_options(pool, channel_id, before_seq, limit, false).await
+}
+
+async fn load_older_channel_messages_with_options(
+    pool: &SqlitePool,
+    channel_id: Uuid,
+    before_seq: i64,
+    limit: i64,
+    include_artifact_content: bool,
+) -> CommandResult<ChannelMessagePage> {
+    let limit = limit.clamp(1, MAX_OLDER_CHANNEL_ROOT_MESSAGES_PER_PAGE);
+    let root_rows = sqlx::query(
+        r#"
+        select id, seq
+        from messages
+        where channel_id = $1
+          and thread_root_id is null
+          and seq < $2
+        order by seq desc
+        limit $3
+        "#,
+    )
+    .bind(channel_id)
+    .bind(before_seq)
+    .bind(limit + 1)
+    .fetch_all(pool)
+    .await
+    .map_err(to_string)?;
+
+    let has_more = root_rows.len() > limit as usize;
+    let selected_roots = root_rows
+        .into_iter()
+        .take(limit as usize)
+        .collect::<Vec<_>>();
+    let next_before_seq = selected_roots.last().map(|row| row.get::<i64, _>("seq"));
+    if selected_roots.is_empty() {
+        return Ok(ChannelMessagePage {
+            messages: Vec::new(),
+            next_before_seq: None,
+            has_more: false,
+        });
+    }
+
+    let root_ids = selected_roots
+        .iter()
+        .map(|row| row.get::<Uuid, _>("id"))
+        .collect::<Vec<_>>();
+    let placeholders = (0..root_ids.len())
+        .map(|index| format!("${}", index + 1))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let channel_placeholder = format!("${}", root_ids.len() + 1);
+    let sql = format!(
+        r#"
+        select
+            m.id,
+            m.seq,
+            m.channel_id,
+            m.thread_root_id,
+            m.sender_agent_id,
+            m.sender_name,
+            m.sender_role,
+            m.body,
+            m.is_task,
+            m.thread_followed,
+            m.delivery_state,
+            m.stream_key,
+            t.number as task_number,
+            t.status as task_status,
+            m.created_at,
+            m.updated_at
+        from messages m
+        left join tasks t on t.message_id = m.id
+        where m.channel_id = {channel_placeholder}
+          and (
+              m.id in ({placeholders})
+              or m.thread_root_id in ({placeholders})
+          )
+        order by m.seq asc
+        "#,
+    );
+    let mut query = sqlx::query(&sql);
+    for root_id in &root_ids {
+        query = query.bind(*root_id);
+    }
+    query = query.bind(channel_id);
+    let rows = query.fetch_all(pool).await.map_err(to_string)?;
+    let messages = messages_from_rows(pool, rows, include_artifact_content).await?;
+
+    Ok(ChannelMessagePage {
+        messages,
+        next_before_seq,
+        has_more,
+    })
+}
+
+pub(crate) fn channel_message_history_from_messages(
+    messages: &[Message],
+    per_channel_limit: i64,
+) -> Vec<ChannelMessageHistory> {
+    let limit = per_channel_limit.max(0) as usize;
+    if limit == 0 {
+        return Vec::new();
+    }
+    let mut roots_by_channel: HashMap<Uuid, Vec<i64>> = HashMap::new();
+    for message in messages
+        .iter()
+        .filter(|message| message.thread_root_id.is_none())
+    {
+        roots_by_channel
+            .entry(message.channel_id)
+            .or_default()
+            .push(message.seq);
+    }
+    let mut history = roots_by_channel
+        .into_iter()
+        .map(|(channel_id, mut root_seqs)| {
+            root_seqs.sort_unstable_by(|left, right| right.cmp(left));
+            let may_have_more = root_seqs.len() >= limit;
+            ChannelMessageHistory {
+                channel_id,
+                before_seq: may_have_more.then(|| root_seqs[limit - 1]),
+                has_more: may_have_more,
+            }
+        })
+        .collect::<Vec<_>>();
+    history.sort_unstable_by_key(|entry| entry.channel_id);
+    history
+}
+
 enum MessageLoadScope {
     All,
     RecentPerChannel(i64),
@@ -59,6 +210,7 @@ async fn load_messages_with_scope(
             r#"
             select
                 m.id,
+                m.seq,
                 m.channel_id,
                 m.thread_root_id,
                 m.sender_agent_id,
@@ -75,21 +227,31 @@ async fn load_messages_with_scope(
                 m.updated_at
             from messages m
             left join tasks t on t.message_id = m.id
-            order by julianday(m.created_at) asc, m.created_at asc
+            order by m.seq asc
             "#,
             None,
         ),
         MessageLoadScope::RecentPerChannel(limit) => (
             r#"
-            with ranked_messages as (
+            with ranked_recent_messages as (
                 select
                     id,
                     thread_root_id,
                     row_number() over (
                         partition by channel_id
-                        order by julianday(created_at) desc, created_at desc
+                        order by seq desc
                     ) as message_rank
                 from messages
+            ),
+            ranked_root_messages as (
+                select
+                    id,
+                    row_number() over (
+                        partition by channel_id
+                        order by seq desc
+                    ) as message_rank
+                from messages
+                where thread_root_id is null
             ),
             recent_work_items as (
                 select source_message_id, thread_root_id
@@ -99,7 +261,11 @@ async fn load_messages_with_scope(
             ),
             base_selected_message_ids as (
                 select id
-                from ranked_messages
+                from ranked_recent_messages
+                where message_rank <= $1
+                union
+                select id
+                from ranked_root_messages
                 where message_rank <= $1
                 union
                 select message_id from saved_messages
@@ -110,7 +276,7 @@ async fn load_messages_with_scope(
                 union
                 select thread_root_id from recent_work_items where thread_root_id is not null
             ),
-            selected_message_ids as (
+            selected_thread_root_ids as (
                 select id
                 from base_selected_message_ids
                 where id is not null
@@ -119,9 +285,18 @@ async fn load_messages_with_scope(
                 from messages m
                 join base_selected_message_ids selected on selected.id = m.id
                 where m.thread_root_id is not null
+            ),
+            selected_message_ids as (
+                select id
+                from selected_thread_root_ids
+                union
+                select m.id
+                from messages m
+                join selected_thread_root_ids selected on selected.id = m.thread_root_id
             )
             select
                 m.id,
+                m.seq,
                 m.channel_id,
                 m.thread_root_id,
                 m.sender_agent_id,
@@ -139,7 +314,7 @@ async fn load_messages_with_scope(
             from messages m
             left join tasks t on t.message_id = m.id
             where m.id in (select id from selected_message_ids)
-            order by julianday(m.created_at) asc, m.created_at asc
+            order by m.seq asc
             "#,
             Some(limit),
         ),
@@ -150,10 +325,19 @@ async fn load_messages_with_scope(
     }
     let rows = query.fetch_all(pool).await.map_err(to_string)?;
 
+    messages_from_rows(pool, rows, include_artifact_content).await
+}
+
+async fn messages_from_rows(
+    pool: &SqlitePool,
+    rows: Vec<SqliteRow>,
+    include_artifact_content: bool,
+) -> CommandResult<Vec<Message>> {
     let mut messages: Vec<Message> = rows
         .into_iter()
         .map(|row| Message {
             id: row.get("id"),
+            seq: row.get("seq"),
             channel_id: row.get("channel_id"),
             thread_root_id: row.get("thread_root_id"),
             sender_agent_id: row.get("sender_agent_id"),
@@ -223,6 +407,7 @@ pub(crate) async fn load_message(pool: &SqlitePool, message_id: Uuid) -> Command
         r#"
         select
             m.id,
+            m.seq,
             m.channel_id,
             m.thread_root_id,
             m.sender_agent_id,
@@ -249,6 +434,7 @@ pub(crate) async fn load_message(pool: &SqlitePool, message_id: Uuid) -> Command
 
     let mut message = Message {
         id: row.get("id"),
+        seq: row.get("seq"),
         channel_id: row.get("channel_id"),
         thread_root_id: row.get("thread_root_id"),
         sender_agent_id: row.get("sender_agent_id"),
@@ -949,7 +1135,10 @@ async fn attach_message_artifacts(
 mod tests {
     use crate::test_support::{drop_test_schema, insert_test_channel, test_pool};
 
-    use super::{load_messages, load_recent_messages_per_channel};
+    use super::{
+        channel_message_history_from_messages, load_messages, load_older_channel_messages,
+        load_older_channel_messages_without_artifact_content, load_recent_messages_per_channel,
+    };
 
     #[tokio::test]
     async fn recent_messages_per_channel_keeps_limited_replies_and_their_roots() {
@@ -998,8 +1187,310 @@ mod tests {
 
             let recent = load_recent_messages_per_channel(&pool, 2).await?;
             let bodies: Vec<&str> = recent.iter().map(|message| message.body.as_str()).collect();
-            assert_eq!(bodies, vec!["old root", "reply 2", "reply 3"]);
+            assert_eq!(bodies, vec!["old root", "reply 1", "reply 2", "reply 3"]);
             assert!(recent.iter().any(|message| message.id == root_id));
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn recent_messages_per_channel_keeps_limited_root_timeline_messages() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let channel_id = insert_test_channel(&pool, "recent-root-messages").await?;
+            let _old_root_id: uuid::Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (
+                    channel_id, sender_name, sender_role, body, is_task, created_at
+                )
+                values ($1, 'Dylan', 'owner', 'old root', false, '2026-01-01T00:00:00.000+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let middle_root_id: uuid::Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (
+                    channel_id, sender_name, sender_role, body, is_task, created_at
+                )
+                values ($1, 'Dylan', 'owner', 'middle root', false, '2026-01-01T00:00:01.000+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let newest_root_id: uuid::Uuid = sqlx::query_scalar(
+                r#"
+                insert into messages (
+                    channel_id, sender_name, sender_role, body, is_task, created_at
+                )
+                values ($1, 'Dylan', 'owner', 'newest root', false, '2026-01-01T00:00:02.000+00:00')
+                returning id
+                "#,
+            )
+            .bind(channel_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            for index in 1..=5 {
+                sqlx::query(
+                    r#"
+                    insert into messages (
+                        channel_id, thread_root_id, sender_name, sender_role, body, is_task, created_at
+                    )
+                    values (
+                        $1, $2, 'agent', 'agent', $3, false,
+                        printf('2026-01-01T00:00:0%d.000+00:00', $4)
+                    )
+                    "#,
+                )
+                .bind(channel_id)
+                .bind(newest_root_id)
+                .bind(format!("reply {index}"))
+                .bind(index + 2)
+                .execute(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+            }
+
+            let recent = load_recent_messages_per_channel(&pool, 2).await?;
+            let bodies: Vec<&str> = recent.iter().map(|message| message.body.as_str()).collect();
+            assert!(bodies.contains(&"middle root"));
+            assert!(bodies.contains(&"newest root"));
+            assert!(bodies.contains(&"reply 4"));
+            assert!(bodies.contains(&"reply 5"));
+            assert!(!bodies.contains(&"old root"));
+            assert!(recent.iter().any(|message| message.id == middle_root_id));
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn older_channel_messages_uses_seq_cursor_and_omits_web_artifact_content() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let channel_id = insert_test_channel(&pool, "older-channel-messages").await?;
+            let mut roots = Vec::new();
+            for index in 1..=4 {
+                let id: uuid::Uuid = sqlx::query_scalar(
+                    r#"
+                    insert into messages (
+                        channel_id, sender_name, sender_role, body, is_task, created_at
+                    )
+                    values ($1, 'Dylan', 'owner', $2, false, '2026-01-01T00:00:00.000+00:00')
+                    returning id
+                    "#,
+                )
+                .bind(channel_id)
+                .bind(format!("root {index}"))
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+                let seq: i64 = sqlx::query_scalar("select seq from messages where id = $1")
+                    .bind(id)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|err| err.to_string())?;
+                roots.push((id, seq));
+            }
+            for index in 1..=2 {
+                sqlx::query(
+                    r#"
+                    insert into messages (
+                        channel_id, thread_root_id, sender_name, sender_role, body, is_task,
+                        created_at
+                    )
+                    values (
+                        $1, $2, 'agent', 'agent', $3, false,
+                        '2026-01-01T00:00:00.000+00:00'
+                    )
+                    "#,
+                )
+                .bind(channel_id)
+                .bind(roots[1].0)
+                .bind(format!("root 2 reply {index}"))
+                .execute(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+            }
+            sqlx::query(
+                r#"
+                insert into artifacts (
+                    message_id, channel_id, kind, title, summary, content, metadata
+                )
+                values ($1, $2, 'markdown', 'history artifact', 'artifact summary',
+                        'large historical content', '{}')
+                "#,
+            )
+            .bind(roots[1].0)
+            .bind(channel_id)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let first_page = load_older_channel_messages(&pool, channel_id, roots[3].1, 2).await?;
+            let first_page_roots = first_page
+                .messages
+                .iter()
+                .filter(|message| message.thread_root_id.is_none())
+                .map(|message| message.body.as_str())
+                .collect::<Vec<_>>();
+            assert_eq!(first_page_roots, vec!["root 2", "root 3"]);
+            assert_eq!(first_page.next_before_seq, Some(roots[1].1));
+            assert!(first_page.has_more);
+            assert!(first_page
+                .messages
+                .iter()
+                .any(|message| message.body == "root 2 reply 1"));
+            let artifact = &first_page
+                .messages
+                .iter()
+                .find(|message| message.id == roots[1].0)
+                .expect("root 2 should be present")
+                .artifacts[0];
+            assert_eq!(artifact.content, "large historical content");
+
+            let web_page = load_older_channel_messages_without_artifact_content(
+                &pool, channel_id, roots[3].1, 2,
+            )
+            .await?;
+            let web_artifact = &web_page
+                .messages
+                .iter()
+                .find(|message| message.id == roots[1].0)
+                .expect("root 2 should be present in web page")
+                .artifacts[0];
+            assert_eq!(web_artifact.title, "history artifact");
+            assert!(web_artifact.content.is_empty());
+
+            let second_page = load_older_channel_messages(
+                &pool,
+                channel_id,
+                first_page.next_before_seq.expect("first page cursor"),
+                2,
+            )
+            .await?;
+            let second_page_roots = second_page
+                .messages
+                .iter()
+                .filter(|message| message.thread_root_id.is_none())
+                .map(|message| message.body.as_str())
+                .collect::<Vec<_>>();
+            assert_eq!(second_page_roots, vec!["root 1"]);
+            assert!(!second_page.has_more);
+
+            let loaded_root_ids = first_page
+                .messages
+                .iter()
+                .chain(second_page.messages.iter())
+                .filter(|message| message.thread_root_id.is_none())
+                .map(|message| message.id)
+                .collect::<std::collections::HashSet<_>>();
+            assert_eq!(loaded_root_ids.len(), 3);
+            assert!(loaded_root_ids.contains(&roots[0].0));
+            assert!(loaded_root_ids.contains(&roots[1].0));
+            assert!(loaded_root_ids.contains(&roots[2].0));
+            Ok(())
+        }
+        .await;
+        drop_test_schema(pool, schema).await;
+        result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn channel_history_cursor_ignores_contextual_old_roots() {
+        let Some((pool, schema)) = test_pool().await else {
+            return;
+        };
+        let result: Result<(), String> = async {
+            let channel_id = insert_test_channel(&pool, "history-cursor").await?;
+            let mut roots = Vec::new();
+            for index in 1..=100 {
+                let id: uuid::Uuid = sqlx::query_scalar(
+                    r#"
+                    insert into messages (
+                        channel_id, sender_name, sender_role, body, is_task, created_at
+                    )
+                    values ($1, 'Dylan', 'owner', $2, false, '2026-01-01T00:00:00.000+00:00')
+                    returning id
+                    "#,
+                )
+                .bind(channel_id)
+                .bind(format!("root {index}"))
+                .fetch_one(&pool)
+                .await
+                .map_err(|err| err.to_string())?;
+                let seq: i64 = sqlx::query_scalar("select seq from messages where id = $1")
+                    .bind(id)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|err| err.to_string())?;
+                roots.push((id, seq));
+            }
+            sqlx::query(
+                r#"
+                insert into messages (
+                    channel_id, thread_root_id, sender_name, sender_role, body, is_task,
+                    created_at
+                )
+                values (
+                    $1, $2, 'agent', 'agent', 'recent reply on root 1', false,
+                    '2026-01-01T00:00:00.000+00:00'
+                )
+                "#,
+            )
+            .bind(channel_id)
+            .bind(roots[0].0)
+            .execute(&pool)
+            .await
+            .map_err(|err| err.to_string())?;
+
+            let recent = load_recent_messages_per_channel(&pool, 80).await?;
+            assert!(recent.iter().any(|message| message.id == roots[0].0));
+            let history = channel_message_history_from_messages(&recent, 80);
+            let channel_history = history
+                .iter()
+                .find(|entry| entry.channel_id == channel_id)
+                .expect("history cursor should be returned");
+            assert_eq!(channel_history.before_seq, Some(roots[20].1));
+            assert!(channel_history.has_more);
+            assert_ne!(channel_history.before_seq, Some(roots[0].1));
+
+            let page = load_older_channel_messages(
+                &pool,
+                channel_id,
+                channel_history.before_seq.expect("history cursor"),
+                40,
+            )
+            .await?;
+            let page_root_ids = page
+                .messages
+                .iter()
+                .filter(|message| message.thread_root_id.is_none())
+                .map(|message| message.id)
+                .collect::<std::collections::HashSet<_>>();
+            assert!(page_root_ids.contains(&roots[19].0));
+            assert!(page_root_ids.contains(&roots[1].0));
+            assert!(page_root_ids.contains(&roots[0].0));
+            assert_eq!(page_root_ids.len(), 20);
             Ok(())
         }
         .await;

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -100,6 +100,7 @@ pub(crate) struct ChannelMember {
 #[derive(Debug, Serialize)]
 pub(crate) struct Message {
     pub(crate) id: Uuid,
+    pub(crate) seq: i64,
     pub(crate) channel_id: Uuid,
     pub(crate) thread_root_id: Option<Uuid>,
     pub(crate) sender_agent_id: Option<Uuid>,
@@ -116,6 +117,20 @@ pub(crate) struct Message {
     pub(crate) artifacts: Vec<Artifact>,
     pub(crate) created_at: DateTime<Utc>,
     pub(crate) updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ChannelMessageHistory {
+    pub(crate) channel_id: Uuid,
+    pub(crate) before_seq: Option<i64>,
+    pub(crate) has_more: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ChannelMessagePage {
+    pub(crate) messages: Vec<Message>,
+    pub(crate) next_before_seq: Option<i64>,
+    pub(crate) has_more: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -399,6 +414,7 @@ pub(crate) struct Bootstrap {
     pub(crate) channel_members: Vec<ChannelMember>,
     pub(crate) agents: Vec<Agent>,
     pub(crate) messages: Vec<Message>,
+    pub(crate) channel_message_history: Vec<ChannelMessageHistory>,
     pub(crate) saved_messages: Vec<SavedMessage>,
     pub(crate) dismissed_inbox_items: HashMap<String, DateTime<Utc>>,
     pub(crate) read_inbox_items: HashMap<String, DateTime<Utc>>,

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -43,7 +43,10 @@ use crate::channels::{
 use crate::domain::reminders::complete_reminder_in_pool;
 use crate::launch_agent;
 use crate::lifecycle_commands::start_agent_in_pool;
-use crate::message_store::{load_artifact, send_owner_message_in_pool, set_message_saved_in_pool};
+use crate::message_store::{
+    load_artifact, load_older_channel_messages_without_artifact_content,
+    send_owner_message_in_pool, set_message_saved_in_pool,
+};
 use crate::models::AttachmentUpload;
 use crate::owner_inbox::{
     dismiss_inbox_items_in_pool, mark_all_owner_inbox_read_in_pool, mark_channel_read_in_pool,
@@ -78,6 +81,14 @@ struct SendMessageRequest {
     body: String,
     as_task: bool,
     attachments: Option<Vec<AttachmentUpload>>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LoadOlderChannelMessagesRequest {
+    channel_id: Uuid,
+    before_seq: i64,
+    limit: i64,
 }
 
 #[derive(Deserialize)]
@@ -304,6 +315,10 @@ fn web_router(state: Arc<WebState>, dist_dir: PathBuf) -> Router {
             "/api/send_message",
             post(api_send_message).layer(DefaultBodyLimit::max(WEB_SEND_MESSAGE_BODY_LIMIT)),
         )
+        .route(
+            "/api/load_older_channel_messages",
+            post(api_load_older_channel_messages).layer(CompressionLayer::new()),
+        )
         .route("/api/create_channel", post(api_create_channel))
         .route("/api/update_channel", post(api_update_channel))
         .route("/api/delete_channel", post(api_delete_channel))
@@ -425,6 +440,21 @@ async fn api_send_message(
         &request.body,
         request.as_task,
         request.attachments.unwrap_or_default(),
+    )
+    .await
+    .map(Json)
+    .map_err(api_error)
+}
+
+async fn api_load_older_channel_messages(
+    State(state): State<Arc<WebState>>,
+    Json(request): Json<LoadOlderChannelMessagesRequest>,
+) -> Result<impl IntoResponse, Response> {
+    load_older_channel_messages_without_artifact_content(
+        &state.pool,
+        request.channel_id,
+        request.before_seq,
+        request.limit,
     )
     .await
     .map(Json)

--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -93,6 +93,9 @@ type ConversationProps = {
   savedMessageIds: Set<string>;
   focusedMessageId: string | null;
   showImageThumbnails: boolean;
+  hasMoreRootMessages: boolean;
+  isLoadingOlderRootMessages: boolean;
+  onLoadOlderRootMessages: () => Promise<void>;
   onToggleMessageSaved: (message: Message, saved: boolean) => void;
 };
 
@@ -115,6 +118,7 @@ const MESSAGE_CARD_INTERACTIVE_TARGET_SELECTOR = [
   ".message-artifacts",
   ".message-attachments",
 ].join(",");
+const LOAD_OLDER_SCROLL_TOP_PX = 96;
 
 function taskStatusLabel(status: string) {
   return status.replace("_", " ");
@@ -265,6 +269,9 @@ export function Conversation({
   savedMessageIds,
   focusedMessageId,
   showImageThumbnails,
+  hasMoreRootMessages,
+  isLoadingOlderRootMessages,
+  onLoadOlderRootMessages,
   onToggleMessageSaved,
 }: ConversationProps) {
   const [showChannelActions, setShowChannelActions] = useState(false);
@@ -281,6 +288,8 @@ export function Conversation({
   const userMessageScrollUntilRef = useRef(0);
   const messageListFollowSuppressUntilRef = useRef(0);
   const messageListMetricsRef = useRef({ scrollHeight: 0, scrollTop: 0, clientHeight: 0 });
+  const olderMessagesLoadInFlightRef = useRef(false);
+  const messageListContextEpochRef = useRef(0);
   const channelActionsRef = useRef<HTMLDivElement | null>(null);
   const isDm = channel?.kind === "dm";
   const dmAgent = isDm ? agents.find((agent) => agent.id === channel?.dm_agent_id) ?? null : null;
@@ -545,6 +554,39 @@ export function Conversation({
     const element = messageListRef.current;
     if (!element) return;
     if (shouldSuppressMessageListFollow(element)) return;
+    if (
+      activeTab === "chat" &&
+      channel &&
+      rootMessages.length > 0 &&
+      hasMoreRootMessages &&
+      !isLoadingOlderRootMessages &&
+      !olderMessagesLoadInFlightRef.current &&
+      element.scrollTop <= LOAD_OLDER_SCROLL_TOP_PX
+    ) {
+      const contextEpoch = messageListContextEpochRef.current;
+      const messageList = element;
+      const previousScrollHeight = element.scrollHeight;
+      stopFollowingMessages(element);
+      olderMessagesLoadInFlightRef.current = true;
+      void onLoadOlderRootMessages()
+        .finally(() => {
+          if (messageListContextEpochRef.current !== contextEpoch) return;
+          olderMessagesLoadInFlightRef.current = false;
+          window.requestAnimationFrame(() => {
+            if (
+              messageListContextEpochRef.current !== contextEpoch
+              || messageListRef.current !== messageList
+            ) return;
+            const list = messageListRef.current;
+            if (!list) return;
+            const heightDelta = list.scrollHeight - previousScrollHeight;
+            if (heightDelta > 0) {
+              list.scrollTop += heightDelta;
+            }
+            rememberMessageListMetrics(list);
+          });
+        });
+    }
     const atBottom = isMessageListAtBottom(element);
     const layoutChanged =
       messageListMetricsRef.current.scrollHeight !== element.scrollHeight
@@ -702,6 +744,11 @@ export function Conversation({
     shouldFollowMessagesRef.current = true;
     scrollMessagesToBottom();
   }, [channel?.id]);
+
+  useLayoutEffect(() => {
+    messageListContextEpochRef.current += 1;
+    olderMessagesLoadInFlightRef.current = false;
+  }, [activeTab, channel?.id]);
 
   useEffect(() => () => {
     if (bottomScrollFrameRef.current !== null) window.cancelAnimationFrame(bottomScrollFrameRef.current);
@@ -982,8 +1029,14 @@ export function Conversation({
             <div ref={messageListContentRef} className="message-list-content">
               {channel ? (
                 rootMessages.length > 0 ? (
-                  <div className="beginning">
-                    {isDm ? `Beginning of your DM with @${dmAgent?.handle || "agent"}` : `Beginning of #${channel.name}`}
+                  <div className="beginning" aria-live="polite">
+                    {hasMoreRootMessages
+                      ? isLoadingOlderRootMessages
+                        ? "Loading earlier messages..."
+                        : "Earlier messages available"
+                      : isDm
+                        ? `Beginning of your DM with @${dmAgent?.handle || "agent"}`
+                        : `Beginning of #${channel.name}`}
                   </div>
                 ) : (
                   <div className="empty-state">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -46,6 +46,7 @@ import {
   Artifact,
   Bootstrap,
   Channel,
+  ChannelMessagePage,
   ChannelMember,
   DraftAttachment,
   EMPTY_AGENT_FORM,
@@ -170,6 +171,7 @@ const EPHEMERAL_FLUSH_FALLBACK_MS = 80;
 const MIN_BOOT_SPLASH_MS = 3000;
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 const ACTIVITY_HISTORY_LIMIT_PER_AGENT = 80;
+const OLDER_CHANNEL_MESSAGES_PAGE_SIZE = 40;
 // Issue #82: run states that must bypass the ephemeral coalescing buffer
 // so terminal transitions land immediately. "stopped" is included to
 // match runtime supervisor terminology even if it is rare in practice.
@@ -844,7 +846,15 @@ function App() {
   const [dismissedActivityFeedItems, setDismissedActivityFeedItems] = useState<Record<string, string>>({});
   const [readActivityFeedItems, setReadActivityFeedItems] = useState<Record<string, string>>({});
   const [locallyUnfollowedThreadIds, setLocallyUnfollowedThreadIds] = useState<Set<string>>(() => new Set());
+  const [loadingOlderChannelIds, setLoadingOlderChannelIds] = useState<Set<string>>(() => new Set());
+  const [exhaustedOlderChannelIds, setExhaustedOlderChannelIds] = useState<Set<string>>(() => new Set());
   const knownMessageIdsRef = useRef<Set<string> | null>(null);
+  const loadedHistoricalMessageIdsRef = useRef<Set<string>>(new Set());
+  const paginatedChannelIdsRef = useRef<Set<string>>(new Set());
+  const initializedOlderChannelIdsRef = useRef<Set<string>>(new Set());
+  const olderChannelBeforeSeqRef = useRef<Map<string, number>>(new Map());
+  const loadingOlderChannelIdsRef = useRef<Set<string>>(new Set());
+  const olderChannelRequestEpochRef = useRef<Map<string, number>>(new Map());
   const refreshTimerRef = useRef<number | null>(null);
   const refreshInFlightRef = useRef(false);
   const refreshQueuedRef = useRef(false);
@@ -948,15 +958,86 @@ function App() {
   }
 
   function sortedMessages(messages: Message[]) {
-    return [...messages].sort((left, right) => new Date(left.created_at).getTime() - new Date(right.created_at).getTime());
+    return [...messages].sort((left, right) => {
+      const leftSeq = Number.isSafeInteger(left.seq) && left.seq > 0 ? left.seq : Number.MAX_SAFE_INTEGER;
+      const rightSeq = Number.isSafeInteger(right.seq) && right.seq > 0 ? right.seq : Number.MAX_SAFE_INTEGER;
+      if (leftSeq !== rightSeq) return leftSeq - rightSeq;
+      return new Date(left.created_at).getTime() - new Date(right.created_at).getTime();
+    });
+  }
+
+  function mergedSortedMessages(current: Message[], incoming: Message[]) {
+    if (incoming.length === 0) return current;
+    const messagesById = new Map(current.map((message) => [message.id, message]));
+    for (const message of incoming) {
+      messagesById.set(message.id, message);
+    }
+    return sortedMessages(Array.from(messagesById.values()));
   }
 
   function normalizeBootstrap(next: Bootstrap): Bootstrap {
     return {
       ...next,
       messages: sortedMessages(next.messages),
+      channel_message_history: next.channel_message_history ?? [],
       agent_activities: limitActivitiesPerAgent(next.agent_activities),
     };
+  }
+
+  function initializeChannelMessageHistory(next: Bootstrap) {
+    const availableChannelIds = new Set(next.channels.map((channel) => channel.id));
+    for (const channelId of Array.from(olderChannelBeforeSeqRef.current.keys())) {
+      if (!availableChannelIds.has(channelId)) olderChannelBeforeSeqRef.current.delete(channelId);
+    }
+    for (const channelId of Array.from(initializedOlderChannelIdsRef.current)) {
+      if (!availableChannelIds.has(channelId)) initializedOlderChannelIdsRef.current.delete(channelId);
+    }
+    for (const channelId of Array.from(paginatedChannelIdsRef.current)) {
+      if (!availableChannelIds.has(channelId)) paginatedChannelIdsRef.current.delete(channelId);
+    }
+    let removedLoadingChannel = false;
+    for (const channelId of Array.from(loadingOlderChannelIdsRef.current)) {
+      if (availableChannelIds.has(channelId)) continue;
+      loadingOlderChannelIdsRef.current.delete(channelId);
+      olderChannelRequestEpochRef.current.set(
+        channelId,
+        (olderChannelRequestEpochRef.current.get(channelId) ?? 0) + 1,
+      );
+      removedLoadingChannel = true;
+    }
+    if (removedLoadingChannel) {
+      setLoadingOlderChannelIds((current) => {
+        const filtered = new Set(Array.from(current).filter((channelId) => availableChannelIds.has(channelId)));
+        return filtered.size === current.size ? current : filtered;
+      });
+    }
+
+    const newlyExhaustedChannelIds = new Set<string>();
+    const newlyAvailableChannelIds = new Set<string>();
+    for (const history of next.channel_message_history) {
+      if (initializedOlderChannelIdsRef.current.has(history.channel_id)) continue;
+      initializedOlderChannelIdsRef.current.add(history.channel_id);
+      if (history.has_more && history.before_seq !== null) {
+        olderChannelBeforeSeqRef.current.set(history.channel_id, history.before_seq);
+        newlyAvailableChannelIds.add(history.channel_id);
+      } else {
+        paginatedChannelIdsRef.current.add(history.channel_id);
+        newlyExhaustedChannelIds.add(history.channel_id);
+      }
+    }
+    setExhaustedOlderChannelIds((current) => {
+      const exhausted = new Set(Array.from(current).filter((channelId) => availableChannelIds.has(channelId)));
+      let changed = exhausted.size !== current.size;
+      for (const channelId of newlyAvailableChannelIds) {
+        if (exhausted.delete(channelId)) changed = true;
+      }
+      for (const channelId of newlyExhaustedChannelIds) {
+        if (exhausted.has(channelId)) continue;
+        exhausted.add(channelId);
+        changed = true;
+      }
+      return changed ? exhausted : current;
+    });
   }
 
   function invalidatePendingRefreshResult() {
@@ -991,6 +1072,7 @@ function App() {
     const refreshed = withPendingSavedToggles(
       includeOptimistic ? withOptimisticChannels(withOptimisticMessages(next)) : next,
     );
+    initializeChannelMessageHistory(refreshed);
     if (perf) {
       perf.counts = {
         channels: refreshed.channels.length,
@@ -1002,9 +1084,22 @@ function App() {
       };
     }
     setData((current) => {
-      if (!current || refreshInvalidation === refreshInvalidationRef.current) return refreshed;
+      if (!current) return refreshed;
       const refreshedMessageIds = new Set(refreshed.messages.map((message) => message.id));
-      const currentOnlyMessages = current.messages.filter((message) => !refreshedMessageIds.has(message.id));
+      const refreshedChannelIds = new Set(refreshed.channels.map((channel) => channel.id));
+      let currentOnlyMessages = current.messages.filter((message) => !refreshedMessageIds.has(message.id));
+      if (refreshInvalidation === refreshInvalidationRef.current) {
+        currentOnlyMessages = currentOnlyMessages.filter((message) => (
+          refreshedChannelIds.has(message.channel_id)
+          && (loadedHistoricalMessageIdsRef.current.has(message.id)
+            || paginatedChannelIdsRef.current.has(message.channel_id))
+        ));
+        for (const message of currentOnlyMessages) {
+          loadedHistoricalMessageIdsRef.current.add(message.id);
+        }
+      } else {
+        currentOnlyMessages = currentOnlyMessages.filter((message) => refreshedChannelIds.has(message.channel_id));
+      }
       if (currentOnlyMessages.length === 0) return refreshed;
       return {
         ...refreshed,
@@ -1021,11 +1116,6 @@ function App() {
       }
       if (channels.some((item) => item.id === prev)) return prev;
       return channels[0]?.id || "";
-    });
-    setActiveThreadId((prev) => {
-      const rootIds = new Set(next.messages.filter((item) => !item.thread_root_id).map((item) => item.id));
-      if (prev && rootIds.has(prev)) return prev;
-      return null;
     });
     const applyEndedAt = performance.now();
     if (perf) {
@@ -1062,6 +1152,84 @@ function App() {
       refreshTimerRef.current = null;
       refreshWithError(fallback);
     }, UI_REFRESH_DEBOUNCE_MS);
+  }
+
+  async function loadOlderRootMessages(channelId: string) {
+    const beforeSeq = olderChannelBeforeSeqRef.current.get(channelId);
+    if (
+      isTauriRuntime()
+      || beforeSeq === undefined
+      || loadingOlderChannelIdsRef.current.has(channelId)
+      || exhaustedOlderChannelIds.has(channelId)
+    ) {
+      return;
+    }
+    const requestEpoch = (olderChannelRequestEpochRef.current.get(channelId) ?? 0) + 1;
+    olderChannelRequestEpochRef.current.set(channelId, requestEpoch);
+    loadingOlderChannelIdsRef.current.add(channelId);
+    setLoadingOlderChannelIds((current) => new Set(current).add(channelId));
+    try {
+      const page = await apiInvoke<ChannelMessagePage>("load_older_channel_messages", {
+        channelId,
+        beforeSeq,
+        limit: OLDER_CHANNEL_MESSAGES_PAGE_SIZE,
+      });
+      if (olderChannelRequestEpochRef.current.get(channelId) !== requestEpoch) return;
+      if (page.has_more && page.next_before_seq !== null) {
+        olderChannelBeforeSeqRef.current.set(channelId, page.next_before_seq);
+      } else {
+        olderChannelBeforeSeqRef.current.delete(channelId);
+        setExhaustedOlderChannelIds((current) => new Set(current).add(channelId));
+      }
+      paginatedChannelIdsRef.current.add(channelId);
+      for (const message of page.messages) {
+        loadedHistoricalMessageIdsRef.current.add(message.id);
+        knownMessageIdsRef.current?.add(message.id);
+      }
+      if (page.messages.length > 0) {
+        setData((current) => {
+          if (!current || !current.channels.some((channel) => channel.id === channelId)) return current;
+          return { ...current, messages: mergedSortedMessages(current.messages, page.messages) };
+        });
+      }
+    } catch (err) {
+      if (olderChannelRequestEpochRef.current.get(channelId) === requestEpoch) {
+        setAppError(errorMessage(err, "Failed to load earlier messages"));
+        console.error(err);
+      }
+    } finally {
+      if (olderChannelRequestEpochRef.current.get(channelId) === requestEpoch) {
+        loadingOlderChannelIdsRef.current.delete(channelId);
+        setLoadingOlderChannelIds((current) => {
+          const next = new Set(current);
+          next.delete(channelId);
+          return next;
+        });
+      }
+    }
+  }
+
+  function clearChannelMessageHistory(channelId: string) {
+    olderChannelRequestEpochRef.current.set(
+      channelId,
+      (olderChannelRequestEpochRef.current.get(channelId) ?? 0) + 1,
+    );
+    olderChannelBeforeSeqRef.current.delete(channelId);
+    paginatedChannelIdsRef.current.delete(channelId);
+    initializedOlderChannelIdsRef.current.delete(channelId);
+    loadingOlderChannelIdsRef.current.delete(channelId);
+    setLoadingOlderChannelIds((current) => {
+      if (!current.has(channelId)) return current;
+      const next = new Set(current);
+      next.delete(channelId);
+      return next;
+    });
+    setExhaustedOlderChannelIds((current) => {
+      if (!current.has(channelId)) return current;
+      const next = new Set(current);
+      next.delete(channelId);
+      return next;
+    });
   }
 
   function applyMessageUpsert(message: Message) {
@@ -1128,6 +1296,7 @@ function App() {
       thread_activities: next.thread_activities.filter((item) => !channelIds.has(item.channel_id)),
       channel_members: next.channel_members.filter((item) => !channelIds.has(item.channel_id)),
       messages: next.messages.filter((item) => !channelIds.has(item.channel_id)),
+      channel_message_history: next.channel_message_history.filter((item) => !channelIds.has(item.channel_id)),
       saved_messages: next.saved_messages.filter((item) => !channelIds.has(item.channel_id)),
       artifacts: next.artifacts.filter((item) => !channelIds.has(item.channel_id)),
       tasks: next.tasks.filter((item) => !channelIds.has(item.channel_id)),
@@ -1220,7 +1389,19 @@ function App() {
         requestRefresh(`Failed to refresh ${APP_DISPLAY_NAME} state after message deletion`);
         return current;
       }
-      return { ...current, messages: current.messages.filter((item) => item.id !== messageId) };
+      const deletedMessageIds = current.messages
+        .filter((message) => message.id === messageId || message.thread_root_id === messageId)
+        .map((message) => message.id);
+      for (const deletedMessageId of deletedMessageIds) {
+        loadedHistoricalMessageIdsRef.current.delete(deletedMessageId);
+        knownMessageIdsRef.current?.delete(deletedMessageId);
+      }
+      return {
+        ...current,
+        messages: current.messages.filter((message) => (
+          message.id !== messageId && message.thread_root_id !== messageId
+        )),
+      };
     });
   }
 
@@ -2178,8 +2359,27 @@ function App() {
     if (!channel) return [];
     return visibleMessages.filter((m) => m.channel_id === channel.id && !m.thread_root_id);
   }, [visibleMessages, channel]);
+  const hasMoreRootMessages = Boolean(
+    channel &&
+    !isTauriRuntime() &&
+    olderChannelBeforeSeqRef.current.has(channel.id) &&
+    !exhaustedOlderChannelIds.has(channel.id),
+  );
+  const isLoadingOlderRootMessages = Boolean(channel && loadingOlderChannelIds.has(channel.id));
 
   const activeRoot = activeThreadId ? rootMessages.find((m) => m.id === activeThreadId) ?? null : null;
+
+  useEffect(() => {
+    if (!data || !activeChannelId || !activeThreadId) return;
+    const rootExists = data.messages.some((message) => (
+      message.id === activeThreadId
+      && message.channel_id === activeChannelId
+      && !message.thread_root_id
+    ));
+    if (rootExists) return;
+    setActiveThreadId(null);
+    rememberChannelThread(activeChannelId, null);
+  }, [activeChannelId, activeThreadId, data]);
 
   const replies = useMemo(() => {
     if (!activeRoot) return [];
@@ -2863,8 +3063,17 @@ function App() {
         }
         optimisticChannelsRef.current.delete(channelToDelete.id);
         optimisticRemovedChannelsRef.current.add(channelToDelete.id);
+        clearChannelMessageHistory(channelToDelete.id);
         invalidatePendingRefreshResult();
-        setData((current) => current ? bootstrapWithoutChannels(current, optimisticRemovedChannelsRef.current) : current);
+        setData((current) => {
+          if (!current) return current;
+          for (const message of current.messages) {
+            if (message.channel_id !== channelToDelete.id) continue;
+            loadedHistoricalMessageIdsRef.current.delete(message.id);
+            knownMessageIdsRef.current?.delete(message.id);
+          }
+          return bootstrapWithoutChannels(current, optimisticRemovedChannelsRef.current);
+        });
         setShowChannelSettingsModal(false);
         forgetChannelThread(channelToDelete.id);
         if (activeChannelId === channelToDelete.id) {
@@ -3266,6 +3475,7 @@ function App() {
     const createdAt = new Date().toISOString();
     const optimisticMessage: Message = {
       id,
+      seq: 0,
       channel_id: channelId,
       thread_root_id: threadRootId,
       sender_agent_id: null,
@@ -4222,6 +4432,9 @@ function App() {
         savedMessageIds={savedMessageIds}
         focusedMessageId={focusedMessageId}
         showImageThumbnails={showImageThumbnails}
+        hasMoreRootMessages={hasMoreRootMessages}
+        isLoadingOlderRootMessages={isLoadingOlderRootMessages}
+        onLoadOlderRootMessages={() => channel ? loadOlderRootMessages(channel.id) : Promise.resolve()}
         onToggleMessageSaved={setMessageSaved}
       />
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export type ChannelMember = {
 
 export type Message = {
   id: string;
+  seq: number;
   channel_id: string;
   thread_root_id: string | null;
   sender_agent_id: string | null;
@@ -92,6 +93,18 @@ export type Message = {
   artifacts: Artifact[];
   created_at: string;
   updated_at: string;
+};
+
+export type ChannelMessageHistory = {
+  channel_id: string;
+  before_seq: number | null;
+  has_more: boolean;
+};
+
+export type ChannelMessagePage = {
+  messages: Message[];
+  next_before_seq: number | null;
+  has_more: boolean;
 };
 
 export type ThreadReplySummary = {
@@ -284,6 +297,7 @@ export type Bootstrap = {
   channel_members: ChannelMember[];
   agents: Agent[];
   messages: Message[];
+  channel_message_history: ChannelMessageHistory[];
   saved_messages: SavedMessage[];
   dismissed_inbox_items: Record<string, string>;
   read_inbox_items: Record<string, string>;


### PR DESCRIPTION
## Summary
- keep recent top-level channel root messages in web bootstrap so active thread replies do not hide the channel timeline
- add a web/Tauri load_older_channel_messages endpoint that pages older root messages and includes their replies
- load older channel history as the web message list is scrolled upward while preserving scroll position

## Tests
- cargo test message_store::tests::
- npm run build
- git diff --check