### PR TITLE
Render markdown artifacts in preview modal

### DIFF
--- a/src/components/ArtifactModal.tsx
+++ b/src/components/ArtifactModal.tsx
@@ -1,0 +1,45 @@
+import { ExternalLink } from "lucide-react";
+import { Artifact } from "../types";
+import { MessageMarkdown } from "./MessageMarkdown";
+import { Modal } from "./Modal";
+
+type ArtifactModalProps = {
+  artifact: Artifact | null;
+  onClose: () => void;
+  onOpenRaw: (artifact: Artifact) => void;
+};
+
+function ArtifactBody({ artifact }: { artifact: Artifact }) {
+  if (artifact.kind === "markdown") {
+    return <MessageMarkdown body={artifact.content} scrollKey={`artifact-modal:${artifact.id}`} />;
+  }
+
+  return <pre className="artifact-modal-raw">{artifact.content}</pre>;
+}
+
+export function ArtifactModal({ artifact, onClose, onOpenRaw }: ArtifactModalProps) {
+  return (
+    <Modal
+      open={Boolean(artifact)}
+      title={artifact?.title || "Artifact"}
+      onClose={onClose}
+      width={920}
+    >
+      {artifact && (
+        <div className="artifact-modal">
+          <div className="artifact-modal-meta">
+            <span>{artifact.kind} · artifact {artifact.id.slice(0, 8)}</span>
+            <button type="button" onClick={() => onOpenRaw(artifact)}>
+              <ExternalLink size={15} />
+              <span>Open raw</span>
+            </button>
+          </div>
+          {artifact.summary && <p className="artifact-modal-summary">{artifact.summary}</p>}
+          <div className="artifact-modal-content">
+            <ArtifactBody artifact={artifact} />
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,6 +21,7 @@ import { APP_DISPLAY_NAME } from "./branding";
 import { AgentDetailDrawer } from "./components/AgentDetailDrawer";
 import type { AgentPerformance } from "./components/AgentDetailDrawer";
 import { AgentFormModal } from "./components/AgentFormModal";
+import { ArtifactModal } from "./components/ArtifactModal";
 import { randomDylanAvatarSpec } from "./avatar-utils";
 import { ChannelAgentsModal } from "./components/ChannelAgentsModal";
 import { ChannelSettingsModal } from "./components/ChannelSettingsModal";
@@ -772,6 +773,7 @@ function App() {
   const [showSavedModal, setShowSavedModal] = useState(false);
   const [showOwnerProfileModal, setShowOwnerProfileModal] = useState(false);
   const [showSettingsModal, setShowSettingsModal] = useState(false);
+  const [openArtifactPreview, setOpenArtifactPreview] = useState<Artifact | null>(null);
   const [themePreference, setThemePreference] = useState<ThemePreference>(() => getStoredThemePreference());
   const [chatTextSize, setChatTextSize] = useState<ChatTextSize>(() => getStoredChatTextSize());
   const [fontPreset, setFontPreset] = useState<FontPreset>(() => getStoredFontPreset());
@@ -1690,13 +1692,17 @@ function App() {
   async function openArtifact(artifact: Artifact) {
     try {
       const fullArtifact = await apiInvoke<Artifact>("artifact_read", { artifactId: artifact.id });
-      const blob = new Blob([fullArtifact.content], { type: "text/plain;charset=utf-8" });
-      const url = URL.createObjectURL(blob);
-      window.open(url, "_blank", "noopener,noreferrer");
-      window.setTimeout(() => URL.revokeObjectURL(url), 30_000);
+      setOpenArtifactPreview(fullArtifact);
     } catch (err) {
       setAppError(errorMessage(err, "Failed to open artifact"));
     }
+  }
+
+  function openRawArtifact(artifact: Artifact) {
+    const blob = new Blob([artifact.content], { type: "text/plain;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    window.open(url, "_blank", "noopener,noreferrer");
+    window.setTimeout(() => URL.revokeObjectURL(url), 30_000);
   }
 
   function handleBackendEvent(payload: unknown) {
@@ -4490,6 +4496,12 @@ function App() {
         onFontPresetChange={setFontPreset}
         onShowImageThumbnailsChange={setShowImageThumbnails}
         onClose={() => setShowSettingsModal(false)}
+      />
+
+      <ArtifactModal
+        artifact={openArtifactPreview}
+        onClose={() => setOpenArtifactPreview(null)}
+        onOpenRaw={openRawArtifact}
       />
 
       <Conversation

--- a/src/styles.css
+++ b/src/styles.css
@@ -3785,6 +3785,52 @@ mark {
   white-space: pre-wrap;
 }
 
+.artifact-modal {
+  display: grid;
+  gap: 14px;
+}
+
+.artifact-modal-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--muted);
+  font-size: var(--type-size-caption);
+}
+
+.artifact-modal-meta button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: var(--type-size-caption);
+}
+
+.artifact-modal-meta button:hover {
+  border-color: var(--accent);
+}
+
+.artifact-modal-summary {
+  margin: 0;
+  color: var(--muted);
+}
+
+.artifact-modal-content {
+  min-width: 0;
+}
+
+.artifact-modal-raw {
+  margin: 0;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .attachment-meta {
   display: grid;
   width: 100%;


### PR DESCRIPTION
## Summary
- Open artifacts in an in-app preview modal instead of a raw text blob tab
- Render markdown artifacts with the existing MessageMarkdown component
- Keep an Open raw action for viewing the original artifact contents

## Testing
- npm run build