### PR TITLE
perf: batch GitHub refresh and cache commit comparisons

### DIFF
--- a/src-tauri/src/application/github.rs
+++ b/src-tauri/src/application/github.rs
@@ -74,6 +74,13 @@ pub(crate) async fn load_github_review_queue(
     load_cached_github_channel_overview(pool, request.channel_id).await
 }
 
+pub(crate) async fn load_github_review_comparisons(
+    pool: &SqlitePool,
+    request: GithubChannelRequest,
+) -> CommandResult<crate::github::GithubReviewComparisons> {
+    crate::github::load_github_review_comparisons(pool, request.channel_id).await
+}
+
 pub(crate) async fn refresh_github_review_queue(
     pool: &SqlitePool,
     request: GithubChannelRequest,
@@ -220,7 +227,7 @@ pub(crate) async fn rereview_github_pull_request(
         return Err("review task already anchors the current pull request head".to_owned());
     }
     let commits_ahead =
-        load_github_commits_ahead(&binding, &context.head_sha, pull_request.head_sha())
+        load_github_commits_ahead(pool, &binding, &context.head_sha, pull_request.head_sha())
             .await
             .ok();
     let dispatch = rereview_github_review_task_record(

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     github::{
         GithubChannelOverview, GithubIssueDetail, GithubIssueTaskResult, GithubRepositoryBinding,
-        GithubRereviewTaskResult, GithubReviewTaskResult,
+        GithubRereviewTaskResult, GithubReviewComparisons, GithubReviewTaskResult,
     },
 };
 
@@ -20,6 +20,15 @@ pub(crate) async fn load_github_review_queue(
     state: State<'_, AppState>,
 ) -> CommandResult<GithubChannelOverview> {
     application::load_github_review_queue(&state.pool, GithubChannelRequest { channel_id }).await
+}
+
+#[tauri::command]
+pub(crate) async fn load_github_review_comparisons(
+    channel_id: Uuid,
+    state: State<'_, AppState>,
+) -> CommandResult<GithubReviewComparisons> {
+    application::load_github_review_comparisons(&state.pool, GithubChannelRequest { channel_id })
+        .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -362,6 +362,15 @@ pub(crate) async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
         )
         "#,
         r#"
+        create table if not exists github_commit_comparisons (
+            repository_id text not null,
+            base_sha text not null,
+            head_sha text not null,
+            ahead_by integer not null check (ahead_by >= 0),
+            primary key (repository_id, base_sha, head_sha)
+        )
+        "#,
+        r#"
         create table if not exists github_issue_cache (
             channel_id blob not null references channels(id) on delete cascade,
             repository_id text not null,

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -16,6 +16,13 @@ use crate::{
     ui_notifications::{enqueue_ui_event_in_tx, UiEvent},
 };
 
+mod comparisons;
+mod pull_requests;
+
+pub(crate) use comparisons::{
+    load_github_commits_ahead, load_github_review_comparisons, GithubReviewComparisons,
+};
+
 const GITHUB_CLI_TIMEOUT: Duration = Duration::from_secs(30);
 const GITHUB_REVIEW_REQUEST_LIMIT: &str = "50";
 const GITHUB_AUTHORED_PULL_REQUEST_LIMIT: &str = "100";
@@ -253,7 +260,6 @@ struct GithubPullRequestSnapshot {
     checks: GithubCheckSummary,
     is_review_requested: bool,
     is_authored: bool,
-    review_commits_ahead: Option<i64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -309,20 +315,8 @@ pub(crate) struct GithubPullRequestDetail {
     number: i64,
     title: String,
     url: String,
-    author: Option<GithubActorCli>,
-    is_draft: bool,
     state: String,
-    updated_at: String,
     head_ref_oid: String,
-    #[serde(default)]
-    status_check_rollup: Vec<GithubStatusCheckCli>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct GithubCompareCli {
-    status: String,
-    ahead_by: i64,
 }
 
 impl GithubPullRequestDetail {
@@ -332,20 +326,6 @@ impl GithubPullRequestDetail {
 
     pub(crate) fn head_sha(&self) -> &str {
         &self.head_ref_oid
-    }
-
-    fn as_queue_item(&self) -> GithubPullRequestCli {
-        GithubPullRequestCli {
-            number: self.number,
-            title: self.title.clone(),
-            url: self.url.clone(),
-            author: self.author.clone(),
-            is_draft: self.is_draft,
-            state: self.state.clone(),
-            updated_at: self.updated_at.clone(),
-            head_ref_oid: self.head_ref_oid.clone(),
-            status_check_rollup: self.status_check_rollup.clone(),
-        }
     }
 }
 
@@ -802,7 +782,6 @@ fn merge_pull_request_snapshots(
                     checks,
                     is_review_requested: true,
                     is_authored: false,
-                    review_commits_ahead: None,
                 },
             )
         })
@@ -821,7 +800,6 @@ fn merge_pull_request_snapshots(
                 checks,
                 is_review_requested: false,
                 is_authored: true,
-                review_commits_ahead: None,
             });
     }
     let mut pull_requests = pull_requests.into_values().collect::<Vec<_>>();
@@ -970,28 +948,6 @@ async fn load_resource_links(
         .collect())
 }
 
-pub(crate) async fn load_github_commits_ahead(
-    binding: &GithubRepositoryBinding,
-    previous_head_sha: &str,
-    head_sha: &str,
-) -> CommandResult<i64> {
-    let output = run_github_cli(vec![
-        "api".to_owned(),
-        format!(
-            "repos/{}/compare/{}...{}",
-            binding.name_with_owner, previous_head_sha, head_sha
-        ),
-        "--jq".to_owned(),
-        "{status: .status, aheadBy: .ahead_by}".to_owned(),
-    ])
-    .await?;
-    let comparison: GithubCompareCli = parse_json(&output, "GitHub commit comparison")?;
-    if comparison.status.eq_ignore_ascii_case("identical") {
-        return Ok(0);
-    }
-    Ok(comparison.ahead_by.max(0))
-}
-
 async fn complete_closed_github_review_tasks(
     pool: &SqlitePool,
     links: &HashMap<i64, GithubResourceLink>,
@@ -1044,49 +1000,30 @@ async fn reconcile_linked_pull_request_snapshots(
         PULL_REQUEST_RESOURCE_KIND,
     )
     .await?;
-    let mut known_pull_numbers = requests
+    let known_pull_numbers = requests
         .iter()
         .map(|snapshot| snapshot.pull_request.number)
         .collect::<HashSet<_>>();
     let mut closed_pull_numbers = HashSet::new();
 
-    for pull_number in links.keys().copied() {
-        if known_pull_numbers.contains(&pull_number) {
-            continue;
-        }
-        let pull_request = load_github_pull_request(binding, pull_number).await?;
-        if pull_request.is_open() {
-            let pull_request = pull_request.as_queue_item();
+    let mut missing = links
+        .keys()
+        .copied()
+        .filter(|number| !known_pull_numbers.contains(number))
+        .collect::<Vec<_>>();
+    missing.sort_unstable();
+    for pull_request in pull_requests::load_linked_pull_requests(binding, &missing).await? {
+        if pull_request.state.eq_ignore_ascii_case("open") {
             let checks = summarize_checks(&pull_request.status_check_rollup);
             requests.push(GithubPullRequestSnapshot {
                 pull_request,
                 checks,
                 is_review_requested: false,
                 is_authored: false,
-                review_commits_ahead: None,
             });
-            known_pull_numbers.insert(pull_number);
         } else {
-            closed_pull_numbers.insert(pull_number);
+            closed_pull_numbers.insert(pull_request.number);
         }
-    }
-
-    for snapshot in &mut requests {
-        let Some(link) = links.get(&snapshot.pull_request.number) else {
-            continue;
-        };
-        let current_head_sha = snapshot.pull_request.head_ref_oid.as_str();
-        if link.head_sha.is_empty()
-            || current_head_sha.is_empty()
-            || link.head_sha == current_head_sha
-        {
-            snapshot.review_commits_ahead = None;
-            continue;
-        }
-        snapshot.review_commits_ahead =
-            load_github_commits_ahead(binding, &link.head_sha, current_head_sha)
-                .await
-                .ok();
     }
 
     complete_closed_github_review_tasks(pool, &links, &closed_pull_numbers).await?;
@@ -1109,7 +1046,7 @@ async fn load_cached_review_requests(
         select
             pull_number, title, url, author_login, is_draft, state, github_updated_at,
             is_review_requested, is_authored, head_sha, checks_status, checks_total,
-            checks_pending, checks_failed, failing_checks_json, review_commits_ahead
+            checks_pending, checks_failed, failing_checks_json
         from github_review_request_cache
         where channel_id = $1
           and repository_id = $2
@@ -1152,7 +1089,6 @@ async fn load_cached_review_requests(
             },
             is_review_requested: row.get("is_review_requested"),
             is_authored: row.get("is_authored"),
-            review_commits_ahead: row.get("review_commits_ahead"),
         });
     }
     Ok(requests)
@@ -1335,12 +1271,12 @@ async fn replace_cached_review_requests(
                 channel_id, repository_id, review_login, pull_number, title, url,
                 author_login, is_draft, state, github_updated_at,
                 is_review_requested, is_authored, head_sha, checks_status, checks_total,
-                checks_pending, checks_failed, failing_checks_json, review_commits_ahead,
+                checks_pending, checks_failed, failing_checks_json,
                 attention_unread
             )
             values (
                 $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
-                $14, $15, $16, $17, $18, $19, $20
+                $14, $15, $16, $17, $18, $19
             )
             "#,
         )
@@ -1368,7 +1304,6 @@ async fn replace_cached_review_requests(
         .bind(snapshot.checks.pending)
         .bind(snapshot.checks.failed)
         .bind(failing_checks_json)
-        .bind(snapshot.review_commits_ahead)
         .bind(attention_unread)
         .execute(&mut *transaction)
         .await
@@ -1482,6 +1417,8 @@ async fn decorate_review_requests(
         PULL_REQUEST_RESOURCE_KIND,
     )
     .await?;
+    let mut commits_ahead =
+        comparisons::cached_counts_for_requests(pool, binding, &requests, &links).await?;
     Ok(requests
         .into_iter()
         .map(|snapshot| {
@@ -1517,9 +1454,7 @@ async fn decorate_review_requests(
                 linked_assignee_name: link.as_ref().and_then(|link| link.assignee_name.clone()),
                 review_anchor_sha,
                 review_is_stale,
-                review_commits_ahead: review_is_stale
-                    .then_some(snapshot.review_commits_ahead)
-                    .flatten(),
+                review_commits_ahead: commits_ahead.remove(&pull_request.number),
             }
         })
         .collect())
@@ -1623,16 +1558,6 @@ pub(crate) async fn refresh_github_review_attention(
     let mut requests = Vec::with_capacity(current_requests.len() + cached_requests.len());
     for pull_request in current_requests {
         let previous = cached_requests.remove(&pull_request.number);
-        let same_head = previous.as_ref().is_some_and(|snapshot| {
-            snapshot.pull_request.head_ref_oid == pull_request.head_ref_oid
-        });
-        let review_commits_ahead = same_head
-            .then(|| {
-                previous
-                    .as_ref()
-                    .and_then(|snapshot| snapshot.review_commits_ahead)
-            })
-            .flatten();
         let is_authored = previous
             .as_ref()
             .is_some_and(|snapshot| snapshot.is_authored);
@@ -1642,7 +1567,6 @@ pub(crate) async fn refresh_github_review_attention(
             checks,
             is_review_requested: true,
             is_authored,
-            review_commits_ahead,
         });
     }
     requests.extend(cached_requests.into_values().filter_map(|mut snapshot| {
@@ -1713,16 +1637,16 @@ pub(crate) async fn refresh_github_channel_overview(
     pool: &SqlitePool,
     channel_id: Uuid,
 ) -> CommandResult<GithubChannelOverview> {
-    let account = github_account().await?;
     let Some(binding) = load_github_binding(pool, channel_id).await? else {
         return Ok(GithubChannelOverview {
-            account,
+            account: github_account().await?,
             binding: None,
             review_requests: Vec::new(),
             issues: Vec::new(),
         });
     };
-    let (review_requests, authored_pull_requests) = tokio::try_join!(
+    let (account, review_requests, authored_pull_requests) = tokio::try_join!(
+        github_account(),
         search_review_requests(&binding),
         search_authored_pull_requests(&binding)
     )?;
@@ -1751,16 +1675,16 @@ pub(crate) async fn refresh_github_issue_overview(
     pool: &SqlitePool,
     channel_id: Uuid,
 ) -> CommandResult<GithubChannelOverview> {
-    let account = github_account().await?;
     let Some(binding) = load_github_binding(pool, channel_id).await? else {
         return Ok(GithubChannelOverview {
-            account,
+            account: github_account().await?,
             binding: None,
             review_requests: Vec::new(),
             issues: Vec::new(),
         });
     };
-    let (open_issues, related_issues) = tokio::try_join!(
+    let (account, open_issues, related_issues) = tokio::try_join!(
+        github_account(),
         search_issues(&binding, false),
         search_issues(&binding, true)
     )?;
@@ -1794,7 +1718,7 @@ pub(crate) async fn load_github_pull_request(
         "--repo".to_owned(),
         binding.name_with_owner.clone(),
         "--json".to_owned(),
-        "number,title,url,author,isDraft,state,updatedAt,headRefOid,statusCheckRollup".to_owned(),
+        "number,title,url,state,headRefOid".to_owned(),
     ])
     .await?;
     let pull_request: GithubPullRequestDetail = parse_json(&output, "GitHub pull request")?;
@@ -2574,14 +2498,8 @@ mod tests {
                 number: 42,
                 title: "Keep the queue bounded".to_owned(),
                 url: "https://github.com/acme/stream/pull/42".to_owned(),
-                author: Some(GithubActorCli {
-                    login: "octocat".to_owned(),
-                }),
-                is_draft: false,
                 state: "OPEN".to_owned(),
-                updated_at: "2026-07-27T04:00:00Z".to_owned(),
                 head_ref_oid: "abc123".to_owned(),
-                status_check_rollup: Vec::new(),
             };
 
             let first = create_github_review_task_record(
@@ -2659,14 +2577,8 @@ mod tests {
                 number: 42,
                 title: "Keep the queue bounded".to_owned(),
                 url: "https://github.com/acme/stream/pull/42".to_owned(),
-                author: Some(GithubActorCli {
-                    login: "octocat".to_owned(),
-                }),
-                is_draft: false,
                 state: "OPEN".to_owned(),
-                updated_at: "2026-07-27T04:00:00Z".to_owned(),
                 head_ref_oid: "abc123".to_owned(),
-                status_check_rollup: Vec::new(),
             };
             let created =
                 create_github_review_task_record(&pool, channel_id, agent_id, &binding, &original)
@@ -2678,7 +2590,6 @@ mod tests {
                 .map_err(|err| err.to_string())?;
 
             let next = GithubPullRequestDetail {
-                updated_at: "2026-07-27T06:00:00Z".to_owned(),
                 head_ref_oid: "def456".to_owned(),
                 ..original.clone()
             };
@@ -2823,7 +2734,6 @@ mod tests {
                     },
                     is_review_requested: true,
                     is_authored: false,
-                    review_commits_ahead: Some(2),
                 },
                 GithubPullRequestSnapshot {
                     pull_request: GithubPullRequestCli {
@@ -2840,7 +2750,6 @@ mod tests {
                     checks: GithubCheckSummary::default(),
                     is_review_requested: false,
                     is_authored: true,
-                    review_commits_ahead: None,
                 },
             ];
             let baseline_update =
@@ -2942,7 +2851,6 @@ mod tests {
                 },
                 is_review_requested: true,
                 is_authored: false,
-                review_commits_ahead: None,
             }];
             replace_cached_review_requests(&pool, &binding, "next-owner", &second_snapshot, true)
                 .await?;
@@ -2973,7 +2881,6 @@ mod tests {
                 checks: GithubCheckSummary::default(),
                 is_review_requested: true,
                 is_authored: false,
-                review_commits_ahead: None,
             });
             let new_request_update = replace_cached_review_requests(
                 &pool,

--- a/src-tauri/src/github/comparisons.rs
+++ b/src-tauri/src/github/comparisons.rs
@@ -1,0 +1,256 @@
+//! Successful comparisons are immutable for an exact repository/base/head tuple.
+//! Optional counts are loaded separately so they cannot hold up the PR list.
+
+use std::{collections::HashMap, future::Future};
+
+use serde::{Deserialize, Serialize};
+use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool};
+use tokio::task::JoinSet;
+use uuid::Uuid;
+
+use super::{
+    load_cached_review_requests, load_github_binding, load_resource_links, parse_json,
+    run_github_cli, GithubPullRequestSnapshot, GithubRepositoryBinding, GithubResourceLink,
+    PULL_REQUEST_RESOURCE_KIND,
+};
+use crate::app::{to_string, CommandResult};
+
+const COMPARISON_CONCURRENCY: usize = 4;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GithubCompareCli {
+    status: String,
+    ahead_by: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct GithubReviewComparisons {
+    pub(crate) repository_id: String,
+    pub(crate) comparisons: Vec<GithubReviewComparison>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct GithubReviewComparison {
+    pub(crate) pull_number: i64,
+    pub(crate) review_anchor_sha: String,
+    pub(crate) head_sha: String,
+    pub(crate) commits_ahead: i64,
+}
+
+#[derive(Clone)]
+struct ComparisonTarget {
+    pull_number: i64,
+    base_sha: String,
+    head_sha: String,
+}
+
+fn comparison_targets(
+    requests: &[GithubPullRequestSnapshot],
+    links: &HashMap<i64, GithubResourceLink>,
+) -> Vec<ComparisonTarget> {
+    requests
+        .iter()
+        .filter_map(|snapshot| {
+            let pull = &snapshot.pull_request;
+            let link = links.get(&pull.number)?;
+            if link.head_sha.is_empty()
+                || pull.head_ref_oid.is_empty()
+                || link.head_sha == pull.head_ref_oid
+            {
+                return None;
+            }
+            Some(ComparisonTarget {
+                pull_number: pull.number,
+                base_sha: link.head_sha.clone(),
+                head_sha: pull.head_ref_oid.clone(),
+            })
+        })
+        .collect()
+}
+
+pub(super) async fn cached_counts_for_requests(
+    pool: &SqlitePool,
+    binding: &GithubRepositoryBinding,
+    requests: &[GithubPullRequestSnapshot],
+    links: &HashMap<i64, GithubResourceLink>,
+) -> CommandResult<HashMap<i64, i64>> {
+    let targets = comparison_targets(requests, links);
+    let mut counts = HashMap::new();
+    for batch in targets.chunks(100) {
+        let mut query = QueryBuilder::<Sqlite>::new(
+            "select base_sha, head_sha, ahead_by from github_commit_comparisons where repository_id = ",
+        );
+        query.push_bind(&binding.repository_id).push(" and (");
+        for (index, target) in batch.iter().enumerate() {
+            if index > 0 {
+                query.push(" or ");
+            }
+            query
+                .push("(base_sha = ")
+                .push_bind(&target.base_sha)
+                .push(" and head_sha = ")
+                .push_bind(&target.head_sha)
+                .push(")");
+        }
+        query.push(")");
+        let rows = query.build().fetch_all(pool).await.map_err(to_string)?;
+        let by_sha = rows
+            .into_iter()
+            .map(|row| {
+                (
+                    (
+                        row.get::<String, _>("base_sha"),
+                        row.get::<String, _>("head_sha"),
+                    ),
+                    row.get::<i64, _>("ahead_by"),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        for target in batch {
+            if let Some(count) = by_sha.get(&(target.base_sha.clone(), target.head_sha.clone())) {
+                counts.insert(target.pull_number, *count);
+            }
+        }
+    }
+    Ok(counts)
+}
+
+async fn cached_or_fetch<F, Fut>(
+    pool: &SqlitePool,
+    repository_id: &str,
+    base_sha: &str,
+    head_sha: &str,
+    fetch: F,
+) -> CommandResult<i64>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = CommandResult<i64>>,
+{
+    if base_sha.is_empty() || head_sha.is_empty() {
+        return Err("GitHub comparison requires both commit SHAs".to_owned());
+    }
+    if base_sha == head_sha {
+        return Ok(0);
+    }
+    let cached: Option<i64> = sqlx::query_scalar(
+        "select ahead_by from github_commit_comparisons where repository_id = $1 and base_sha = $2 and head_sha = $3",
+    ).bind(repository_id).bind(base_sha).bind(head_sha)
+        .fetch_optional(pool).await.map_err(to_string)?;
+    if let Some(count) = cached {
+        return Ok(count);
+    }
+    let count = fetch().await?;
+    sqlx::query(
+        "insert into github_commit_comparisons (repository_id, base_sha, head_sha, ahead_by) values ($1, $2, $3, $4) on conflict do nothing",
+    ).bind(repository_id).bind(base_sha).bind(head_sha).bind(count)
+        .execute(pool).await.map_err(to_string)?;
+    Ok(count)
+}
+
+pub(crate) async fn load_github_commits_ahead(
+    pool: &SqlitePool,
+    binding: &GithubRepositoryBinding,
+    previous_head_sha: &str,
+    head_sha: &str,
+) -> CommandResult<i64> {
+    cached_or_fetch(
+        pool,
+        &binding.repository_id,
+        previous_head_sha,
+        head_sha,
+        || async {
+            let output = run_github_cli(vec![
+                "api".to_owned(),
+                format!(
+                    "repos/{}/compare/{}...{}",
+                    binding.name_with_owner, previous_head_sha, head_sha
+                ),
+                "--jq".to_owned(),
+                "{status: .status, aheadBy: .ahead_by}".to_owned(),
+            ])
+            .await?;
+            let comparison: GithubCompareCli = parse_json(&output, "GitHub commit comparison")?;
+            Ok(if comparison.status.eq_ignore_ascii_case("identical") {
+                0
+            } else {
+                comparison.ahead_by.max(0)
+            })
+        },
+    )
+    .await
+}
+
+async fn resolve_comparisons<F, Fut>(
+    targets: Vec<ComparisonTarget>,
+    fetch: F,
+) -> CommandResult<Vec<GithubReviewComparison>>
+where
+    F: Fn(ComparisonTarget) -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = CommandResult<i64>> + Send + 'static,
+{
+    let mut targets = targets.into_iter();
+    let mut pending = JoinSet::new();
+    let mut comparisons = Vec::new();
+    loop {
+        while pending.len() < COMPARISON_CONCURRENCY {
+            let Some(target) = targets.next() else {
+                break;
+            };
+            let fetch = fetch.clone();
+            pending.spawn(async move {
+                let count = fetch(target.clone()).await?;
+                Ok::<_, String>(GithubReviewComparison {
+                    pull_number: target.pull_number,
+                    review_anchor_sha: target.base_sha,
+                    head_sha: target.head_sha,
+                    commits_ahead: count,
+                })
+            });
+        }
+        let Some(result) = pending.join_next().await else {
+            break;
+        };
+        // An unavailable comparison must not discard other PRs' counts.
+        if let Ok(comparison) = result.map_err(to_string)? {
+            comparisons.push(comparison);
+        }
+    }
+    comparisons.sort_by_key(|comparison| comparison.pull_number);
+    Ok(comparisons)
+}
+
+pub(crate) async fn load_github_review_comparisons(
+    pool: &SqlitePool,
+    channel_id: Uuid,
+) -> CommandResult<GithubReviewComparisons> {
+    let binding = load_github_binding(pool, channel_id)
+        .await?
+        .ok_or_else(|| "channel has no GitHub repository binding".to_owned())?;
+    let requests = load_cached_review_requests(pool, &binding).await?;
+    let links = load_resource_links(
+        pool,
+        channel_id,
+        &binding.repository_id,
+        PULL_REQUEST_RESOURCE_KIND,
+    )
+    .await?;
+    let targets = comparison_targets(&requests, &links);
+    let repository_id = binding.repository_id.clone();
+    let pool = pool.clone();
+    let comparisons = resolve_comparisons(targets, move |target| {
+        let pool = pool.clone();
+        let binding = binding.clone();
+        async move {
+            load_github_commits_ahead(&pool, &binding, &target.base_sha, &target.head_sha).await
+        }
+    })
+    .await?;
+    Ok(GithubReviewComparisons {
+        repository_id,
+        comparisons,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/src-tauri/src/github/comparisons/tests.rs
+++ b/src-tauri/src/github/comparisons/tests.rs
@@ -1,0 +1,180 @@
+use super::*;
+use crate::test_support::{drop_test_schema, test_pool};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+#[tokio::test]
+async fn reuses_only_successes_for_the_exact_repository_and_sha_pair() {
+    let (pool, schema) = test_pool().await.expect("create test database");
+    let calls = AtomicUsize::new(0);
+    for (repo, base, head, expected) in [
+        ("repo", "base", "head", 1),
+        ("repo", "base", "head", 1),
+        ("repo", "other-base", "head", 2),
+        ("repo", "base", "other-head", 3),
+        ("other-repo", "base", "head", 4),
+    ] {
+        let count = cached_or_fetch(&pool, repo, base, head, || async {
+            Ok(calls.fetch_add(1, Ordering::SeqCst) as i64 + 1)
+        })
+        .await
+        .unwrap();
+        assert_eq!(count, expected);
+    }
+    assert_eq!(calls.load(Ordering::SeqCst), 4);
+    assert!(cached_or_fetch(&pool, "repo", "base", "retry", || async {
+        Err("unavailable".to_owned())
+    })
+    .await
+    .is_err());
+    assert_eq!(
+        cached_or_fetch(&pool, "repo", "base", "retry", || async { Ok(5) })
+            .await
+            .unwrap(),
+        5
+    );
+    assert_eq!(
+        cached_or_fetch(&pool, "repo", "head", "head", || async {
+            panic!("identical heads need no network")
+        })
+        .await
+        .unwrap(),
+        0
+    );
+    assert!(
+        cached_or_fetch(&pool, "repo", "", "head", || async { Ok(0) })
+            .await
+            .is_err()
+    );
+    drop_test_schema(pool, schema).await;
+}
+
+#[tokio::test]
+async fn comparisons_run_concurrently_with_a_limit_and_keep_partial_successes() {
+    let active = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+    let barrier = Arc::new(tokio::sync::Barrier::new(COMPARISON_CONCURRENCY));
+    let targets = (0..8)
+        .map(|number| ComparisonTarget {
+            pull_number: number,
+            base_sha: "base".to_owned(),
+            head_sha: format!("head-{number}"),
+        })
+        .collect();
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        resolve_comparisons(targets, {
+            let active = active.clone();
+            let peak = peak.clone();
+            move |target| {
+                let active = active.clone();
+                let peak = peak.clone();
+                let barrier = barrier.clone();
+                async move {
+                    let count = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(count, Ordering::SeqCst);
+                    barrier.wait().await;
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    if target.pull_number == 2 {
+                        Err("unavailable".to_owned())
+                    } else {
+                        Ok(target.pull_number)
+                    }
+                }
+            }
+        }),
+    )
+    .await
+    .expect("bounded concurrency must make progress")
+    .unwrap();
+    assert_eq!(peak.load(Ordering::SeqCst), COMPARISON_CONCURRENCY);
+    assert_eq!(active.load(Ordering::SeqCst), 0);
+    assert_eq!(result.len(), 7);
+    assert!(!result.iter().any(|item| item.pull_number == 2));
+    assert!(result
+        .iter()
+        .all(|item| item.commits_ahead == item.pull_number));
+}
+
+#[tokio::test]
+async fn cached_list_counts_follow_the_current_review_anchor_and_head() {
+    use crate::github::{GithubCheckSummary, GithubPullRequestCli};
+    let (pool, schema) = test_pool().await.expect("create test database");
+    let binding = GithubRepositoryBinding {
+        channel_id: Uuid::nil(),
+        repository_id: "repo".to_owned(),
+        name_with_owner: "a/b".to_owned(),
+        url: String::new(),
+        local_path: String::new(),
+        account_login: "owner".to_owned(),
+        review_login: "owner".to_owned(),
+        review_queue_synced_at: None,
+        issue_queue_synced_at: None,
+        created_at: String::new(),
+        updated_at: String::new(),
+    };
+    let mut requests = vec![GithubPullRequestSnapshot {
+        pull_request: GithubPullRequestCli {
+            number: 42,
+            title: "PR".to_owned(),
+            url: String::new(),
+            author: None,
+            is_draft: false,
+            state: "OPEN".to_owned(),
+            updated_at: String::new(),
+            head_ref_oid: "head".to_owned(),
+            status_check_rollup: Vec::new(),
+        },
+        checks: GithubCheckSummary::default(),
+        is_review_requested: true,
+        is_authored: false,
+    }];
+    let mut links = HashMap::from([(
+        42,
+        GithubResourceLink {
+            thread_root_id: Uuid::nil(),
+            task_id: None,
+            task_number: None,
+            task_status: Some("done".to_owned()),
+            assignee_id: None,
+            assignee_name: None,
+            head_sha: "base".to_owned(),
+        },
+    )]);
+    assert!(
+        cached_counts_for_requests(&pool, &binding, &requests, &links)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    cached_or_fetch(&pool, "repo", "base", "head", || async { Ok(3) })
+        .await
+        .unwrap();
+    assert_eq!(
+        cached_counts_for_requests(&pool, &binding, &requests, &links)
+            .await
+            .unwrap()
+            .get(&42),
+        Some(&3)
+    );
+    requests[0].pull_request.head_ref_oid = "new-head".to_owned();
+    assert!(
+        cached_counts_for_requests(&pool, &binding, &requests, &links)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    requests[0].pull_request.head_ref_oid = "head".to_owned();
+    links.get_mut(&42).unwrap().head_sha = "new-base".to_owned();
+    assert!(
+        cached_counts_for_requests(&pool, &binding, &requests, &links)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    links.get_mut(&42).unwrap().head_sha = "head".to_owned();
+    assert!(comparison_targets(&requests, &links).is_empty());
+    drop_test_schema(pool, schema).await;
+}

--- a/src-tauri/src/github/pull_requests.rs
+++ b/src-tauri/src/github/pull_requests.rs
@@ -1,0 +1,237 @@
+//! Batched metadata for linked PRs, including all check-context pages.
+
+use std::{collections::HashSet, future::Future};
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::{
+    parse_json, run_github_cli, GithubPullRequestCli, GithubRepositoryBinding, GithubStatusCheckCli,
+};
+use crate::app::CommandResult;
+
+const PULL_REQUEST_BATCH_SIZE: usize = 20;
+const CHECK_FIELDS: &str = r#"
+    nodes {
+        __typename
+        ... on CheckRun { name status conclusion }
+        ... on StatusContext { context state }
+    }
+    pageInfo { hasNextPage endCursor }
+"#;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CheckPage {
+    nodes: Vec<GithubStatusCheckCli>,
+    page_info: PageInfo,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PageInfo {
+    has_next_page: bool,
+    end_cursor: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CheckRollup {
+    contexts: CheckPage,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Commit {
+    oid: String,
+    status_check_rollup: Option<CheckRollup>,
+}
+
+#[derive(Deserialize)]
+struct PullRequestCommit {
+    commit: Commit,
+}
+
+#[derive(Deserialize)]
+struct Commits {
+    nodes: Vec<PullRequestCommit>,
+}
+
+#[derive(Deserialize)]
+struct PullRequest {
+    #[serde(flatten)]
+    metadata: GithubPullRequestCli,
+    commits: Commits,
+}
+
+struct PendingPullRequest {
+    metadata: GithubPullRequestCli,
+    next_cursor: Option<String>,
+}
+
+fn batch_query(numbers: &[i64]) -> String {
+    let fields = numbers
+        .iter()
+        .map(|number| {
+            format!(
+                r#"
+        pr{number}: pullRequest(number: {number}) {{
+            number title url author {{ login }} isDraft state updatedAt headRefOid
+            commits(last: 1) {{ nodes {{ commit {{ oid statusCheckRollup {{
+                contexts(first: 100) {{ {CHECK_FIELDS} }}
+            }} }} }} }}
+        }}
+    "#
+            )
+        })
+        .collect::<String>();
+    format!("query($owner: String!, $name: String!) {{ repository(owner: $owner, name: $name) {{ {fields} }} }}")
+}
+
+fn next_cursor(page: &PageInfo) -> CommandResult<Option<String>> {
+    if !page.has_next_page {
+        return Ok(None);
+    }
+    page.end_cursor
+        .clone()
+        .filter(|cursor| !cursor.is_empty())
+        .map(Some)
+        .ok_or_else(|| "GitHub returned a check page without a continuation cursor".to_owned())
+}
+
+fn parse_batch(bytes: &[u8], numbers: &[i64]) -> CommandResult<Vec<PendingPullRequest>> {
+    let response: Value = parse_json(bytes, "GitHub pull request batch")?;
+    if response
+        .get("errors")
+        .and_then(Value::as_array)
+        .is_some_and(|errors| !errors.is_empty())
+    {
+        return Err("GitHub returned errors in the pull request batch".to_owned());
+    }
+    let repository = response
+        .pointer("/data/repository")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "GitHub did not return the requested repository".to_owned())?;
+    numbers.iter().map(|number| {
+        let value = repository.get(&format!("pr{number}")).filter(|value| !value.is_null())
+            .ok_or_else(|| format!("GitHub did not return linked pull request #{number}"))?;
+        let mut pull: PullRequest = serde_json::from_value(value.clone())
+            .map_err(|err| format!("failed to parse GitHub pull request #{number}: {err}"))?;
+        if pull.metadata.number != *number {
+            return Err("GitHub returned an unexpected pull request in the batch".to_owned());
+        }
+        let mut cursor = None;
+        if let Some(last) = pull.commits.nodes.pop() {
+            if last.commit.oid != pull.metadata.head_ref_oid {
+                return Err(format!("GitHub pull request #{number} head changed while loading checks; refresh and retry"));
+            }
+            if let Some(rollup) = last.commit.status_check_rollup {
+                cursor = next_cursor(&rollup.contexts.page_info)?;
+                pull.metadata.status_check_rollup = rollup.contexts.nodes;
+            }
+        }
+        Ok(PendingPullRequest { metadata: pull.metadata, next_cursor: cursor })
+    }).collect()
+}
+
+pub(super) async fn load_linked_pull_requests(
+    binding: &GithubRepositoryBinding,
+    numbers: &[i64],
+) -> CommandResult<Vec<GithubPullRequestCli>> {
+    load_linked_pull_requests_with(binding, numbers, run_github_cli).await
+}
+
+async fn load_linked_pull_requests_with<F, Fut>(
+    binding: &GithubRepositoryBinding,
+    numbers: &[i64],
+    run: F,
+) -> CommandResult<Vec<GithubPullRequestCli>>
+where
+    F: Fn(Vec<String>) -> Fut,
+    Fut: Future<Output = CommandResult<Vec<u8>>>,
+{
+    if numbers.is_empty() {
+        return Ok(Vec::new());
+    }
+    if numbers.iter().any(|number| *number <= 0) {
+        return Err("pull request number must be positive".to_owned());
+    }
+    let (owner, name) = binding
+        .name_with_owner
+        .split_once('/')
+        .ok_or_else(|| "invalid GitHub repository binding".to_owned())?;
+    let mut pulls = Vec::with_capacity(numbers.len());
+    for batch in numbers.chunks(PULL_REQUEST_BATCH_SIZE) {
+        let output = run(vec![
+            "api".to_owned(),
+            "graphql".to_owned(),
+            "-f".to_owned(),
+            format!("owner={owner}"),
+            "-f".to_owned(),
+            format!("name={name}"),
+            "-f".to_owned(),
+            format!("query={}", batch_query(batch)),
+        ])
+        .await?;
+        // Reject incomplete batches before any PR is interpreted as closed.
+        for mut pull in parse_batch(&output, batch)? {
+            let mut seen_cursors = HashSet::new();
+            while let Some(cursor) = pull.next_cursor.take() {
+                if !seen_cursors.insert(cursor.clone()) {
+                    return Err("GitHub check pagination did not advance".to_owned());
+                }
+                // Pin follow-up pages to the same commit even if the PR is pushed meanwhile.
+                let query = format!(
+                    r#"
+                    query($owner: String!, $name: String!, $head: GitObjectID!, $cursor: String!) {{
+                        repository(owner: $owner, name: $name) {{
+                            object(oid: $head) {{ ... on Commit {{ statusCheckRollup {{
+                                contexts(first: 100, after: $cursor) {{ {CHECK_FIELDS} }}
+                            }} }} }}
+                        }}
+                    }}
+                "#
+                );
+                let output = run(vec![
+                    "api".to_owned(),
+                    "graphql".to_owned(),
+                    "-f".to_owned(),
+                    format!("owner={owner}"),
+                    "-f".to_owned(),
+                    format!("name={name}"),
+                    "-f".to_owned(),
+                    format!("head={}", pull.metadata.head_ref_oid),
+                    "-f".to_owned(),
+                    format!("cursor={cursor}"),
+                    "-f".to_owned(),
+                    format!("query={query}"),
+                ])
+                .await?;
+                let response: Value = parse_json(&output, "GitHub check page")?;
+                if response
+                    .get("errors")
+                    .and_then(Value::as_array)
+                    .is_some_and(|errors| !errors.is_empty())
+                {
+                    return Err("GitHub returned errors loading check contexts".to_owned());
+                }
+                let page: CheckPage = serde_json::from_value(
+                    response
+                        .pointer("/data/repository/object/statusCheckRollup/contexts")
+                        .cloned()
+                        .ok_or_else(|| {
+                            "GitHub did not return the requested check page".to_owned()
+                        })?,
+                )
+                .map_err(|err| format!("failed to parse GitHub check page: {err}"))?;
+                pull.next_cursor = next_cursor(&page.page_info)?;
+                pull.metadata.status_check_rollup.extend(page.nodes);
+            }
+            pulls.push(pull.metadata);
+        }
+    }
+    Ok(pulls)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src-tauri/src/github/pull_requests/tests.rs
+++ b/src-tauri/src/github/pull_requests/tests.rs
@@ -1,0 +1,165 @@
+use super::*;
+use serde_json::json;
+
+fn fixture() -> Value {
+    json!({"data": {"repository": {"pr42": {
+        "number": 42, "title": "PR", "url": "https://github.com/a/b/pull/42",
+        "author": null, "isDraft": false, "state": "OPEN", "updatedAt": "2026-09-06T00:00:00Z",
+        "headRefOid": "head", "commits": {"nodes": [{"commit": {
+            "oid": "head", "statusCheckRollup": {"contexts": {
+                "nodes": [
+                    {"__typename": "CheckRun", "name": "Build", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                    {"__typename": "StatusContext", "context": "CI", "state": "FAILURE"}
+                ],
+                "pageInfo": {"hasNextPage": true, "endCursor": "page1"}
+            }}
+        }}]}
+    }}}})
+}
+
+#[test]
+fn parses_checks_and_keeps_pagination_cursor() {
+    let pulls = parse_batch(&serde_json::to_vec(&fixture()).unwrap(), &[42]).unwrap();
+    assert_eq!(pulls[0].metadata.number, 42);
+    assert!(pulls[0].metadata.author.is_none());
+    assert_eq!(pulls[0].next_cursor.as_deref(), Some("page1"));
+    let summary = super::super::summarize_checks(&pulls[0].metadata.status_check_rollup);
+    assert_eq!(summary.total, 2);
+    assert_eq!(summary.failed, 1);
+    assert_eq!(summary.failing_checks, ["CI"]);
+}
+
+#[test]
+fn incomplete_batches_are_not_interpreted_as_closed_prs() {
+    for response in [
+        json!({"data": {"repository": {"pr42": null}}}),
+        json!({"data": {"repository": {}}}),
+        json!({"data": {"repository": null}}),
+        json!({"errors": [{"message": "denied"}], "data": fixture()["data"]}),
+    ] {
+        assert!(parse_batch(&serde_json::to_vec(&response).unwrap(), &[42]).is_err());
+    }
+    let mut response = fixture();
+    response["data"]["repository"]["pr42"]["number"] = json!(43);
+    assert!(parse_batch(&serde_json::to_vec(&response).unwrap(), &[42]).is_err());
+}
+
+#[test]
+fn head_mismatch_and_missing_cursor_are_errors() {
+    let mut response = fixture();
+    response["data"]["repository"]["pr42"]["headRefOid"] = json!("new-head");
+    assert!(parse_batch(&serde_json::to_vec(&response).unwrap(), &[42]).is_err());
+    assert!(next_cursor(&PageInfo {
+        has_next_page: true,
+        end_cursor: None
+    })
+    .is_err());
+    assert!(next_cursor(&PageInfo {
+        has_next_page: true,
+        end_cursor: Some(String::new())
+    })
+    .is_err());
+    assert_eq!(
+        next_cursor(&PageInfo {
+            has_next_page: false,
+            end_cursor: Some("last".to_owned())
+        })
+        .unwrap(),
+        None
+    );
+}
+
+#[test]
+fn closed_and_merged_prs_without_checks_are_preserved() {
+    for state in ["CLOSED", "MERGED"] {
+        let mut response = fixture();
+        let pr = &mut response["data"]["repository"]["pr42"];
+        pr["state"] = json!(state);
+        pr["commits"]["nodes"][0]["commit"]["statusCheckRollup"] = Value::Null;
+        let pulls = parse_batch(&serde_json::to_vec(&response).unwrap(), &[42]).unwrap();
+        assert_eq!(pulls[0].metadata.state, state);
+        assert!(pulls[0].metadata.status_check_rollup.is_empty());
+        assert!(pulls[0].next_cursor.is_none());
+    }
+}
+
+fn binding() -> GithubRepositoryBinding {
+    GithubRepositoryBinding {
+        channel_id: uuid::Uuid::nil(),
+        repository_id: "repo".to_owned(),
+        name_with_owner: "a/b".to_owned(),
+        url: String::new(),
+        local_path: String::new(),
+        account_login: "owner".to_owned(),
+        review_login: "owner".to_owned(),
+        review_queue_synced_at: None,
+        issue_queue_synced_at: None,
+        created_at: String::new(),
+        updated_at: String::new(),
+    }
+}
+
+#[tokio::test]
+async fn loads_later_check_pages_from_the_original_head() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let calls = AtomicUsize::new(0);
+    let pulls = load_linked_pull_requests_with(&binding(), &[42], |args| {
+        let call = calls.fetch_add(1, Ordering::SeqCst);
+        async move {
+            let response = match call {
+                0 => fixture(),
+                1 => {
+                    assert!(args.contains(&"head=head".to_owned()));
+                    assert!(args.contains(&"cursor=page1".to_owned()));
+                    json!({"data": {"repository": {"object": {"statusCheckRollup": {"contexts": {
+                        "nodes": [{"__typename": "StatusContext", "context": "Slow CI", "state": "PENDING"}],
+                        "pageInfo": {"hasNextPage": false, "endCursor": "page2"}
+                    }}}}}})
+                },
+                _ => panic!("unexpected extra request"),
+            };
+            Ok(serde_json::to_vec(&response).unwrap())
+        }
+    }).await.unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    let summary = super::super::summarize_checks(&pulls[0].status_check_rollup);
+    assert_eq!(summary.total, 3);
+    assert_eq!(summary.pending, 1);
+    assert_eq!(summary.failed, 1);
+}
+
+#[tokio::test]
+async fn large_link_sets_are_batched_without_losing_prs() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let calls = AtomicUsize::new(0);
+    let pulls = load_linked_pull_requests_with(&binding(), &(1..=25).collect::<Vec<_>>(), |args| {
+        let call = calls.fetch_add(1, Ordering::SeqCst);
+        async move {
+            let numbers = match call {
+                0 => 1..=20,
+                1 => 21..=25,
+                _ => panic!("too many requests"),
+            };
+            let query = args.iter().find(|arg| arg.starts_with("query=")).unwrap();
+            assert_eq!(
+                query.matches(": pullRequest(").count(),
+                numbers.clone().count()
+            );
+            let mut entries = serde_json::Map::new();
+            for number in numbers {
+                let mut pr = fixture()["data"]["repository"]["pr42"].clone();
+                pr["number"] = json!(number);
+                pr["commits"]["nodes"][0]["commit"]["statusCheckRollup"] = Value::Null;
+                entries.insert(format!("pr{number}"), pr);
+            }
+            Ok(serde_json::to_vec(&json!({"data": {"repository": entries}})).unwrap())
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        pulls.iter().map(|pull| pull.number).collect::<Vec<_>>(),
+        (1..=25).collect::<Vec<_>>()
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -68,8 +68,9 @@ use commands::{
     },
     github::{
         bind_github_repository, create_github_issue_task, create_github_review_task,
-        load_github_issue_detail, load_github_review_queue, mark_github_review_attention_read,
-        refresh_github_issue_queue, refresh_github_review_queue, rereview_github_pull_request,
+        load_github_issue_detail, load_github_review_comparisons, load_github_review_queue,
+        mark_github_review_attention_read, refresh_github_issue_queue, refresh_github_review_queue,
+        rereview_github_pull_request,
     },
     inbox::{
         dismiss_inbox_items, mark_all_inbox_read, mark_channel_read, mark_inbox_items_read,
@@ -324,6 +325,7 @@ pub fn run() {
             load_channel_previews,
             load_channel_wiki,
             load_message,
+            load_github_review_comparisons,
             load_github_review_queue,
             load_github_issue_detail,
             load_older_channel_messages,

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -237,6 +237,10 @@ fn web_router(state: Arc<WebState>, dist_dir: PathBuf) -> Router {
             post(api_search_channel_wikis).layer(CompressionLayer::new()),
         )
         .route(
+            "/api/load_github_review_comparisons",
+            post(api_load_github_review_comparisons),
+        )
+        .route(
             "/api/load_github_review_queue",
             post(api_load_github_review_queue),
         )
@@ -579,6 +583,16 @@ async fn api_search_channel_wikis(
     Json(request): Json<SearchChannelWikisRequest>,
 ) -> Result<impl IntoResponse, Response> {
     wiki_commands::search_channel_wikis(&state.pool, request)
+        .await
+        .map(Json)
+        .map_err(api_error)
+}
+
+async fn api_load_github_review_comparisons(
+    State(state): State<Arc<WebState>>,
+    Json(request): Json<GithubChannelRequest>,
+) -> Result<impl IntoResponse, Response> {
+    github_commands::load_github_review_comparisons(&state.pool, request)
         .await
         .map(Json)
         .map_err(api_error)

--- a/src/api-contract.ts
+++ b/src/api-contract.ts
@@ -7,6 +7,7 @@ import type {
   ChannelWikiOverview,
   ChannelWikiSearchHit,
   GithubChannelOverview,
+  GithubReviewComparisons,
   GithubIssueDetail,
   GithubIssueTaskResult,
   GithubRepositoryBinding,
@@ -139,6 +140,10 @@ export type ApiContract = {
       note: string;
     };
     result: PublishChannelWikiResult;
+  };
+  load_github_review_comparisons: {
+    args: { channelId: string };
+    result: GithubReviewComparisons;
   };
   load_github_review_queue: {
     args: { channelId: string };
@@ -337,6 +342,7 @@ const API_COMMAND_NAMES = {
   load_channel_wiki: true,
   publish_channel_wiki: true,
   search_channel_wikis: true,
+  load_github_review_comparisons: true,
   load_github_review_queue: true,
   refresh_github_review_queue: true,
   refresh_github_issue_queue: true,

--- a/src/components/GithubPanel.tsx
+++ b/src/components/GithubPanel.tsx
@@ -16,6 +16,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 
 import { apiInvoke, openExternalUrl } from "../apiClient";
+import { githubComparisonRequestKey, mergeGithubReviewComparisons } from "../github-review";
 import { formatRelativeTime } from "../ui-utils";
 import type {
   Agent,
@@ -27,6 +28,7 @@ import type {
   GithubLabel,
   GithubPullRequest,
   GithubReviewTaskResult,
+  GithubReviewComparisons,
 } from "../types";
 import { GithubIssueDrawer } from "./GithubIssueDrawer";
 import { Modal } from "./Modal";
@@ -47,6 +49,7 @@ type GithubIssueFilter = "related" | "assigned" | "authored" | "linked" | "open"
 const GITHUB_AUTO_REFRESH_INTERVAL_MS = 60_000;
 const githubOverviewCache = new Map<string, GithubChannelOverview>();
 const githubRefreshRequests = new Map<string, Promise<GithubChannelOverview>>();
+const githubComparisonRequests = new Map<string, Promise<GithubReviewComparisons>>();
 
 function cacheGithubOverview(channelId: string, overview: GithubChannelOverview) {
   githubOverviewCache.set(channelId, overview);
@@ -199,6 +202,32 @@ export function GithubPanel({
     syncedAt: channel.github_review_synced_at,
   });
 
+  const enrichOverview = useCallback((next: GithubChannelOverview, requestEpoch: number) => {
+    const requestKey = githubComparisonRequestKey(next);
+    if (!requestKey) return;
+    let request = githubComparisonRequests.get(requestKey);
+    if (!request) {
+      request = apiInvoke("load_github_review_comparisons", { channelId: channel.id })
+        .finally(() => {
+          if (githubComparisonRequests.get(requestKey) === request) {
+            githubComparisonRequests.delete(requestKey);
+          }
+        });
+      githubComparisonRequests.set(requestKey, request);
+    }
+    void request.then((comparisons) => {
+      if (requestEpochRef.current !== requestEpoch) return;
+      setOverview((current) => {
+        if (!current) return current;
+        const updated = mergeGithubReviewComparisons(current, comparisons);
+        if (updated !== current) cacheGithubOverview(channel.id, updated);
+        return updated;
+      });
+    }).catch(() => {
+      // Counts are optional. Keep "New head" and retry on the next load/refresh.
+    });
+  }, [channel.id]);
+
   const refreshOverview = useCallback(async (resource: GithubResource) => {
     const requestEpoch = requestEpochRef.current + 1;
     requestEpochRef.current = requestEpoch;
@@ -209,6 +238,7 @@ export function GithubPanel({
       if (requestEpochRef.current !== requestEpoch) return;
       cacheGithubOverview(channel.id, next);
       setOverview(next);
+      if (resource === "pulls") enrichOverview(next, requestEpoch);
     } catch (loadError) {
       if (requestEpochRef.current !== requestEpoch) return;
       setError(errorMessage(
@@ -220,7 +250,7 @@ export function GithubPanel({
     } finally {
       if (requestEpochRef.current === requestEpoch) setRefreshingResource(null);
     }
-  }, [channel.id]);
+  }, [channel.id, enrichOverview]);
 
   const loadOverview = useCallback(async () => {
     const requestEpoch = requestEpochRef.current + 1;
@@ -240,6 +270,8 @@ export function GithubPanel({
       setLoading(false);
       if (githubQueueNeedsRefresh(next, activeResource)) {
         void refreshOverview(activeResource);
+      } else if (activeResource === "pulls") {
+        enrichOverview(next, requestEpoch);
       }
     } catch (loadError) {
       if (requestEpochRef.current !== requestEpoch) return;
@@ -247,7 +279,7 @@ export function GithubPanel({
       setError(errorMessage(loadError, "Failed to load the cached GitHub review queue"));
       setLoading(false);
     }
-  }, [activeResource, channel.id, refreshOverview]);
+  }, [activeResource, channel.id, enrichOverview, refreshOverview]);
 
   useEffect(() => {
     void loadOverview();

--- a/src/github-review.ts
+++ b/src/github-review.ts
@@ -1,0 +1,31 @@
+import type { GithubChannelOverview, GithubReviewComparisons } from "./types";
+
+export function githubComparisonRequestKey(overview: GithubChannelOverview): string | null {
+  if (!overview.binding) return null;
+  const missing = overview.review_requests
+    .filter((pull) => pull.review_is_stale && pull.review_commits_ahead === null)
+    .map((pull) => [pull.number, pull.review_anchor_sha, pull.head_sha])
+    .sort((a, b) => Number(a[0]) - Number(b[0]));
+  if (missing.length === 0) return null;
+  return JSON.stringify([overview.binding.channel_id, overview.binding.repository_id, missing]);
+}
+
+export function mergeGithubReviewComparisons(
+  overview: GithubChannelOverview,
+  result: GithubReviewComparisons,
+): GithubChannelOverview {
+  if (overview.binding?.repository_id !== result.repository_id) return overview;
+  const counts = new Map(result.comparisons.map((comparison) => [comparison.pull_number, comparison]));
+  let changed = false;
+  const reviewRequests = overview.review_requests.map((pull) => {
+    const comparison = counts.get(pull.number);
+    // A refresh, new push, or Re-review can finish before these optional counts.
+    if (!comparison || !pull.review_is_stale
+      || comparison.review_anchor_sha !== pull.review_anchor_sha
+      || comparison.head_sha !== pull.head_sha
+      || comparison.commits_ahead === pull.review_commits_ahead) return pull;
+    changed = true;
+    return { ...pull, review_commits_ahead: comparison.commits_ahead };
+  });
+  return changed ? { ...overview, review_requests: reviewRequests } : overview;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -284,6 +284,16 @@ export type GithubIssueDetail = {
   updated_at: string;
 };
 
+export type GithubReviewComparisons = {
+  repository_id: string;
+  comparisons: {
+    pull_number: number;
+    review_anchor_sha: string;
+    head_sha: string;
+    commits_ahead: number;
+  }[];
+};
+
 export type GithubChannelOverview = {
   account: GithubAccount;
   binding: GithubRepositoryBinding | null;

--- a/tests/github-review.test.ts
+++ b/tests/github-review.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { githubComparisonRequestKey, mergeGithubReviewComparisons } from "../src/github-review";
+import type { GithubChannelOverview, GithubReviewComparisons } from "../src/types";
+
+function overview(): GithubChannelOverview {
+  return {
+    account: { login: "owner", host: "github.com" },
+    binding: {
+      channel_id: "channel", repository_id: "repo", name_with_owner: "owner/repo",
+      url: "", local_path: "", account_login: "owner", review_login: "owner",
+      review_queue_synced_at: null, issue_queue_synced_at: null, created_at: "", updated_at: "",
+    },
+    issues: [],
+    review_requests: [{
+      number: 42, title: "PR", url: "", author_login: "author", is_draft: false,
+      state: "OPEN", updated_at: "", head_sha: "head", is_review_requested: true, is_authored: false,
+      checks: { status: "none", total: 0, pending: 0, failed: 0, failing_checks: [] },
+      linked_thread_root_id: "thread", linked_task_id: "task", linked_task_number: 1,
+      linked_task_status: "done", linked_assignee_id: "agent", linked_assignee_name: "Agent",
+      review_anchor_sha: "base", review_is_stale: true, review_commits_ahead: null,
+    }],
+  };
+}
+const result: GithubReviewComparisons = {
+  repository_id: "repo",
+  comparisons: [{ pull_number: 42, review_anchor_sha: "base", head_sha: "head", commits_ahead: 3 }],
+};
+
+test("enriches matching heads without replacing list or task metadata", () => {
+  const current = overview();
+  const updated = mergeGithubReviewComparisons(current, result);
+  assert.equal(updated.review_requests[0].review_commits_ahead, 3);
+  assert.equal(current.review_requests[0].review_commits_ahead, null);
+  assert.equal(updated.review_requests[0].linked_task_status, "done");
+  assert.strictEqual(updated.issues, current.issues);
+  assert.strictEqual(mergeGithubReviewComparisons(updated, result), updated);
+  assert.equal(githubComparisonRequestKey(updated), null);
+});
+
+test("ignores late counts after rebind, push, or re-review", () => {
+  for (const change of [
+    (o: GithubChannelOverview) => { o.binding!.repository_id = "another-repo"; },
+    (o: GithubChannelOverview) => { o.review_requests[0].head_sha = "new-head"; },
+    (o: GithubChannelOverview) => { o.review_requests[0].review_anchor_sha = "new-base"; },
+    (o: GithubChannelOverview) => { o.review_requests[0].review_is_stale = false; },
+  ]) {
+    const current = overview();
+    change(current);
+    assert.strictEqual(mergeGithubReviewComparisons(current, result), current);
+  }
+});
+
+test("request deduplication distinguishes changed heads and channels", () => {
+  const current = overview();
+  const originalKey = githubComparisonRequestKey(current);
+  assert.ok(originalKey);
+  current.review_requests[0].head_sha = "new-head";
+  assert.notEqual(githubComparisonRequestKey(current), originalKey);
+  current.review_requests[0].head_sha = "head";
+  current.binding!.channel_id = "another-channel";
+  assert.notEqual(githubComparisonRequestKey(current), originalKey);
+  current.binding = null;
+  assert.equal(githubComparisonRequestKey(current), null);
+});
+
+test("failed optional comparisons keep the usable PR list", () => {
+  const current = overview();
+  assert.strictEqual(mergeGithubReviewComparisons(current, { repository_id: "repo", comparisons: [] }), current);
+  assert.ok(githubComparisonRequestKey(current));
+});


### PR DESCRIPTION
GitHub queue refresh currently waits for one `gh pr view` per historical linked PR, then repeats commit comparisons before returning any new list data. The wait grows with review history even when those PRs are already closed.

This change batches linked PR metadata in groups of 20, follows check pagination at the same head SHA, and returns the updated queue before optional commit counts. A separate request fills in counts with at most four concurrent comparisons. Successful results are stored by repository/base SHA/head SHA and reused by queue loads and Re-review; late frontend responses must still match the repository and both SHAs. Account lookup runs alongside queue searches, and task metadata reads no longer request unused check details.

Validation:
- `cargo fmt --check`, `cargo check`, and all 243 Rust tests pass.
- `npm run build` and all 33 frontend tests pass, including API transport registration.
- Mocked browser check confirms the updated list and enabled Refresh button appear while comparisons remain blocked, and an older response cannot replace newer-head counts.
- Real GitHub reads exercised the implementation against isolated test databases: RisingWave list returned in 7.1 s and iceberg-rust in 3.0 s (previous network-path replay: 27.5 s / 8.8 s). The first RisingWave comparison completed separately in 1.7 s; the cached repeat took under 1 ms. These are single local samples, not percentile benchmarks. Live Lantor data was read-only.

The new SQLite cache is created by the existing startup migration. The former unkeyed queue count column is retained for compatibility but is no longer read or written. API failures are not cached; missing batch objects are treated as errors, never as closed PRs.
