### PR TITLE
fix: reconcile sent messages and agent lifecycle status

### DIFF
--- a/docs/web-state-sync.md
+++ b/docs/web-state-sync.md
@@ -1,6 +1,8 @@
 # Web state synchronization
 
-`bootstrap` initializes the UI and captures the durable `ui_events.id` cursor before loading state. Normal writes no longer wait for another bootstrap. Message responses replace optimistic rows by id; committed entity events update the other clients. Refresh events invalidate only the collections listed in `src/ui-state-sync.ts`, read through `load_ui_state`. That endpoint does not read message history, run logs, or artifact content.
+`bootstrap` initializes the UI and captures the durable `ui_events.id` cursor before loading state. Normal writes no longer wait for another bootstrap. Owner sends supply an optional client-generated `messageId` UUID, shared by the optimistic row, persisted message, committed event and response. SSE/Tauri delivery may precede the send response; either path reconciles the same row. A committed event or snapshot also acknowledges the send if its HTTP response later fails. Older callers that omit `messageId` still receive a server-generated UUID. Refresh events invalidate only the collections listed in `src/ui-state-sync.ts`, read through `load_ui_state`. That endpoint does not read message history, run logs, or artifact content.
+
+Run lifecycle events invalidate the `agents` collection as well as updating their run row. The server's current agent status is authoritative: an old run finishing does not imply idleness if a successor is already queued or running. Profile reads use the same versioned, coalesced scope queue, so a response started before completion cannot restore a stale busy status. Usage-only run events remain buffered and do not trigger profile reads.
 
 Web SSE and Tauri share the committed event hub described in [ui-event-delivery.md](ui-event-delivery.md). It replaces per-connection polling with one cross-process metadata observer and broadcast delivery.
 
@@ -15,5 +17,6 @@ When adding a mutation, publish its affected entity or a scoped invalidation in 
 Validation:
 
 - `npm test`: state patches, optimistic preservation, cursor deduplication, backoff and disposal.
+- `npm run test:message-state-races`: hold send responses after committed SSE delivery, check roots/replies and identical real sends, lose an acknowledged response, and race lifecycle changes against in-flight profile reads. Set `LANTOR_RACE_ENGINE=webkit` for WebKit coverage.
 - `npm run build` followed by `npm run test:web-sync`: production React UI and real EventSource against an isolated synthetic HTTP service; send/read/task operations, stale collection response, simulated hidden lifecycle for 65 seconds, real SSE outage for 10 seconds, and unchanged foreground checks.
 - `cargo test --manifest-path src-tauri/Cargo.toml`: real SQLite and Axum mutation, scoped read and replay contracts, alongside existing backend coverage.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:attachments": "cargo test --manifest-path src-tauri/Cargo.toml web::attachment_tests::browser_cache_range_and_upload_memory -- --ignored --nocapture",
     "test:sse-push": "cargo test --manifest-path src-tauri/Cargo.toml web::sse_push_tests::browser_cross_process_delivery_and_query_scaling -- --ignored --nocapture",
     "test:web-sync": "node tests/web-sync.e2e.mjs",
+    "test:message-state-races": "node tests/message-state-races.e2e.mjs",
     "test:web-math": "node tests/web-math.e2e.mjs",
     "test:message-rows": "node tests/message-rows.e2e.mjs",
     "test:avatar-cache": "node tests/avatar-cache.e2e.mjs",

--- a/src-tauri/src/application/messages.rs
+++ b/src-tauri/src/application/messages.rs
@@ -20,6 +20,7 @@ use crate::{
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SendMessageRequest {
+    pub(crate) message_id: Option<Uuid>,
     pub(crate) channel_id: Uuid,
     pub(crate) thread_root_id: Option<Uuid>,
     pub(crate) body: String,
@@ -81,6 +82,7 @@ pub(crate) async fn send_message(
 ) -> CommandResult<Message> {
     send_owner_message_in_pool(
         pool,
+        request.message_id,
         request.channel_id,
         request.thread_root_id,
         &request.body,

--- a/src-tauri/src/commands/messages.rs
+++ b/src-tauri/src/commands/messages.rs
@@ -13,6 +13,7 @@ use crate::{
 
 #[tauri::command]
 pub(crate) async fn send_message(
+    message_id: Option<Uuid>,
     channel_id: Uuid,
     thread_root_id: Option<Uuid>,
     body: String,
@@ -23,6 +24,7 @@ pub(crate) async fn send_message(
     application::send_message(
         &state.pool,
         SendMessageRequest {
+            message_id,
             channel_id,
             thread_root_id,
             body,

--- a/src-tauri/src/message_store.rs
+++ b/src-tauri/src/message_store.rs
@@ -1017,6 +1017,7 @@ pub(crate) async fn insert_agent_message_with_options(
 
 pub(crate) async fn send_owner_message_in_pool(
     pool: &SqlitePool,
+    message_id: Option<Uuid>,
     channel_id: Uuid,
     thread_root_id: Option<Uuid>,
     body: &str,
@@ -1052,11 +1053,12 @@ pub(crate) async fn send_owner_message_in_pool(
 
     let msg_id: Uuid = sqlx::query_scalar(
         r#"
-        insert into messages (channel_id, thread_root_id, sender_name, sender_role, body, is_task)
-        values ($1, $2, $3, 'owner', $4, $5)
+        insert into messages (id, channel_id, thread_root_id, sender_name, sender_role, body, is_task)
+        values ($1, $2, $3, $4, 'owner', $5, $6)
         returning id
         "#,
     )
+    .bind(message_id.unwrap_or_else(Uuid::new_v4))
     .bind(channel_id)
     .bind(thread_root_id)
     .bind(owner_display_name)

--- a/src-tauri/src/tests/agent_inbox_wake.rs
+++ b/src-tauri/src/tests/agent_inbox_wake.rs
@@ -284,6 +284,7 @@ async fn inbox_wake_context_exposes_root_message_attachments() {
 
         let message = send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             None,
             "@file-agent please inspect the attached plan",
@@ -339,6 +340,7 @@ async fn inbox_wake_creates_work_items_without_serializing_unread_items() {
 
         send_owner_message_in_pool(
             &pool,
+            None,
             dm_channel_id,
             None,
             "first inbox item",
@@ -348,6 +350,7 @@ async fn inbox_wake_creates_work_items_without_serializing_unread_items() {
         .await?;
         send_owner_message_in_pool(
             &pool,
+            None,
             dm_channel_id,
             None,
             "second inbox item",
@@ -468,6 +471,7 @@ async fn inbox_wake_batches_unread_items_for_same_thread() {
 
         send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             Some(root_id),
             "first pending follow-up",
@@ -477,6 +481,7 @@ async fn inbox_wake_batches_unread_items_for_same_thread() {
         .await?;
         send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             Some(root_id),
             "second pending follow-up",

--- a/src-tauri/src/tests/agent_routing.rs
+++ b/src-tauri/src/tests/agent_routing.rs
@@ -53,7 +53,7 @@ async fn dm_rejects_tasks_and_auto_dispatches_owner_messages() {
                 .map_err(|err| err.to_string())?;
 
         let owner_task_err =
-            send_owner_message_in_pool(&pool, dm_channel_id, None, "task body", true, vec![])
+            send_owner_message_in_pool(&pool, None, dm_channel_id, None, "task body", true, vec![])
                 .await
                 .unwrap_err();
         assert!(owner_task_err.contains("direct messages do not support tasks"));
@@ -66,6 +66,7 @@ async fn dm_rejects_tasks_and_auto_dispatches_owner_messages() {
 
         send_owner_message_in_pool(
             &pool,
+            None,
             dm_channel_id,
             None,
             "please inspect this",
@@ -147,6 +148,7 @@ async fn owner_channel_root_message_without_mentions_delivers_to_member_agent_in
 
         send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             None,
             "Lantor README needs a quick review",
@@ -228,6 +230,7 @@ async fn owner_channel_root_message_does_not_dispatch_error_agent() {
 
         send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             None,
             "This should not wake a quota-limited agent",
@@ -273,6 +276,7 @@ async fn owner_mention_does_not_dispatch_error_agent() {
 
         send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             None,
             "@quota-mentioned please check this",
@@ -319,6 +323,7 @@ async fn owner_mention_resolves_agent_handle_case_insensitively() {
 
         send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             None,
             "@mixedcaseagent please inspect this",
@@ -390,6 +395,7 @@ async fn owner_thread_followup_dispatches_to_thread_agents_without_mentions() {
 
         send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             Some(root_id),
             "我补充一下：这个复现只在 thread 里出现",
@@ -499,6 +505,7 @@ async fn owner_thread_followup_with_explicit_mention_does_not_fan_out_to_thread_
 
         send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             Some(root_id),
             "@mentioned-agent 这个后续只给被点名的 agent",
@@ -587,6 +594,7 @@ async fn owner_thread_followup_with_unknown_mention_does_not_fall_back_to_thread
 
         send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             Some(root_id),
             "@missing-agent 这个后续不应该 fallback 给 thread 参与者",
@@ -660,6 +668,7 @@ async fn owner_thread_followup_uses_agent_thread_subscription_after_work_done() 
 
         send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             Some(root_id),
             "继续补充，不需要重新 @ agent",
@@ -705,6 +714,7 @@ async fn mentions_create_agent_requests_but_only_task_mode_creates_global_tasks(
 
         send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             None,
             "@task-agent please look at this",
@@ -728,6 +738,7 @@ async fn mentions_create_agent_requests_but_only_task_mode_creates_global_tasks(
 
         send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             None,
             "@task-agent implement the tracked feature",

--- a/src-tauri/src/tests/agent_work_dispatch.rs
+++ b/src-tauri/src/tests/agent_work_dispatch.rs
@@ -124,6 +124,7 @@ async fn owner_task_without_mentions_auto_assigns_single_channel_agent() {
 
         send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             None,
             "Implement the compact task flow",
@@ -181,6 +182,7 @@ async fn owner_task_without_mentions_stays_unassigned_with_multiple_channel_agen
 
         send_owner_message_in_pool(
             &pool,
+            None,
             channel_id,
             None,
             "Implement the unassigned queue",

--- a/src-tauri/src/tests/context_tool.rs
+++ b/src-tauri/src/tests/context_tool.rs
@@ -470,6 +470,7 @@ async fn agent_context_inbox_tools_list_read_and_archive_items() {
             .map_err(|err| err.to_string())?;
         let message = send_owner_message_in_pool(
             &pool,
+            None,
             dm_channel_id,
             None,
             "please inspect inbox tools",

--- a/src-tauri/src/tests/web_sync.rs
+++ b/src-tauri/src/tests/web_sync.rs
@@ -8,6 +8,7 @@ use axum::{
 use serde_json::{json, Value};
 use std::{path::PathBuf, sync::Arc};
 use tower::ServiceExt;
+use uuid::Uuid;
 
 async fn post(app: &Router, command: &str, args: Value) -> Value {
     let response = app
@@ -115,5 +116,87 @@ async fn web_mutations_replay_entities_and_read_only_affected_state() {
             .await
             .is_err()
     );
+    drop_test_schema(pool, path).await;
+}
+
+#[tokio::test]
+async fn client_message_ids_match_responses_replay_and_thread_history() {
+    let (pool, path) = test_pool().await.expect("SQLite fixture");
+    let channel = insert_test_channel(&pool, "message-id-test").await.unwrap();
+    let app = web_router(
+        Arc::new(WebState {
+            pool: pool.clone(),
+            db_url: "synthetic".into(),
+        }),
+        PathBuf::from("/nonexistent"),
+    );
+    let root_id = Uuid::new_v4();
+    let root = post(
+        &app,
+        "send_message",
+        json!({
+            "messageId": root_id, "channelId": channel, "body": "Same text", "asTask": true
+        }),
+    )
+    .await;
+    assert_eq!(root["id"], root_id.to_string());
+    assert!(root["seq"].as_i64().unwrap() > 0);
+    let reply_id = Uuid::new_v4();
+    let reply = post(
+        &app,
+        "send_message",
+        json!({
+            "messageId": reply_id, "channelId": channel, "threadRootId": root_id,
+            "body": "Same text", "asTask": false
+        }),
+    )
+    .await;
+    assert_eq!(reply["id"], reply_id.to_string());
+    assert_eq!(reply["thread_root_id"], root["id"]);
+    assert!(reply["seq"].as_i64().unwrap() > root["seq"].as_i64().unwrap());
+    let history = post(
+        &app,
+        "load_thread_messages",
+        json!({"threadRootId": root_id}),
+    )
+    .await;
+    assert_eq!(history.as_array().unwrap().len(), 2);
+    let replay = post(&app, "replay_ui_events", json!({"cursor": 0})).await;
+    let messages: Vec<Value> = replay["events"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|delivery| serde_json::from_str::<Value>(delivery["event"].as_str().unwrap()).unwrap())
+        .filter(|event| event["type"] == "message_upsert")
+        .map(|event| event["message"].clone())
+        .collect();
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0]["id"], root["id"]);
+    assert_eq!(messages[1]["id"], reply["id"]);
+
+    // An identity collision cannot overwrite a message, enqueue another event,
+    // or create a second task. Older callers without an id are covered above.
+    let collision = crate::message_store::send_owner_message_in_pool(
+        &pool,
+        Some(root_id),
+        channel,
+        None,
+        "Overwrite attempt",
+        true,
+        vec![],
+    )
+    .await;
+    assert!(collision.is_err());
+    let unchanged = post(&app, "load_message", json!({"messageId": root_id})).await;
+    assert_eq!(unchanged["body"], "Same text");
+    let tasks = post(&app, "load_ui_state", json!({"scopes": ["tasks"]})).await;
+    assert_eq!(tasks["tasks"].as_array().unwrap().len(), 1);
+    let replay = post(
+        &app,
+        "replay_ui_events",
+        json!({"cursor": replay["cursor"]}),
+    )
+    .await;
+    assert_eq!(replay["events"], json!([]));
     drop_test_schema(pool, path).await;
 }

--- a/src-tauri/src/web_upload.rs
+++ b/src-tauri/src/web_upload.rs
@@ -181,8 +181,9 @@ mod tests {
     async fn multipart_send_message_preserves_binary_attachments() {
         let boundary = "lantor-attachment-boundary";
         let channel_id = Uuid::new_v4();
+        let message_id = Uuid::new_v4();
         let metadata = format!(
-            r#"{{"channelId":"{channel_id}","threadRootId":null,"body":"hello","asTask":false}}"#
+            r#"{{"messageId":"{message_id}","channelId":"{channel_id}","threadRootId":null,"body":"hello","asTask":false}}"#
         );
         let mut body = format!(
             "--{boundary}\r\n\
@@ -209,6 +210,7 @@ mod tests {
         let request = parse_multipart_in(multipart, &root).await.unwrap();
 
         assert_eq!(request.channel_id, channel_id);
+        assert_eq!(request.message_id, Some(message_id));
         assert_eq!(request.thread_root_id, None);
         assert_eq!(request.body, "hello");
         assert!(!request.as_task);

--- a/src/api-contract.ts
+++ b/src/api-contract.ts
@@ -82,6 +82,7 @@ export type ApiContract = {
   };
   send_message: {
     args: {
+      messageId?: string | null;
       channelId: string;
       threadRootId?: string | null;
       body: string;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -539,7 +539,13 @@ function clientId() {
   if (globalThis.crypto && typeof globalThis.crypto.randomUUID === "function") {
     return globalThis.crypto.randomUUID();
   }
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  // randomUUID requires a secure context; LAN HTTP clients still have
+  // getRandomValues. Message identities must also be valid UUIDs there.
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
 function draftAttachmentFromFile(file: File): DraftAttachment {
@@ -1174,6 +1180,7 @@ function App() {
       perf.phases.parseMs = measurement.parseMs;
     }
     const applyStartedAt = performance.now();
+    for (const message of payload.messages) acknowledgeOptimisticMessage(message);
     const hydration = {
       snapshotInvalidated: refreshInvalidation !== refreshInvalidationRef.current,
       loadedHistoricalMessageIds: new Set([
@@ -1404,6 +1411,7 @@ function App() {
     void apiInvoke("load_thread_messages", { threadRootId: threadId }).then((messages) => {
       if (cancelled) return;
       for (const message of messages) {
+        acknowledgeOptimisticMessage(message);
         knownMessageIdsRef.current?.add(message.id);
         loadedHistoricalMessageIdsRef.current.add(message.id);
       }
@@ -1482,6 +1490,7 @@ function App() {
         setExhaustedOlderChannelIds((current) => new Set(current).add(channelId));
       }
       for (const message of page.messages) {
+        acknowledgeOptimisticMessage(message);
         hydratedMessageIdsRef.current.add(message.id);
         hydratedMessageBodiesRef.current.set(message.id, message.body);
         knownMessageIdsRef.current?.add(message.id);
@@ -1537,6 +1546,7 @@ function App() {
       }
       paginatedChannelIdsRef.current.add(channelId);
       for (const message of page.messages) {
+        acknowledgeOptimisticMessage(message);
         loadedHistoricalMessageIdsRef.current.add(message.id);
         hydratedMessageIdsRef.current.add(message.id);
         hydratedMessageBodiesRef.current.set(message.id, message.body);
@@ -1590,6 +1600,7 @@ function App() {
   }
 
   function applyMessageUpsert(message: Message, preserveBufferedDeltas = false) {
+    acknowledgeOptimisticMessage(message);
     const perf = shouldEnablePerfTelemetry() ? createPerfDraft("message-upsert") : null;
     if (!preserveBufferedDeltas) {
       messageDeltaBufferRef.current.delete(message.id);
@@ -1958,6 +1969,11 @@ function App() {
           continue;
         }
         if (event.type === "agent_run_upsert") {
+          // Run patches do not contain the agent's current status. Re-read it
+          // for lifecycle changes, including completion and failure. A newer
+          // run may already be queued, so never infer idle from an old run.
+          // Usage-only updates stay on the inexpensive buffered path.
+          if (event.reason !== "run_usage") requestUiState(["agents"]);
           // Run terminal transitions MUST land immediately so the UI shows
           // completion / failure without waiting for the buffer. Drop any
           // stale pending ephemeral for the same run id first to avoid the
@@ -4164,7 +4180,9 @@ function App() {
     asTask: boolean,
     attachments: DraftAttachment[] = [],
   ) {
-    const id = `local-${clientId()}`;
+    // Use the same identity for the optimistic row, committed event and HTTP
+    // response. Either transport can acknowledge the send first.
+    const id = clientId();
     const createdAt = new Date().toISOString();
     const optimisticMessage: Message = {
       id,
@@ -4198,8 +4216,16 @@ function App() {
     return id;
   }
 
+  function acknowledgeOptimisticMessage(message: Message) {
+    if (message.seq > 0 && optimisticMessagesRef.current.delete(message.id)) {
+      releaseOptimisticAttachmentUrls(message.id);
+    }
+  }
+
   function removeOptimisticMessage(messageId: string) {
-    optimisticMessagesRef.current.delete(messageId);
+    // A committed event (or snapshot) may have acknowledged this send even if
+    // the HTTP response failed. Keep the message and the user's newer draft.
+    if (!optimisticMessagesRef.current.delete(messageId)) return false;
     releaseOptimisticAttachmentUrls(messageId);
     knownMessageIdsRef.current?.delete(messageId);
     invalidatePendingRefreshResult();
@@ -4209,6 +4235,7 @@ function App() {
         messageId,
       }),
     );
+    return true;
   }
 
   function settleOptimisticMessage(messageId: string, persistedMessage: Message) {
@@ -4482,6 +4509,7 @@ function App() {
     try {
       const persistedMessage = await sendMessage(
         {
+          messageId: optimisticId,
           channelId: channel.id,
           threadRootId: null,
           body,
@@ -4491,7 +4519,7 @@ function App() {
       );
       settleOptimisticMessage(optimisticId, persistedMessage);
     } catch (err) {
-      removeOptimisticMessage(optimisticId);
+      if (!removeOptimisticMessage(optimisticId)) return;
       updateRootComposerDraft(channel.id, () => ({ text: body, attachments }));
       const message = errorMessage(err, "Failed to send message");
       setAppError(message);
@@ -4524,6 +4552,7 @@ function App() {
     try {
       const persistedMessage = await sendMessage(
         {
+          messageId: optimisticId,
           channelId: channel.id,
           threadRootId: activeRoot.id,
           body,
@@ -4533,7 +4562,7 @@ function App() {
       );
       settleOptimisticMessage(optimisticId, persistedMessage);
     } catch (err) {
-      removeOptimisticMessage(optimisticId);
+      if (!removeOptimisticMessage(optimisticId)) return;
       updateReplyComposerDraft(activeRoot.id, () => ({ text: body, attachments }));
       const message = errorMessage(err, "Failed to send reply");
       setAppError(message);

--- a/tests/message-state-races.e2e.mjs
+++ b/tests/message-state-races.e2e.mjs
@@ -1,0 +1,202 @@
+// Production UI and real SSE against an isolated API. Never uses live workspace data.
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { chromium, webkit } from "playwright";
+
+const id = n => `00000000-0000-4000-8000-${String(n).padStart(12, "0")}`;
+const now = new Date().toISOString(), channelId = id(1), agentId = id(2);
+let seq = 10;
+const message = (body, extra = {}) => ({ id: id(++seq), seq, channel_id: channelId, thread_root_id: null,
+  sender_agent_id: null, sender_name: "Test owner", sender_role: "owner", body, is_task: false,
+  thread_followed: true, delivery_state: "complete", stream_key: "", task_number: null, task_status: null,
+  attachments: [], artifacts: [], created_at: now, updated_at: now, ...extra });
+const root = message("Open race test thread");
+const agent = { id: agentId, handle: "RaceAgent", display_name: "Race Agent", role: "agent", status: "running",
+  runtime: "codex", model: "", reasoning_effort: "", service_tier: "", avatar: "R", description: "",
+  launch_command: "", environment_variables: "", working_directory: "", workspace_exists: false,
+  workspace_memory_path: "", workspace_memory_exists: false, workspace_entries: [], details_loaded: true,
+  daily_budget_micros: 0, subscription_status: null };
+const run = (status, extra = {}) => ({ id: id(3), agent_id: agentId, work_item_id: null, command: "fixture",
+  working_directory: "", status, pid: null, exit_code: null, log: "", started_at: now,
+  stopped_at: status === "running" ? null : now, input_tokens: 0, output_tokens: 0, cost_micros: 0, ...extra });
+const state = { db_url: "synthetic://message-state-races", web_base_url: null,
+  owner_profile: { display_name: "Test owner", avatar: "T", description: "" },
+  channels: [{ id: channelId, name: "race-test", description: "", kind: "channel", dm_agent_id: null,
+    unread_count: 0, github_unread_count: 0, github_review_synced_at: null }],
+  messages: [root, message("Existing reply", { thread_root_id: root.id }), message("Agent status fixture", { sender_agent_id: agentId, sender_name: agent.display_name, sender_role: "agent" })],
+  channel_message_history: [{ channel_id: channelId, before_seq: null, has_more: false }],
+  agents: [agent], agent_runs: [run("running")], thread_activities: [], channel_members: [], saved_messages: [],
+  dismissed_inbox_items: {}, read_inbox_items: {}, tasks: [], artifacts: [], reminders: [], agent_schedules: [],
+  agent_work_items: [], agent_activities: [], supervisor: { pid: null, status: "stopped", updated_at: null },
+  launch_agent: { label: "", plist_path: "", installed: false, loaded: false }, ui_event_cursor: 0 };
+const clients = new Set(), events = [], requests = [], pendingSends = [];
+let heldAgentRead = null;
+const publish = event => {
+  const delivery = { cursor: events.length + 1, event: JSON.stringify(event) };
+  events.push(delivery);
+  for (const client of clients) client.write(`id: ${delivery.cursor}\nevent: lantor\ndata: ${delivery.event}\n\n`);
+};
+const api = createServer(async (req, res) => {
+  const url = new URL(req.url, "http://localhost");
+  if (!url.pathname.startsWith("/api/")) {
+    const file = resolve("dist", url.pathname === "/" ? "index.html" : url.pathname.slice(1));
+    if (!file.startsWith(resolve("dist") + "/")) { res.writeHead(404).end(); return; }
+    try {
+      const mime = { html: "text/html", js: "application/javascript", css: "text/css", woff2: "font/woff2", svg: "image/svg+xml" };
+      res.writeHead(200, { "content-type": mime[file.split(".").pop()] || "application/octet-stream" }).end(await readFile(file));
+    } catch { res.writeHead(404).end(); }
+    return;
+  }
+  if (url.pathname === "/api/events") {
+    res.writeHead(200, { "content-type": "text/event-stream" }); res.write(": ready\n\n");
+    clients.add(res); res.on("close", () => clients.delete(res)); return;
+  }
+  const chunks = []; for await (const chunk of req) chunks.push(chunk);
+  const raw = Buffer.concat(chunks);
+  let args, files = [];
+  if (req.headers["content-type"]?.startsWith("multipart/form-data")) {
+    const form = await new Response(raw, { headers: { "content-type": req.headers["content-type"] } }).formData();
+    args = JSON.parse(form.get("request")); files = form.getAll("attachments");
+  } else args = raw.length ? JSON.parse(raw.toString()) : {};
+  requests.push({ path: url.pathname, args });
+  let result = { ok: true };
+  switch (url.pathname) {
+    case "/api/bootstrap": result = { ...state, ui_event_cursor: events.length }; break;
+    case "/api/load_channel_previews": case "/api/load_activity_messages": result = []; break;
+    case "/api/load_channel_messages": result = { messages: state.messages, next_before_seq: null, has_more: false }; break;
+    case "/api/load_thread_messages": result = state.messages.filter(m => m.id === args.threadRootId || m.thread_root_id === args.threadRootId); break;
+    case "/api/load_message": result = state.messages.find(m => m.id === args.messageId); break;
+    case "/api/load_ui_state": result = Object.fromEntries(args.scopes.map(scope => [scope, state[scope]])); break;
+    case "/api/replay_ui_events": result = { cursor: events.length, replayGap: false, events: events.filter(e => e.cursor > args.cursor) }; break;
+    case "/api/send_message": {
+      const row = message(args.body, { ...(args.messageId ? { id: args.messageId } : {}), thread_root_id: args.threadRootId ?? null });
+      row.attachments = files.map((file, i) => ({ id: id(100 + i), message_id: row.id, original_name: file.name,
+        mime_type: file.type, size_bytes: file.size, storage_path: "", created_at: now }));
+      state.messages.push(row);
+      publish({ type: "message_upsert", reason: "message", message: row });
+      const fail = await new Promise(release => pendingSends.push({ row, release }));
+      res.writeHead(fail ? 500 : 200, { "content-type": "application/json" }).end(JSON.stringify(fail ? { error: "Response lost after commit" } : row));
+      return;
+    }
+  }
+  const payload = JSON.stringify(result);
+  if (url.pathname === "/api/load_ui_state" && args.scopes.includes("agents") && heldAgentRead) {
+    heldAgentRead.started = true;
+    await heldAgentRead.promise;
+  }
+  res.writeHead(200, { "content-type": "application/json" }).end(payload);
+});
+await new Promise(done => api.listen(0, "127.0.0.1", done));
+const count = path => requests.filter(r => r.path === `/api/${path}`).length;
+const agentReads = () => requests.filter(r => r.path === "/api/load_ui_state" && r.args.scopes.includes("agents")).length;
+let browser;
+try {
+  const engine = process.env.LANTOR_RACE_ENGINE === "webkit" ? webkit : chromium;
+  browser = await engine.launch();
+  const mobile = process.env.LANTOR_RACE_MOBILE === "1";
+  const context = await browser.newContext({ serviceWorkers: "block", viewport: mobile ? { width: 390, height: 844 } : { width: 1440, height: 1000 } });
+  // randomUUID is unavailable on non-localhost HTTP mobile clients; getRandomValues remains available.
+  await context.addInitScript(() => Object.defineProperty(crypto, "randomUUID", { value: undefined }));
+  const page = await context.newPage(); page.setDefaultTimeout(5000);
+  const errors = []; page.on("pageerror", error => errors.push(error.message));
+  await page.goto(`http://127.0.0.1:${api.address().port}`, { waitUntil: "domcontentloaded" });
+  await page.locator(`.conversation [data-message-id="${root.id}"]`).waitFor();
+  const until = async predicate => {
+    for (let i = 0; i < 100 && !predicate(); i++) await page.waitForTimeout(25);
+    assert.ok(predicate(), "fixture condition reached");
+  };
+  await until(() => clients.size > 0);
+  if (process.env.LANTOR_RACE_CASE !== "status") {
+    const send = async (surface, text) => {
+      const before = pendingSends.length;
+      const panel = page.locator(surface);
+      await panel.locator("textarea").fill(text);
+      await panel.getByRole("button", { name: surface === ".thread" ? "Send reply" : "Send message", exact: true }).click();
+      await until(() => pendingSends.length === before + 1);
+      const pending = pendingSends.at(-1);
+      await page.locator(`${surface} [data-message-id="${pending.row.id}"]`).waitFor();
+      await page.waitForTimeout(150);
+      return pending;
+    };
+    const bodyCount = async (surface, text) => page.locator(`${surface} .markdown-body`).filter({ hasText: text }).count();
+    const sent = await send(".conversation", "Root response held");
+    assert.equal(await bodyCount(".conversation", sent.row.body), 1, "root must have one row before HTTP response");
+    assert.match(sent.row.id, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/, "client supplies a UUID even over HTTP");
+    sent.release(false); await page.waitForTimeout(100);
+    const rootRow = page.locator(`.conversation [data-message-id="${root.id}"]`);
+    if (mobile) await rootRow.locator(".markdown-body").click();
+    else { await rootRow.hover(); await rootRow.getByRole("button", { name: "View thread replies", exact: true }).click(); }
+    await page.locator(".thread textarea").waitFor();
+    const reply = await send(".thread", "Reply response held");
+    assert.equal(await bodyCount(".thread", reply.row.body), 1, "reply must have one row before HTTP response");
+    // A second real send with identical text remains a distinct message.
+    const second = await send(".thread", reply.row.body);
+    assert.notEqual(reply.row.id, second.row.id);
+    assert.equal(await bodyCount(".thread", reply.row.body), 2, "identical real sends are not content-deduplicated");
+    second.release(false); reply.release(false); await page.waitForTimeout(100);
+    const lost = await send(".thread", "Committed reply with failed response");
+    await page.locator(".thread textarea").fill("New draft stays here");
+    lost.release(true); await page.waitForTimeout(200);
+    assert.equal(await bodyCount(".thread", lost.row.body), 1, "a committed row survives a failed HTTP response");
+    assert.equal(await page.locator(".thread textarea").inputValue(), "New draft stays here");
+    assert.equal(count("bootstrap"), 1, "message reconciliation never bootstraps");
+    await page.locator('.thread input[type="file"]').setInputFiles({ name: "race.txt", mimeType: "text/plain", buffer: Buffer.from("attachment fixture") });
+    const attachment = await send(".thread", "Attachment response held");
+    assert.equal(attachment.row.attachments.length, 1);
+    assert.equal(await bodyCount(".thread", attachment.row.body), 1);
+    assert.equal(await page.locator(`.thread [data-message-id="${attachment.row.id}"]`).getByText("race.txt", { exact: true }).count(), 1);
+    // Recover a fresh snapshot while the send response remains in flight.
+    const refreshed = page.waitForResponse(response => new URL(response.url()).pathname === "/api/bootstrap");
+    publish({ type: "refresh", reason: "event_replay_gap" });
+    await refreshed; await page.waitForTimeout(250);
+    attachment.release(false); await page.waitForTimeout(150);
+    assert.equal(await bodyCount(".thread", attachment.row.body), 1, "snapshot cannot resurrect the optimistic copy");
+    console.log("PASS: root/reply event-before-response, UUID fallback, identical sends, committed-response failure, attachment/snapshot");
+  }
+  const bootstrapBeforeStatus = count("bootstrap");
+  if (process.env.LANTOR_RACE_CASE !== "messages") {
+    const avatar = page.locator(".conversation .message-agent-avatar-trigger .agent-avatar");
+    const expectStatus = async status => {
+      await page.waitForFunction(status => document.querySelector(".conversation .message-agent-avatar-trigger .agent-avatar")?.classList.contains(`status-${status}`), status);
+    };
+    assert.ok((await avatar.getAttribute("class")).includes("status-running"));
+    agent.status = "idle"; state.agent_runs = [run("exited")];
+    publish({ type: "agent_run_upsert", reason: "codex_turn_finished", run: state.agent_runs[0] });
+    await expectStatus("idle");
+    // A prior collection read must not put the old busy state back after completion.
+    let release;
+    heldAgentRead = { started: false, promise: new Promise(done => { release = done; }) };
+    agent.status = "running";
+    publish({ type: "agent_run_upsert", reason: "run_running", run: run("running", { id: id(4) }) });
+    await until(() => heldAgentRead.started);
+    agent.status = "idle";
+    publish({ type: "agent_run_upsert", reason: "claude_turn_finished", run: run("exited", { id: id(4) }) });
+    await page.waitForTimeout(50); heldAgentRead = null; release();
+    await expectStatus("idle"); await page.waitForTimeout(250); await expectStatus("idle");
+    // An old run finishing is not proof of idleness: the next run may already be queued.
+    agent.status = "queued";
+    publish({ type: "agent_run_upsert", reason: "run_finished", run: run("exited") });
+    await expectStatus("queued");
+    agent.status = "running";
+    publish({ type: "agent_run_upsert", reason: "run_running", run: run("running", { id: id(5) }) });
+    await expectStatus("running");
+    const beforeUsage = agentReads();
+    for (let i = 0; i < 10; i++) publish({ type: "agent_run_upsert", reason: "run_usage", run: run("running", { id: id(5), input_tokens: i }) });
+    await page.waitForTimeout(250);
+    assert.equal(agentReads(), beforeUsage, "usage-only events do not fetch profiles");
+    agent.status = "idle";
+    publish({ type: "agent_run_upsert", reason: "run_failed", run: run("failed", { id: id(5) }) });
+    await expectStatus("idle");
+    assert.equal(count("bootstrap"), bootstrapBeforeStatus, "lifecycle synchronization never bootstraps");
+    console.log("PASS: completion, stale in-flight profile read, queued successor, start/failure, usage-only batching");
+  }
+  assert.deepEqual(errors, []);
+} finally {
+  for (const pending of pendingSends) pending.release(false);
+  if (browser) await browser.close();
+  for (const client of clients) client.end();
+  api.closeAllConnections();
+  await new Promise(done => api.close(done));
+}

--- a/tests/state-sync.test.ts
+++ b/tests/state-sync.test.ts
@@ -193,6 +193,29 @@ test("a delta applied after a request started wins over its stale streaming snap
   assert.equal(result.data.messages[0]?.delivery_state, "streaming");
 });
 
+test("sent roots and replies keep one identity across either event/response order and snapshot recovery", () => {
+  for (const threadRootId of [null, "thread-root"]) {
+    const room = channel("room");
+    const pending = message("client-message-id", room.id, { seq: 0, thread_root_id: threadRootId });
+    const persisted = { ...pending, seq: 12 };
+    for (const eventFirst of [true, false]) {
+      let current = bootstrap({ channels: [room] });
+      current = applyOptimisticMutation(current, { type: "message_add", message: pending })!;
+      const event = () => applyBackendEvent(current, { type: "message_upsert", message: persisted }).data!;
+      const response = () => applyOptimisticMutation(current, {
+        type: "message_replace", optimisticMessageId: pending.id, persistedMessage: persisted,
+      })!;
+      current = eventFirst ? event() : response();
+      assert.deepEqual(current.messages, [persisted]);
+      current = applySnapshot(current, bootstrap({ channels: [room], messages: [persisted] }),
+        snapshotOptions({ messages: new Map([[pending.id, pending]]) })).data;
+      assert.deepEqual(current.messages, [persisted]);
+      current = eventFirst ? response() : event();
+      assert.deepEqual(current.messages, [persisted]);
+    }
+  }
+});
+
 test("an optimistic channel tombstone prevents stale snapshot resurrection until acknowledged", () => {
   const doomed = channel("doomed");
   const doomedMessage = message("message-1", doomed.id);


### PR DESCRIPTION
Owner-message events can arrive before the send response, briefly rendering both the optimistic row and the committed row. Supply one optional client UUID through Web JSON/multipart and Tauri sends so both arrivals reconcile the same message. A committed event or snapshot also acknowledges the send if its response subsequently fails; separate sends with identical text remain separate messages. Older callers can still omit the ID.

Run lifecycle events now invalidate the versioned `agents` scope. This fixes avatars remaining busy after completion while preserving the server's current queued/running status when a successor has already started. Usage-only events retain their buffered path without additional profile reads. Both regressions follow the incremental synchronization changes in `02e87da`.

Validation:

- Reproduced both failures on the unmodified main build: two message rows while the HTTP response was held, and a busy avatar after a terminal run event.
- Production build, 59 frontend tests, `cargo check`, and 271 Rust tests passed (5 manual tests ignored).
- Chromium/WebKit production-UI regression coverage includes roots/replies, identical sends, lost responses after committed events, LAN UUID fallback, attachments, mobile layout, snapshot recovery, stale in-flight profile reads, queued successors, start/failure, and usage-only batching. Existing `test:web-sync` also passed.
- SQLite/Axum tests verify IDs across responses, event replay and thread history, collision rollback and legacy requests; multipart parsing preserves the ID and binary attachment.
- `git diff --check` and formatting of changed Rust files passed. Repository-wide rustfmt still reports the exact same differences as main in `bootstrap.rs`, `events/control.rs`, `task_store.rs`, and `web.rs`. Strict Clippy remains blocked by main's unchanged unused import, test-only stream helpers and items-after-test-module warnings in `web.rs`, `events/control.rs`, and `activity_store.rs`.

No database migration or new dependency. Deploy the matching frontend and backend for shared message IDs. This PR is independent of the earlier request-recovery PR #165; tests use isolated fixtures and do not send messages to or stop real agents.
