### PR TITLE
chore: restore Rust format and strict Clippy checks

### DIFF
--- a/src-tauri/src/activity_store.rs
+++ b/src-tauri/src/activity_store.rs
@@ -293,6 +293,20 @@ fn parse_json_value(raw: String) -> Value {
     serde_json::from_str(&raw).unwrap_or_else(|_| json!({}))
 }
 
+pub(crate) async fn load_agent_detail_activities(
+    pool: &SqlitePool,
+    agent_id: Uuid,
+) -> CommandResult<Vec<AgentActivity>> {
+    load_agent_activities_with_limit(pool, DEFAULT_AGENT_ACTIVITY_LIMIT_PER_AGENT, Some(agent_id))
+        .await
+}
+pub(crate) async fn load_agent_detail_work_items(
+    pool: &SqlitePool,
+    agent_id: Uuid,
+) -> CommandResult<Vec<AgentWorkItem>> {
+    load_agent_work_items_with_context(pool, true, Some(agent_id)).await
+}
+
 #[cfg(test)]
 mod tests {
     use sqlx::SqlitePool;
@@ -420,18 +434,4 @@ mod tests {
         drop_test_schema(pool, schema).await;
         assert!(result.is_ok(), "{:?}", result.err());
     }
-}
-
-pub(crate) async fn load_agent_detail_activities(
-    pool: &SqlitePool,
-    agent_id: Uuid,
-) -> CommandResult<Vec<AgentActivity>> {
-    load_agent_activities_with_limit(pool, DEFAULT_AGENT_ACTIVITY_LIMIT_PER_AGENT, Some(agent_id))
-        .await
-}
-pub(crate) async fn load_agent_detail_work_items(
-    pool: &SqlitePool,
-    agent_id: Uuid,
-) -> CommandResult<Vec<AgentWorkItem>> {
-    load_agent_work_items_with_context(pool, true, Some(agent_id)).await
 }

--- a/src-tauri/src/bootstrap.rs
+++ b/src-tauri/src/bootstrap.rs
@@ -359,7 +359,11 @@ async fn load_bootstrap_with_options(
                 .map(|item| item.thread_root_id.to_string()),
         );
         let relevant = |key: &String| {
-            key == "saved-messages" || key.rsplit(':').next().is_some_and(|id| relevant_ids.contains(id))
+            key == "saved-messages"
+                || key
+                    .rsplit(':')
+                    .next()
+                    .is_some_and(|id| relevant_ids.contains(id))
         };
         read_inbox_items.retain(|key, _| relevant(key));
         dismissed_inbox_items.retain(|key, _| relevant(key));

--- a/src-tauri/src/events/control.rs
+++ b/src-tauri/src/events/control.rs
@@ -329,7 +329,10 @@ fn strip_agent_event_prefix(text: &str) -> Option<&str> {
 mod stream_gate;
 pub(crate) use stream_gate::StreamControlGate;
 
-fn split_agent_event_jsons_from_text(text: &str, strip_incomplete_tail: bool) -> (String, Vec<String>) {
+fn split_agent_event_jsons_from_text(
+    text: &str,
+    strip_incomplete_tail: bool,
+) -> (String, Vec<String>) {
     let mut gate = StreamControlGate::new(false);
     let mut output = gate.push(text);
     let tail = gate.finish(!strip_incomplete_tail);
@@ -391,10 +394,12 @@ pub(crate) fn silent_reply_reason(body: &str) -> Option<String> {
     Some(reason.to_owned())
 }
 
+#[cfg(test)]
 pub(crate) fn split_streaming_agent_event_lines(body: &str) -> (String, Vec<String>) {
     split_agent_event_jsons_from_text(body, false)
 }
 
+#[cfg(test)]
 pub(crate) fn split_complete_streaming_agent_event_lines(body: &str) -> (String, Vec<String>) {
     split_streaming_agent_event_lines(body)
 }
@@ -1333,7 +1338,8 @@ mod tests {
             "引用 LANTOR_EVENT {\"type\":\"activity\"，这是不完整的示例。",
         ] {
             let (visible, events) = split_complete_streaming_agent_event_lines(body);
-            let (terminal_visible, terminal_events) = split_terminal_streaming_agent_event_lines(body);
+            let (terminal_visible, terminal_events) =
+                split_terminal_streaming_agent_event_lines(body);
             assert_eq!(visible, body);
             assert_eq!(terminal_visible, body);
             assert!(events.is_empty());

--- a/src-tauri/src/task_store.rs
+++ b/src-tauri/src/task_store.rs
@@ -90,8 +90,7 @@ pub(crate) async fn update_task_title_in_pool(
         .await
         .map_err(to_string)?;
 
-    let message =
-        crate::message_store::load_message_patch_in_tx(&mut tx, message_id).await?;
+    let message = crate::message_store::load_message_patch_in_tx(&mut tx, message_id).await?;
     enqueue_ui_event_in_tx(
         &mut tx,
         &UiEvent::MessageUpsert {

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -64,8 +64,7 @@ use crate::system_commands::check_runtime_in_env;
 use crate::ui_notifications::{enqueue_ui_event, enqueue_ui_event_in_tx, UiEvent};
 use crate::web_upload::parse_multipart_send_message;
 use crate::{
-    app::{to_string, CommandResult},
-    cancel_agent_work_in_pool, claim_task_in_pool, retry_agent_work_in_pool,
+    app::to_string, cancel_agent_work_in_pool, claim_task_in_pool, retry_agent_work_in_pool,
 };
 
 const WEB_SEND_MESSAGE_BODY_LIMIT: usize = 128 * 1024 * 1024;
@@ -335,7 +334,11 @@ fn web_router(state: Arc<WebState>, dist_dir: PathBuf) -> Router {
             ServeDir::new(&dist_dir)
                 .precompressed_gzip()
                 .precompressed_br()
-                .fallback(ServeFile::new(index).precompressed_gzip().precompressed_br()),
+                .fallback(
+                    ServeFile::new(index)
+                        .precompressed_gzip()
+                        .precompressed_br(),
+                ),
         )
     } else {
         app.fallback(get(move || missing_dist(dist_dir)))
@@ -480,12 +483,10 @@ async fn extract_send_message_request(
                 "multipart request is larger than 64MiB".to_owned(),
             ));
         }
-        let multipart = Multipart::from_request(
-            crate::web_upload::bounded_multipart_body(request),
-            state,
-        )
-        .await
-        .map_err(|rejection| rejection.into_response())?;
+        let multipart =
+            Multipart::from_request(crate::web_upload::bounded_multipart_body(request), state)
+                .await
+                .map_err(|rejection| rejection.into_response())?;
         return parse_multipart_send_message(multipart)
             .await
             .map_err(|error| api_error_status(error.status, error.message));
@@ -999,7 +1000,7 @@ fn requested_event_cursor(headers: &HeaderMap, query: &EventsQuery) -> Option<i6
 async fn event_stream_start(
     pool: &SqlitePool,
     requested_cursor: Option<i64>,
-) -> CommandResult<(i64, bool)> {
+) -> crate::app::CommandResult<(i64, bool)> {
     let mut subscription =
         crate::ui_event_hub::UiEventSubscription::connect(pool, requested_cursor).await?;
     let batch = subscription.recv().await?;


### PR DESCRIPTION
Restore Rust formatting and strict Clippy checks by removing an unused production import, restricting two test-only stream helpers to test builds, and moving activity detail loaders above the test module. Apply rustfmt to the affected backend files. Runtime behavior is unchanged.

Validation passed: `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`, `cargo check --manifest-path src-tauri/Cargo.toml`, `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`, and `git diff --check`. The full Rust test suite passed: 271 tests, 5 explicitly manual tests ignored.
