### PR TITLE
fix: clear progress for finished agent runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ reminder worker, event pruning, and web server, then serves Lantor at
 `http://127.0.0.1:8787/` by default. Set `LANTOR_WEB_BIND` only when you need
 another bind address, or set it to `off` to disable browser access.
 
+During `npm run tauri:dev`, the desktop window uses Vite, while browser access
+on port 8787 serves `dist/`. After pulling frontend updates, run `npm run build`
+and refresh those browser pages to load the updates; restarting the desktop
+development app alone does not rebuild the browser bundle.
+
 `npm run build` also generates gzip/Brotli sidecars for text assets. The web
 server negotiates them via `Accept-Encoding` and keeps the original files for
 other clients; API/SSE routes are not affected. Serve the complete `dist/`

--- a/src/components/ActivityProgressDock.tsx
+++ b/src/components/ActivityProgressDock.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { memo, useState } from "react";
+import { ACTIVE_RUN_STATUSES } from "../types";
 import type { Agent, AgentActivity, AgentRun, AgentWorkItem, Message } from "../types";
 import { messageHasVisibleContent, messageRunId } from "../message-grouping";
 import { formatClockTime } from "../ui-utils";
@@ -107,10 +108,7 @@ const HIDDEN_ACTIVITY_TITLES = new Set([
   "Stream event accepted",
 ]);
 const MAX_PROGRESS_HISTORY_ITEMS = 20;
-const ACTIVE_RUN_STATUSES = new Set(["starting", "running", "stopping"]);
 const ACTIVE_WORK_ITEM_STATUSES = new Set(["queued", "running", "cancelling"]);
-const SETTLING_WORK_ITEM_STATUSES = new Set(["done", "failed", "cancelled", "silent"]);
-const COMPLETION_SETTLE_WINDOW_MS = 15_000;
 const ACTIVITY_STATUS_LABELS: Record<string, string> = {
   active: "Active",
   success: "Done",
@@ -275,11 +273,6 @@ function timestamp(value: string) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function recentlyUpdated(value: string) {
-  const updatedAt = timestamp(value);
-  return updatedAt > 0 && Date.now() - updatedAt <= COMPLETION_SETTLE_WINDOW_MS;
-}
-
 function senderHandle(message: Message) {
   return message.sender_name.replace(/^@/, "").trim();
 }
@@ -316,7 +309,9 @@ export function indexProgress(
     activitiesByRun.set(activity.run_id, group);
   }
   const workItemsByChannel = new Map<string, Map<string | null, AgentWorkItem[]>>();
+  const workItemsByRun = new Map<string, AgentWorkItem>();
   for (const item of workItems) {
+    if (item.run_id) workItemsByRun.set(item.run_id, item);
     if (!item.channel_id) continue;
     const channel = workItemsByChannel.get(item.channel_id) ?? new Map<string | null, AgentWorkItem[]>();
     const root = item.thread_root_id ?? null;
@@ -325,9 +320,18 @@ export function indexProgress(
     channel.set(root, group);
     workItemsByChannel.set(item.channel_id, channel);
   }
+  const latestRunsByAgent = new Map<string, AgentRun>();
+  for (const run of runs) {
+    const latest = latestRunsByAgent.get(run.agent_id);
+    if (!latest || timestamp(run.started_at) > timestamp(latest.started_at)) {
+      latestRunsByAgent.set(run.agent_id, run);
+    }
+  }
   return {
     activitiesByRun,
     runsById: new Map(runs.map((run) => [run.id, run])),
+    latestRunsByAgent,
+    workItemsByRun,
     workItemsByChannel,
     agentsById: new Map(agents.map((agent) => [agent.id, agent])),
     agentsByHandle: new Map(agents.map((agent) => [agent.handle, agent])),
@@ -349,7 +353,7 @@ export function activeProgressByAgent(
       && message.delivery_state === "streaming"
       && !messageHasVisibleContent(message));
 
-  const { activitiesByRun, runsById, agentsById, agentsByHandle } = index;
+  const { activitiesByRun, runsById, latestRunsByAgent, workItemsByRun, agentsById, agentsByHandle } = index;
   const surfaceWorkItems = channelId
     ? index.workItemsByChannel.get(channelId)?.get(threadRootId) ?? []
     : [];
@@ -377,14 +381,10 @@ export function activeProgressByAgent(
       const runId = workItem.run_id;
       if (!runId) return;
       const run = runsById.get(runId);
-      const latestActivity = activitiesByRun.get(runId)?.[0] ?? null;
       const activeRun = Boolean(run && ACTIVE_RUN_STATUSES.has(run.status));
       const activeWorkItem = ACTIVE_WORK_ITEM_STATUSES.has(workItem.status);
-      const settlingWorkItem = SETTLING_WORK_ITEM_STATUSES.has(workItem.status)
-        && !isTerminalProgressActivity(latestActivity)
-        && recentlyUpdated(workItem.updated_at);
 
-      if (!activeRun && !activeWorkItem && !settlingWorkItem) return;
+      if (!activeRun && !activeWorkItem) return;
       addCandidate(runId, {
         message: null,
         workItem,
@@ -399,14 +399,30 @@ export function activeProgressByAgent(
 
   const progressByAgent = new Map<string, ActiveAgentProgress>();
   candidatesByRun.forEach((candidate, runId) => {
+    const run = runsById.get(runId);
+    // A crash, restart or failed launch can leave a streaming placeholder and
+    // no final activity. The run's lifecycle is authoritative over both.
+    if (run && !ACTIVE_RUN_STATUSES.has(run.status)) return;
     const runActivities = compactProgressActivities(activitiesByRun.get(runId) ?? []);
     const latestActivity = runActivities[0] ?? null;
     if (isTerminalProgressActivity(latestActivity)) return;
 
+    const workItem = candidate.workItem ?? workItemsByRun.get(runId) ?? null;
+    const agentId = run?.agent_id || workItem?.agent_id
+      || candidate.message?.sender_agent_id || latestActivity?.agent_id;
     const handle = activityAgentHandle(latestActivity)
-      || candidate.workItem?.agent_handle
+      || workItem?.agent_handle
       || (candidate.message ? senderHandle(candidate.message) : "");
-    const key = handle || candidate.message?.sender_name || runId;
+    const agent = (agentId ? agentsById.get(agentId) : undefined) ?? agentsByHandle.get(handle);
+    // Compact history can omit old runs. Do not revive their placeholders
+    // from an idle profile, settled work, or a newer run on another surface.
+    // A live run/work item still wins over a profile read that lags behind it.
+    if (!run && !(workItem && ACTIVE_WORK_ITEM_STATUSES.has(workItem.status))) {
+      if (workItem || (agent && !ACTIVE_RUN_STATUSES.has(agent.status))) return;
+      const latestRun = latestRunsByAgent.get(agentId || agent?.id || "");
+      if (latestRun && timestamp(latestRun.started_at) > timestamp(candidate.message?.created_at ?? "")) return;
+    }
+    const key = agent?.handle || handle || candidate.message?.sender_name || runId;
     const latestAt = Math.max(timestamp(latestActivity?.created_at ?? ""), candidate.latestAt);
     const existing = progressByAgent.get(key);
     const history = [...runActivities, ...(existing?.history ?? [])]
@@ -414,12 +430,12 @@ export function activeProgressByAgent(
     const compactHistory = compactProgressActivities(history).slice(0, MAX_PROGRESS_HISTORY_ITEMS);
     progressByAgent.set(key, {
       key,
-      agent: existing?.agent ?? agentsByHandle.get(handle) ?? {
+      agent: existing?.agent ?? agent ?? {
         handle: handle || "agent",
         display_name: handle ? `@${handle}` : "Agent",
         status: "running",
       },
-      workItem: candidate.workItem ?? existing?.workItem ?? null,
+      workItem: workItem ?? existing?.workItem ?? null,
       queuedItems: existing?.queuedItems ?? [],
       state: existing?.state === "working" || candidate.state === "working" ? "working" : "queued",
       latestActivity: existing && existing.latestAt > latestAt ? existing.latestActivity : latestActivity,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -216,10 +216,9 @@ const MIN_BOOT_SPLASH_MS = 600;
 const MAX_ATTACHMENT_MIB = 64;
 const MAX_ATTACHMENT_BYTES = MAX_ATTACHMENT_MIB * 1024 * 1024;
 const OLDER_CHANNEL_MESSAGES_PAGE_SIZE = 40;
-// Issue #82: run states that must bypass the ephemeral coalescing buffer
-// so terminal transitions land immediately. "stopped" is included to
-// match runtime supervisor terminology even if it is rare in practice.
-const RUN_TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled", "stopped"]);
+// Terminal transitions bypass the ephemeral buffer (issue #82). Codex/Claude
+// finish as "exited"; startup recovery marks orphaned runs "unknown".
+const RUN_TERMINAL_STATUSES = new Set(["exited", "failed", "cancelled", "unknown", "completed", "stopped"]);
 const DEFAULT_OWNER_DISPLAY_NAME = "Me";
 const DEFAULT_OWNER_AVATAR = "dicebear:dylan:owner";
 const DEFAULT_OWNER_DESCRIPTION = "local owner";

--- a/tests/message-rendering.test.ts
+++ b/tests/message-rendering.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { retainEqual } from "../src/render-identity";
 import { activeProgressByAgent, indexProgress } from "../src/components/ActivityProgressDock";
-import type { AgentActivity, AgentRun, AgentWorkItem, Message } from "../src/types";
+import type { Agent, AgentActivity, AgentRun, AgentWorkItem, Message } from "../src/types";
 
 test("bootstrap structural sharing retains equal rows and nested attachments without ignoring edits", () => {
   const before = { a: { body: "plain", attachments: [{ id: "a", size: 3 }] }, b: { body: "old", metadata: { title: "before" } } };
@@ -60,4 +60,55 @@ test("terminal progress clears running candidates while empty streams and queued
   const run = { id: runId, status: "running", started_at: "2026-09-06T12:00:00Z", stopped_at: null } as AgentRun;
   assert.equal(activeProgressByAgent([], indexProgress([], [run], [{ ...item, status: "done" }], []), "channel", "root").length, 1, "active run wins over a settled work item");
   assert.deepEqual(activeProgressByAgent([], indexProgress([], [], [{ ...item, status: "done", updated_at: "2000-01-01T00:00:00Z" }], []), "channel", "root"), [], "expired completion does not stay active");
+});
+
+const progressRunId = "00000000-0000-4000-8000-000000000002";
+const progressAgent = { id: "agent", handle: "Hancock", display_name: "Air-Hancock", status: "idle" } as Agent;
+const progressRun = (status: string) => ({
+  id: progressRunId, agent_id: progressAgent.id, status,
+  started_at: "2026-09-06T12:00:00Z", stopped_at: status === "running" ? null : "2026-09-06T12:02:00Z",
+}) as AgentRun;
+const emptyStream = {
+  sender_agent_id: progressAgent.id, sender_name: progressAgent.display_name, sender_role: "agent",
+  delivery_state: "streaming", body: "", attachments: [], artifacts: [], stream_key: `${progressRunId}:pending`,
+  created_at: "2026-09-06T12:00:00Z", updated_at: "2026-09-06T12:01:00Z",
+} as Message;
+
+test("ended runs override orphaned streams and stale running work without a terminal activity", () => {
+  const activities = [activity("last-command", progressRunId, "Running command", 1)];
+  for (const status of ["exited", "failed", "cancelled", "unknown", "stopped", "completed"]) {
+    const runs = [progressRun(status)];
+    assert.deepEqual(activeProgressByAgent([emptyStream], indexProgress(activities, runs, [], [progressAgent]), "channel", "root"), [], status);
+    assert.deepEqual(activeProgressByAgent([], indexProgress(activities, runs, [work("w", "root", progressRunId)], [progressAgent]), "channel", "root"), [], `${status} overrides stale work`);
+  }
+});
+
+test("settled work clears immediately without requiring a later event to expire it", () => {
+  for (const status of ["done", "failed", "cancelled", "silent"]) {
+    const item = { ...work("w", "root", progressRunId, status), updated_at: new Date().toISOString() };
+    const index = indexProgress([], [], [item], []);
+    assert.deepEqual(activeProgressByAgent([], index, "channel", "root"), [], status);
+    assert.deepEqual(activeProgressByAgent([emptyStream], index, "channel", "root"), [], `${status} overrides orphaned stream`);
+  }
+});
+
+test("compacted run history uses agent identity and current state without hiding active work", () => {
+  // Display names differ from handles in real messages. Match sender_agent_id.
+  assert.deepEqual(activeProgressByAgent([emptyStream], indexProgress([], [], [], [progressAgent]), "channel", "root"), []);
+  const active = activeProgressByAgent([emptyStream], indexProgress([], [progressRun("running")], [], [progressAgent]), "channel", "root");
+  assert.equal(active.length, 1, "a live run wins over an older idle profile");
+  assert.equal(active[0].agent.id, progressAgent.id);
+  const item = work("w", "root", progressRunId);
+  assert.equal(activeProgressByAgent([emptyStream], indexProgress([], [], [item], [progressAgent]), "channel", "root").length, 1, "active work survives a missing run and an older idle profile");
+  const newerRun = { ...progressRun("running"), id: "newer-run", started_at: "2026-09-06T12:03:00Z" };
+  assert.deepEqual(activeProgressByAgent([emptyStream], indexProgress([], [newerRun], [], [{ ...progressAgent, status: "running" }]), "channel", "root"), [], "a newer run elsewhere cannot revive an old placeholder");
+});
+
+test("a queued successor remains queued after its prior run ends", () => {
+  const queued = work("next", "root", null, "queued");
+  const index = indexProgress([], [progressRun("failed")], [queued], [progressAgent]);
+  const progress = activeProgressByAgent([emptyStream], index, "channel", "root");
+  assert.equal(progress.length, 1);
+  assert.equal(progress[0].state, "queued");
+  assert.deepEqual(progress[0].queuedItems.map((item) => item.id), [queued.id]);
 });

--- a/tests/message-state-races.e2e.mjs
+++ b/tests/message-state-races.e2e.mjs
@@ -99,6 +99,25 @@ try {
   const context = await browser.newContext({ serviceWorkers: "block", viewport: mobile ? { width: 390, height: 844 } : { width: 1440, height: 1000 } });
   // randomUUID is unavailable on non-localhost HTTP mobile clients; getRandomValues remains available.
   await context.addInitScript(() => Object.defineProperty(crypto, "randomUUID", { value: undefined }));
+  // Hold the ephemeral flush like a suspended tab. Terminal lifecycle events
+  // must clear progress even while a prior running/usage patch is buffered.
+  await context.addInitScript(() => {
+    const raf = window.requestAnimationFrame.bind(window), timeout = window.setTimeout.bind(window);
+    const cancelRaf = window.cancelAnimationFrame.bind(window), cancelTimeout = window.clearTimeout.bind(window);
+    const pending = new Map(); let next = -1;
+    const hold = callback => { const id = next--; pending.set(id, callback); return id; };
+    window.__progressFlushGate = { held: false, resume() {
+      this.held = false;
+      const callbacks = [...pending.values()]; pending.clear();
+      for (const callback of callbacks) callback();
+    } };
+    window.requestAnimationFrame = callback => window.__progressFlushGate.held
+      ? hold(() => callback(performance.now())) : raf(callback);
+    window.setTimeout = (callback, delay, ...args) => window.__progressFlushGate.held && delay === 80
+      ? hold(() => callback(...args)) : timeout(callback, delay, ...args);
+    window.cancelAnimationFrame = id => { if (!pending.delete(id)) cancelRaf(id); };
+    window.clearTimeout = id => { if (!pending.delete(id)) cancelTimeout(id); };
+  });
   const page = await context.newPage(); page.setDefaultTimeout(5000);
   const errors = []; page.on("pageerror", error => errors.push(error.message));
   await page.goto(`http://127.0.0.1:${api.address().port}`, { waitUntil: "domcontentloaded" });
@@ -191,6 +210,56 @@ try {
     await expectStatus("idle");
     assert.equal(count("bootstrap"), bootstrapBeforeStatus, "lifecycle synchronization never bootstraps");
     console.log("PASS: completion, stale in-flight profile read, queued successor, start/failure, usage-only batching");
+
+    for (const surface of [".conversation", ".thread"]) {
+      if (mobile && surface === ".conversation" && await page.locator(".thread textarea").isVisible()) {
+        await page.getByRole("button", { name: "Back to channel", exact: true }).click();
+      }
+      if (surface === ".thread" && !await page.locator(".thread textarea").isVisible()) {
+        const rootRow = page.locator(`.conversation [data-message-id="${root.id}"]`);
+        if (mobile) await rootRow.locator(".markdown-body").click();
+        else { await rootRow.hover(); await rootRow.getByRole("button", { name: "View thread replies", exact: true }).click(); }
+        await page.locator(".thread textarea").waitFor();
+      }
+      for (const terminal of ["exited", "unknown", "failed"]) {
+        const runId = id(++seq), threadRootId = surface === ".thread" ? root.id : null;
+        const liveRun = run("running", { id: runId });
+        const item = { id: id(++seq), agent_id: agentId, agent_handle: agent.handle, channel_id: channelId,
+          channel_name: "race-test", thread_root_id: threadRootId, source_message_id: root.id,
+          task_id: null, task_number: null, source_kind: "mention", title: "Progress fixture", context: "",
+          status: "running", run_id: runId, created_at: now, updated_at: now, completed_at: null };
+        const placeholder = message("", { sender_agent_id: agentId, sender_name: agent.display_name, sender_role: "agent",
+          delivery_state: "streaming", stream_key: `${runId}:pending`, thread_root_id: threadRootId });
+        agent.status = "running";
+        state.agent_runs.push(liveRun); state.agent_work_items.push(item); state.messages.push(placeholder);
+        publish({ type: "agent_run_upsert", reason: "run_running", run: liveRun });
+        publish({ type: "work_item_upsert", work_item: item });
+        publish({ type: "message_upsert", message: placeholder });
+        await page.locator(`${surface} .activity-progress-summary[data-state="working"]`).waitFor();
+        await page.waitForTimeout(150);
+        await page.evaluate(() => { window.__progressFlushGate.held = true; });
+        publish({ type: "agent_run_upsert", reason: "run_usage", run: { ...liveRun, input_tokens: 10 } });
+        agent.status = "idle";
+        Object.assign(liveRun, { status: terminal, stopped_at: new Date().toISOString() });
+        publish({ type: "agent_run_upsert", reason: "run_finished", run: liveRun });
+        // Neither a final activity nor a completed message/work-item event is
+        // sent: failures/restarts can leave all three missing in persisted data.
+        await page.waitForFunction(selector => !document.querySelector(selector), `${surface} .activity-progress-dock`, { polling: 20 });
+        await page.evaluate(() => window.__progressFlushGate.resume());
+        await page.waitForTimeout(150);
+        assert.equal(await page.locator(`${surface} .activity-progress-dock`).count(), 0, `${terminal} cannot be overwritten by buffered running state`);
+        item.status = "done"; item.updated_at = new Date().toISOString();
+        publish({ type: "work_item_upsert", work_item: item });
+      }
+    }
+    // An old run may fall outside the bootstrap's 30-row history. Idle profiles
+    // still suppress its empty stream after a reload, using the sender's ID.
+    state.agent_runs = []; state.agent_work_items = [];
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await page.locator(".conversation textarea").waitFor({ state: "attached" });
+    await page.waitForTimeout(200);
+    assert.equal(await page.locator(".activity-progress-dock").count(), 0, "compacted history does not revive orphan streams");
+    console.log("PASS: channel/thread terminal progress, suspended flush, no terminal activity/message, compacted history reload");
   }
   assert.deepEqual(errors, []);
 } finally {


### PR DESCRIPTION
Empty streaming placeholders left by failed launches or restarts could keep channel/thread progress at **Working** after the run ended. Make run lifecycle state authoritative, use agent IDs and remaining work/profile evidence when old runs fall out of recent history, and remove completed-work settling that never scheduled its own expiration. Active runs and queued successors remain visible.

Apply the backend's actual terminal statuses (`exited` and `unknown`) immediately, discarding pending running patches. Document that Tauri development uses Vite while browser access on :8787 requires a rebuilt `dist/`.

Validation: 63 frontend tests, production build and CSS token gate passed. Extended production-UI/SSE regression passed in Chromium desktop and WebKit mobile, including absent terminal activities, suspended progress flushes, queued successors and compacted-history reloads. Existing message-row and Web synchronization regressions passed. New unit/browser cases fail against unmodified main; a read-only comparison also reproduces the old Working card with an idle agent in live data. No Rust changes.
