### PR TITLE
Paginate owner Activity and bound its frontend cache

### DIFF
--- a/docs/owner-activity.md
+++ b/docs/owner-activity.md
@@ -1,0 +1,34 @@
+# Owner Activity
+
+The owner's Activity modal uses `load_activity_feed`, independently of chat
+message hydration. `load_activity_counts` supplies total and unread badges.
+These endpoints are available over both Web and Tauri transports.
+
+- Filter and dismissal/read eligibility are evaluated in SQLite before pagination.
+  All kinds sort newest first, with item ID as the stable tie breaker. Owner
+  replies update thread recency without adding unread counts.
+- Each page returns at most 30 items. Cursors contain timestamp and item ID;
+  `after` loads older items and `before` loads newer items. Only one cursor may
+  be supplied. A cursor does not require its source row to still exist.
+- SQLite selects at most 31 metadata rows, then reads text excerpts capped at
+  2048 characters. Titles, actor names, and channel labels are capped too.
+  Message attachments and artifact bodies are not loaded by this API.
+- The modal holds one page and two cursors. Navigation replaces the page;
+  rapid filter changes serialize requests and retain only the last queued
+  selection. Closing releases the page; reopening starts with latest activity.
+- Updates show a refresh prompt without reshuffling the page being read.
+  Page read/dismiss actions use each item's displayed timestamp, so later
+  activity survives. They do not mark whole channels read.
+- Badge queries are coalesced, limited to one in flight and one start per five
+  seconds, and paused in hidden tabs. Counts are independent of the selected
+  page. A failed refresh retains the last successful badge.
+
+This bounds Activity payloads, frontend cache, and rendered rows. Database
+query cost still grows with history: SQLite aggregates message metadata and
+checks mention text. It is not a constant-time materialized feed. The pressure
+regression reports query latency and payload for 5000 threads / 10000 messages.
+
+Verify with `npm test`, `npm run build`, `npm run test:activity-feed`, and
+`cargo test --manifest-path src-tauri/Cargo.toml owner_inbox -- --nocapture`.
+The browser test uses an isolated fixture server and does not mutate live inbox
+state. The Rust tests use disposable SQLite databases.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "tsx --test tests/*.test.ts",
     "test:dialogs": "node tests/dialogs.e2e.mjs",
     "test:ui-panels": "node tests/ui-panels.e2e.mjs",
+    "test:activity-feed": "node tests/activity-feed.e2e.mjs",
     "test:app-shell": "node tests/app-shell.e2e.mjs",
     "test:streaming": "node tests/streaming.e2e.mjs",
     "test:attachments": "cargo test --manifest-path src-tauri/Cargo.toml web::attachment_tests::browser_cache_range_and_upload_memory -- --ignored --nocapture",

--- a/src-tauri/src/commands/inbox.rs
+++ b/src-tauri/src/commands/inbox.rs
@@ -1,6 +1,24 @@
 use tauri::State;
 use uuid::Uuid;
 
+use crate::owner_inbox::feed::{self, FeedCounts, FeedPage, FeedRequest};
+
+#[tauri::command]
+pub(crate) async fn load_activity_feed(
+    request: FeedRequest,
+    state: State<'_, AppState>,
+) -> CommandResult<FeedPage> {
+    feed::page(&state.pool, request).await
+}
+
+#[tauri::command]
+pub(crate) async fn load_activity_counts(
+    mention_handles: Vec<String>,
+    state: State<'_, AppState>,
+) -> CommandResult<FeedCounts> {
+    feed::counts(&state.pool, &mention_handles).await
+}
+
 use crate::{
     app::{AppState, CommandResult},
     application::inbox::{

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -76,8 +76,8 @@ use commands::{
         rereview_github_pull_request,
     },
     inbox::{
-        dismiss_inbox_items, mark_all_inbox_read, mark_channel_read, mark_inbox_items_read,
-        update_thread_followed,
+        dismiss_inbox_items, load_activity_counts, load_activity_feed, mark_all_inbox_read,
+        mark_channel_read, mark_inbox_items_read, update_thread_followed,
     },
     messages::{
         delete_message, load_activity_messages, load_channel_messages, load_channel_previews,
@@ -316,6 +316,8 @@ pub fn run() {
             install_supervisor_service,
             dismiss_inbox_items,
             mark_inbox_items_read,
+            load_activity_feed,
+            load_activity_counts,
             mark_all_inbox_read,
             mark_channel_read,
             mark_github_review_attention_read,

--- a/src-tauri/src/owner_inbox.rs
+++ b/src-tauri/src/owner_inbox.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+pub(crate) mod feed;
+
 use chrono::{DateTime, Utc};
 use sqlx::{Row, SqlitePool};
 use uuid::Uuid;

--- a/src-tauri/src/owner_inbox/feed.rs
+++ b/src-tauri/src/owner_inbox/feed.rs
@@ -1,0 +1,286 @@
+use serde::{Deserialize, Serialize};
+use sqlx::{Row, SqlitePool};
+use uuid::Uuid;
+
+use crate::app::{to_string, CommandResult};
+
+const CANDIDATES: &str = include_str!("feed.sql");
+const PAGE_SIZE: usize = 30;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum FeedFilter {
+    #[default]
+    All,
+    Unread,
+    Thread,
+    Mention,
+    Dm,
+    Channel,
+    Task,
+    Reminder,
+}
+
+impl FeedFilter {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Unread => "unread",
+            Self::Thread => "thread",
+            Self::Mention => "mention",
+            Self::Dm => "dm",
+            Self::Channel => "channel",
+            Self::Task => "task",
+            Self::Reminder => "reminder",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct FeedCursor {
+    pub(crate) timestamp: String,
+    pub(crate) id: String,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FeedRequest {
+    #[serde(default)]
+    pub(crate) filter: FeedFilter,
+    #[serde(default)]
+    pub(crate) mention_handles: Vec<String>,
+    pub(crate) after: Option<FeedCursor>,
+    pub(crate) before: Option<FeedCursor>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct FeedPageRequest {
+    pub(crate) request: FeedRequest,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FeedCountsRequest {
+    #[serde(default)]
+    pub(crate) mention_handles: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FeedItem {
+    pub(crate) id: String,
+    pub(crate) dismiss_id: String,
+    pub(crate) kind: String,
+    pub(crate) title: String,
+    pub(crate) excerpt: String,
+    pub(crate) surface: String,
+    pub(crate) actor: String,
+    pub(crate) timestamp: String,
+    pub(crate) unread: bool,
+    pub(crate) actor_agent_id: Option<Uuid>,
+    pub(crate) actor_role: Option<String>,
+    pub(crate) channel_id: Option<Uuid>,
+    pub(crate) thread_id: Option<Uuid>,
+    pub(crate) message_id: Option<Uuid>,
+    pub(crate) task_id: Option<Uuid>,
+    pub(crate) reminder_id: Option<Uuid>,
+    pub(crate) reply_count: i64,
+    pub(crate) new_count: i64,
+}
+
+impl FeedItem {
+    fn cursor(&self) -> FeedCursor {
+        FeedCursor {
+            timestamp: self.timestamp.clone(),
+            id: self.id.clone(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FeedPage {
+    pub(crate) items: Vec<FeedItem>,
+    pub(crate) next_cursor: Option<FeedCursor>,
+    pub(crate) previous_cursor: Option<FeedCursor>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct FeedCounts {
+    pub(crate) total: i64,
+    pub(crate) unread: i64,
+}
+
+fn handles_json(handles: &[String]) -> CommandResult<String> {
+    if handles.len() > 8 || handles.iter().any(|s| s.len() > 128 || s.trim().is_empty()) {
+        return Err("Invalid Activity mention handles".into());
+    }
+    serde_json::to_string(handles).map_err(to_string)
+}
+
+pub(crate) async fn counts(pool: &SqlitePool, handles: &[String]) -> CommandResult<FeedCounts> {
+    let sql = format!(
+        "{CANDIDATES} select count(*) as total, coalesce(sum(unread),0) as unread from eligible"
+    );
+    let row = sqlx::query(&sql)
+        .bind(handles_json(handles)?)
+        .fetch_one(pool)
+        .await
+        .map_err(to_string)?;
+    Ok(FeedCounts {
+        total: row.get("total"),
+        unread: row.get("unread"),
+    })
+}
+
+pub(crate) async fn page(pool: &SqlitePool, request: FeedRequest) -> CommandResult<FeedPage> {
+    if request.after.is_some() && request.before.is_some() {
+        return Err("Use either an after or a before cursor".into());
+    }
+    let cursor = request.after.as_ref().or(request.before.as_ref());
+    if let Some(cursor) = cursor {
+        chrono::DateTime::parse_from_rfc3339(&cursor.timestamp).map_err(to_string)?;
+        if cursor.id.len() > 128 {
+            return Err("Invalid Activity cursor".into());
+        }
+    }
+    let backwards = request.before.is_some();
+    let (comparison, order) = if backwards {
+        (">", "asc")
+    } else {
+        ("<", "desc")
+    };
+    // Page metadata first; only then read bounded text for at most 31 items.
+    let sql = format!(
+        r#"{CANDIDATES}, page as materialized (
+        select * from eligible
+        where (?2 = 'all' or (?2 = 'unread' and unread) or kind = ?2)
+          and (?3 is null or (julianday(timestamp),id) {comparison} (julianday(?3),?4))
+        order by julianday(timestamp) {order}, id {order} limit 31
+    )
+    select p.*, c.kind as channel_kind, substr(c.name,1,256) as channel_name,
+        substr(dm.handle,1,128) as dm_handle,
+        substr(m.body,1,2048) as body, substr(m.sender_name,1,256) as sender_name,
+        m.sender_agent_id, m.sender_role,
+        t.number as task_number, substr(t.title,1,512) as task_title, t.status as task_status,
+        t.assignee_agent_id, substr(a.display_name,1,256) as assignee_name,
+        substr(r.title,1,512) as reminder_title, substr(r.note,1,2048) as reminder_note
+    from page p
+    left join channels c on c.id = p.channel_id
+    left join agents dm on dm.id = c.dm_agent_id
+    left join messages m on m.id = p.source_id
+    left join tasks t on t.id = p.task_id
+    left join agents a on a.id = t.assignee_agent_id
+    left join reminders r on r.id = p.reminder_id
+    order by julianday(p.timestamp) {order}, p.id {order}"#
+    );
+    let rows = sqlx::query(&sql)
+        .bind(handles_json(&request.mention_handles)?)
+        .bind(request.filter.as_str())
+        .bind(cursor.map(|c| &c.timestamp))
+        .bind(cursor.map(|c| &c.id))
+        .fetch_all(pool)
+        .await
+        .map_err(to_string)?;
+    let more = rows.len() > PAGE_SIZE;
+    let mut items = Vec::with_capacity(PAGE_SIZE);
+    for row in rows.into_iter().take(PAGE_SIZE) {
+        let id: String = row.get("id");
+        let kind: String = row.get("kind");
+        let body: String = row.get::<Option<String>, _>("body").unwrap_or_default();
+        let channel_name: Option<String> = row.get("channel_name");
+        let surface = if row.get::<Option<String>, _>("channel_kind").as_deref() == Some("dm") {
+            format!(
+                "@{}",
+                row.get::<Option<String>, _>("dm_handle")
+                    .unwrap_or_else(|| "agent".into())
+            )
+        } else {
+            channel_name
+                .map(|n| format!("#{n}"))
+                .unwrap_or_else(|| "Reminder".into())
+        };
+        let (title, excerpt, actor, actor_agent_id, actor_role) = match kind.as_str() {
+            "task" => (
+                format!(
+                    "Task #{}: {}",
+                    row.get::<i64, _>("task_number"),
+                    row.get::<String, _>("task_title")
+                ),
+                row.get::<Option<String>, _>("assignee_name")
+                    .map(|n| format!("Assigned to {n}"))
+                    .unwrap_or_else(|| "Unassigned".into()),
+                row.get::<String, _>("task_status").replace('_', " "),
+                row.get::<Option<Uuid>, _>("assignee_agent_id"),
+                Some("agent".into()),
+            ),
+            "reminder" => (
+                row.get("reminder_title"),
+                row.get("reminder_note"),
+                "Reminder due".into(),
+                None,
+                None,
+            ),
+            _ => (
+                if kind == "channel" {
+                    format!("New activity in {surface}")
+                } else if kind == "dm" {
+                    format!("DM with {surface}")
+                } else {
+                    body.lines()
+                        .next()
+                        .unwrap_or_default()
+                        .chars()
+                        .take(240)
+                        .collect()
+                },
+                body,
+                row.get::<Option<String>, _>("sender_name")
+                    .unwrap_or_default(),
+                row.get("sender_agent_id"),
+                row.get("sender_role"),
+            ),
+        };
+        items.push(FeedItem {
+            dismiss_id: id.clone(),
+            id,
+            kind,
+            title,
+            excerpt,
+            actor,
+            actor_agent_id,
+            actor_role,
+            surface,
+            timestamp: row.get("timestamp"),
+            unread: row.get("unread"),
+            channel_id: row.get("channel_id"),
+            thread_id: row.get("thread_id"),
+            message_id: row.get("message_id"),
+            task_id: row.get("task_id"),
+            reminder_id: row.get("reminder_id"),
+            reply_count: row.get("reply_count"),
+            new_count: row.get("new_count"),
+        });
+    }
+    if backwards {
+        items.reverse();
+    }
+    let next_cursor = if (backwards && cursor.is_some()) || (!backwards && more) {
+        items.last().map(FeedItem::cursor)
+    } else {
+        None
+    };
+    let previous_cursor = if (backwards && more) || (!backwards && cursor.is_some()) {
+        items.first().map(FeedItem::cursor)
+    } else {
+        None
+    };
+    Ok(FeedPage {
+        items,
+        next_cursor,
+        previous_cursor,
+    })
+}

--- a/src-tauri/src/owner_inbox/feed.sql
+++ b/src-tauri/src/owner_inbox/feed.sql
@@ -1,0 +1,94 @@
+with reads as (
+    select item_id, max(julianday(read_until)) as read_until from (
+        select item_id, read_until from owner_inbox_read_state
+        union all
+        select item_id, dismissed_until from owner_inbox_dismissals
+    ) group by item_id
+), visible as materialized (
+    select m.id, m.seq, m.channel_id, m.thread_root_id, m.sender_role,
+        m.thread_followed, m.created_at,
+        lower(substr(hex(m.id),1,8)||'-'||substr(hex(m.id),9,4)||'-'||
+              substr(hex(m.id),13,4)||'-'||substr(hex(m.id),17,4)||'-'||substr(hex(m.id),21,12)) as key,
+        m.sender_role <> 'owner' and exists (
+            select 1 from json_each(?1) handle where instr(lower(m.body), lower(handle.value)) > 0
+        ) as mentions_owner,
+        m.sender_role <> 'owner' and (
+            (cr.last_read_seq is not null and m.seq > cr.last_read_seq) or
+            (cr.last_read_seq is null and julianday(m.created_at) > coalesce(julianday(cr.last_read_at), 0))
+        ) as channel_unread
+    from messages m
+    left join channel_read_state cr on cr.channel_id = m.channel_id
+    where m.delivery_state <> 'streaming'
+      and not (
+        m.sender_role not in ('owner', 'system') and m.delivery_state = 'complete'
+        and m.stream_key glob '????????-????-????-????-????????????:*' and trim(m.body) = ''
+        and not exists (select 1 from message_attachments ma where ma.message_id = m.id)
+        and not exists (select 1 from artifacts ar where ar.message_id = m.id)
+      )
+), replies as (
+    select reply.*,
+        reply.channel_unread and julianday(reply.created_at) > coalesce(r.read_until, 0) as unread,
+        row_number() over (partition by reply.thread_root_id order by julianday(reply.created_at) desc, reply.seq desc, reply.key desc) as rank
+    from visible reply
+    join visible root on root.id = reply.thread_root_id
+    left join reads r on r.item_id = 'thread:' || root.key
+), thread_totals as (
+    select thread_root_id, count(*) as reply_count, sum(unread) as unread_count,
+        min(case when unread then seq end) as first_unread_seq
+    from replies group by thread_root_id
+), threads as (
+    select root.id, root.key, root.channel_id, latest.id as latest_id,
+        latest.created_at, totals.reply_count, totals.unread_count,
+        coalesce(first_unread.id, latest.id) as target_id
+    from visible root
+    join replies latest on latest.thread_root_id = root.id and latest.rank = 1
+    join thread_totals totals on totals.thread_root_id = latest.thread_root_id
+    left join visible first_unread on first_unread.seq = totals.first_unread_seq
+    where root.thread_followed or totals.unread_count > 0
+), channel_totals as (
+    select channel_id, sum(channel_unread) as unread_count from visible group by channel_id
+), latest_channels as (
+    select *, row_number() over (partition by channel_id order by seq desc, key desc) as rank from visible
+), candidates as (
+    select 'thread:' || key as id, 'thread' as kind, channel_id, id as thread_id,
+        target_id as message_id, latest_id as source_id, null as task_id, null as reminder_id,
+        created_at as timestamp, unread_count > 0 as base_unread, reply_count, unread_count as new_count
+    from threads
+    union all
+    select 'mention:' || m.key, 'mention', m.channel_id, coalesce(m.thread_root_id,m.id),
+        m.id, m.id, null, null, m.created_at,
+        case when m.thread_root_id is null then m.channel_unread else coalesce(r.unread,0) end,
+        coalesce(t.reply_count,0), 0
+    from visible m
+    left join replies r on r.id = m.id
+    left join thread_totals t on t.thread_root_id = coalesce(m.thread_root_id,m.id)
+    where m.mentions_owner
+    union all
+    select c.kind || ':' || lower(substr(hex(c.id),1,8)||'-'||substr(hex(c.id),9,4)||'-'||
+        substr(hex(c.id),13,4)||'-'||substr(hex(c.id),17,4)||'-'||substr(hex(c.id),21,12)),
+        c.kind, c.id, latest.thread_root_id, latest.id, latest.id, null, null,
+        latest.created_at, 1, coalesce(t.reply_count,0), totals.unread_count
+    from channels c
+    join latest_channels latest on latest.channel_id = c.id and latest.rank = 1
+    join channel_totals totals on totals.channel_id = latest.channel_id and totals.unread_count > 0
+    left join thread_totals t on t.thread_root_id = latest.thread_root_id
+    where not exists (select 1 from threads where id = latest.thread_root_id)
+    union all
+    select 'task:' || lower(substr(hex(t.id),1,8)||'-'||substr(hex(t.id),9,4)||'-'||
+        substr(hex(t.id),13,4)||'-'||substr(hex(t.id),17,4)||'-'||substr(hex(t.id),21,12)),
+        'task', t.channel_id, t.message_id, t.message_id, null, t.id, null,
+        t.updated_at, t.status = 'in_review', coalesce(tt.reply_count,0), 0
+    from tasks t left join thread_totals tt on tt.thread_root_id = t.message_id where t.status <> 'done'
+    union all
+    select 'reminder:' || lower(substr(hex(r.id),1,8)||'-'||substr(hex(r.id),9,4)||'-'||
+        substr(hex(r.id),13,4)||'-'||substr(hex(r.id),17,4)||'-'||substr(hex(r.id),21,12)),
+        'reminder', r.channel_id, r.thread_root_id, r.message_id, null, null, r.id,
+        coalesce(r.fired_at,r.due_at), 1, coalesce(tt.reply_count,0), 1
+    from reminders r left join thread_totals tt on tt.thread_root_id = r.thread_root_id where r.status = 'fired'
+), eligible as (
+    select c.*, c.base_unread and julianday(c.timestamp) > coalesce(r.read_until,0) as unread
+    from candidates c
+    left join reads r on r.item_id = c.id
+    left join owner_inbox_hidden_items h on h.item_id = c.id
+    where julianday(c.timestamp) > coalesce(julianday(h.hidden_until),0)
+)

--- a/src-tauri/src/owner_inbox/feed/tests.rs
+++ b/src-tauri/src/owner_inbox/feed/tests.rs
@@ -1,0 +1,352 @@
+use super::*;
+use crate::owner_inbox::{dismiss_inbox_items_in_pool, mark_inbox_items_read_in_pool};
+use crate::test_support::{drop_test_schema, insert_test_channel, test_pool};
+use std::collections::HashSet;
+
+#[tokio::test]
+async fn large_history_keeps_page_payload_bounded() {
+    let (pool, path) = test_pool().await.expect("SQLite test database");
+    let channel = insert_test_channel(&pool, "large-activity").await.unwrap();
+    sqlx::query("with recursive n(x) as (select 1 union all select x+1 from n where x<5000) insert into messages(channel_id,sender_name,sender_role,body,created_at) select ?1,'Owner','owner','Large thread '||x,'2026-01-01T00:00:00Z' from n")
+        .bind(channel).execute(&pool).await.unwrap();
+    sqlx::query("insert into messages(channel_id,thread_root_id,sender_name,sender_role,body,created_at) select channel_id,id,'Agent','agent',?2,'2026-01-02T00:00:00Z' from messages where channel_id=?1")
+        .bind(channel).bind("Reply content ".repeat(400)).execute(&pool).await.unwrap();
+    let started = std::time::Instant::now();
+    let totals = counts(&pool, &["@Owner".into()]).await.unwrap();
+    let count_time = started.elapsed();
+    let started = std::time::Instant::now();
+    let result = page(
+        &pool,
+        FeedRequest {
+            mention_handles: vec!["@Owner".into()],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!((totals.total, totals.unread), (5000, 5000));
+    assert_eq!(result.items.len(), PAGE_SIZE);
+    let bytes = serde_json::to_vec(&result).unwrap().len();
+    assert!(bytes < 100_000);
+    eprintln!("Activity 5000 threads / 10000 messages: counts={count_time:?}, page={:?}, payload={bytes} bytes, rows={}", started.elapsed(), result.items.len());
+    drop_test_schema(pool, path).await;
+}
+
+#[tokio::test]
+async fn channel_dm_reminder_and_stream_visibility() {
+    let (pool, path) = test_pool().await.expect("SQLite test database");
+    let channel = insert_test_channel(&pool, "channel-feed").await.unwrap();
+    let dm = insert_test_channel(&pool, "dm-feed").await.unwrap();
+    sqlx::query("update channels set kind='dm' where id=?1")
+        .bind(dm)
+        .execute(&pool)
+        .await
+        .unwrap();
+    for id in [channel, dm] {
+        sqlx::query("insert into messages(channel_id,sender_name,sender_role,body) values (?1,'Agent','agent','Unread root')").bind(id).execute(&pool).await.unwrap();
+        sqlx::query("insert into messages(channel_id,sender_name,sender_role,body,delivery_state) values (?1,'Agent','agent','Unpublished content','streaming')").bind(id).execute(&pool).await.unwrap();
+    }
+    sqlx::query("insert into reminders(channel_id,title,note,status,due_at,fired_at,recurrence) values (?1,'Due reminder','Reminder detail','fired','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z','none')")
+        .bind(channel).execute(&pool).await.unwrap();
+    let all = page(&pool, FeedRequest::default()).await.unwrap();
+    assert_eq!(all.items.len(), 3);
+    assert!(all.items.iter().all(|i| !i.excerpt.contains("Unpublished")));
+    for filter in [FeedFilter::Dm, FeedFilter::Channel, FeedFilter::Reminder] {
+        let result = page(
+            &pool,
+            FeedRequest {
+                filter,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.items.len(), 1);
+        assert!(result.items[0].unread);
+    }
+    drop_test_schema(pool, path).await;
+}
+
+async fn seed(pool: &SqlitePool) -> Uuid {
+    let channel = insert_test_channel(pool, "paged-activity").await.unwrap();
+    sqlx::query("with recursive n(x) as (select 1 union all select x+1 from n where x<205) insert into messages(channel_id,sender_name,sender_role,body,created_at) select ?1,'Owner','owner','Review '||x,'2026-01-01T00:00:00Z' from n")
+        .bind(channel).execute(pool).await.unwrap();
+    sqlx::query("insert into tasks(message_id,channel_id,title,status,updated_at) select id,channel_id,body,'in_review','2026-01-01T00:00:00Z' from messages where channel_id=?1")
+        .bind(channel).execute(pool).await.unwrap();
+    // More recent read threads than the former global 120-item cap.
+    sqlx::query("with recursive n(x) as (select 1 union all select x+1 from n where x<130) insert into messages(channel_id,sender_name,sender_role,body,created_at) select ?1,'Owner','owner','Thread '||x,'2026-01-02T00:00:00Z' from n")
+        .bind(channel).execute(pool).await.unwrap();
+    sqlx::query("insert into messages(channel_id,thread_root_id,sender_name,sender_role,body,created_at) select channel_id,id,'Owner','owner','Waiting for reply','2026-01-03T00:00:00Z' from messages where channel_id=?1 and body like 'Thread %'")
+        .bind(channel).execute(pool).await.unwrap();
+    channel
+}
+
+#[tokio::test]
+async fn filter_before_pagination_and_count_independently() {
+    let (pool, path) = test_pool().await.expect("SQLite test database");
+    seed(&pool).await;
+    let totals = counts(&pool, &[]).await.unwrap();
+    assert_eq!((totals.total, totals.unread), (335, 205));
+    let all = page(&pool, FeedRequest::default()).await.unwrap();
+    assert_eq!(all.items.len(), 30);
+    assert!(all
+        .items
+        .iter()
+        .all(|item| item.kind == "thread" && !item.unread));
+    assert!(all.previous_cursor.is_none());
+    let mut cursor = None;
+    let mut ids = HashSet::new();
+    loop {
+        let result = page(
+            &pool,
+            FeedRequest {
+                filter: FeedFilter::Unread,
+                after: cursor,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert!(result.items.len() <= PAGE_SIZE);
+        for item in result.items {
+            assert_eq!(item.kind, "task");
+            assert!(
+                ids.insert(item.id),
+                "equal timestamps must not duplicate a cursor page"
+            );
+        }
+        cursor = result.next_cursor;
+        if cursor.is_none() {
+            break;
+        }
+    }
+    assert_eq!(ids.len(), 205, "all old unread tasks remain reachable");
+    let second = page(
+        &pool,
+        FeedRequest {
+            after: all.next_cursor.clone(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let previous = page(
+        &pool,
+        FeedRequest {
+            before: second.previous_cursor,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        all.items.iter().map(|i| &i.id).collect::<Vec<_>>(),
+        previous.items.iter().map(|i| &i.id).collect::<Vec<_>>()
+    );
+    assert!(previous.previous_cursor.is_none());
+    assert_eq!(counts(&pool, &[]).await.unwrap().unread, 205);
+    drop_test_schema(pool, path).await;
+}
+
+#[tokio::test]
+async fn read_dismiss_and_new_activity_preserve_existing_semantics() {
+    let (pool, path) = test_pool().await.expect("SQLite test database");
+    let channel = seed(&pool).await;
+    let task_page = page(
+        &pool,
+        FeedRequest {
+            filter: FeedFilter::Task,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let first = &task_page.items[0];
+    let cutoff = chrono::DateTime::parse_from_rfc3339("2026-01-04T00:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    mark_inbox_items_read_in_pool(&pool, [(first.id.clone(), cutoff)])
+        .await
+        .unwrap();
+    assert_eq!(counts(&pool, &[]).await.unwrap().unread, 204);
+    dismiss_inbox_items_in_pool(&pool, [(first.id.clone(), cutoff)])
+        .await
+        .unwrap();
+    assert_eq!(counts(&pool, &[]).await.unwrap().total, 334);
+    sqlx::query("update tasks set updated_at='2026-01-05T00:00:00Z' where id=?1")
+        .bind(first.task_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert_eq!(counts(&pool, &[]).await.unwrap().unread, 205);
+    assert_eq!(
+        page(&pool, FeedRequest::default()).await.unwrap().items[0].id,
+        first.id
+    );
+    let root: Uuid =
+        sqlx::query_scalar("select id from messages where channel_id=?1 and body='Thread 1'")
+            .bind(channel)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    sqlx::query("insert into messages(channel_id,thread_root_id,sender_name,sender_role,body,created_at) values (?1,?2,'Agent','agent','@Owner response','2026-01-06T00:00:00Z')")
+        .bind(channel).bind(root).execute(&pool).await.unwrap();
+    let mentions = page(
+        &pool,
+        FeedRequest {
+            filter: FeedFilter::Mention,
+            mention_handles: vec!["@Owner".into()],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(mentions.items.len(), 1);
+    assert!(mentions.items[0].unread);
+    assert_eq!(mentions.items[0].thread_id, Some(root));
+    drop_test_schema(pool, path).await;
+}
+
+#[tokio::test]
+async fn bounded_summaries_and_cursor_validation() {
+    let (pool, path) = test_pool().await.expect("SQLite test database");
+    seed(&pool).await;
+    sqlx::query("update messages set body=?1 where thread_root_id is not null")
+        .bind("x".repeat(100_000))
+        .execute(&pool)
+        .await
+        .unwrap();
+    let result = page(&pool, FeedRequest::default()).await.unwrap();
+    assert_eq!(result.items.len(), PAGE_SIZE);
+    assert!(result
+        .items
+        .iter()
+        .all(|i| i.excerpt.len() <= 2048 && i.title.len() <= 240));
+    assert!(serde_json::to_vec(&result).unwrap().len() < 100_000);
+    let invalid = FeedCursor {
+        timestamp: "invalid".into(),
+        id: "thread:x".into(),
+    };
+    assert!(page(
+        &pool,
+        FeedRequest {
+            after: Some(invalid),
+            ..Default::default()
+        }
+    )
+    .await
+    .is_err());
+    assert!(counts(&pool, &["".into()]).await.is_err());
+    drop_test_schema(pool, path).await;
+}
+
+#[tokio::test]
+async fn thread_targets_first_unread_and_page_cutoff_preserves_later_reply() {
+    let (pool, path) = test_pool().await.expect("SQLite test database");
+    let channel = insert_test_channel(&pool, "activity-cutoff").await.unwrap();
+    let root: Uuid = sqlx::query_scalar("insert into messages(channel_id,sender_name,sender_role,body,created_at) values (?1,'Owner','owner','Root','2026-01-01T00:00:00Z') returning id")
+        .bind(channel).fetch_one(&pool).await.unwrap();
+    let mut replies = Vec::new();
+    for (day, role) in [(2, "agent"), (3, "owner"), (4, "agent")] {
+        let id: Uuid = sqlx::query_scalar("insert into messages(channel_id,thread_root_id,sender_name,sender_role,body,created_at) values (?1,?2,?3,?3,?4,?5) returning id")
+            .bind(channel).bind(root).bind(role).bind(format!("Reply {day}"))
+            .bind(format!("2026-01-0{day}T00:00:00Z")).fetch_one(&pool).await.unwrap();
+        replies.push(id);
+    }
+    let first = page(&pool, FeedRequest::default()).await.unwrap();
+    assert_eq!(
+        first.items.len(),
+        1,
+        "thread suppresses duplicate channel row"
+    );
+    assert_eq!(first.items[0].message_id, Some(replies[0]));
+    assert_eq!(first.items[0].new_count, 2, "owner reply never adds unread");
+    assert_eq!(first.items[0].excerpt, "Reply 4");
+    // New activity arrives while the user reads the page, before its action is sent.
+    sqlx::query("insert into messages(channel_id,thread_root_id,sender_name,sender_role,body,created_at) values (?1,?2,'Agent','agent','Later reply','2026-01-05T00:00:00Z')")
+        .bind(channel).bind(root).execute(&pool).await.unwrap();
+    let cutoff = chrono::DateTime::parse_from_rfc3339(&first.items[0].timestamp)
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    mark_inbox_items_read_in_pool(&pool, [(first.items[0].id.clone(), cutoff)])
+        .await
+        .unwrap();
+    dismiss_inbox_items_in_pool(&pool, [(first.items[0].id.clone(), cutoff)])
+        .await
+        .unwrap();
+    let newer = page(&pool, FeedRequest::default()).await.unwrap();
+    assert_eq!(
+        newer.items.len(),
+        1,
+        "page dismissal cannot hide later activity"
+    );
+    assert_eq!(newer.items[0].new_count, 1);
+    assert_eq!(newer.items[0].excerpt, "Later reply");
+    assert!(newer.items[0].unread);
+    crate::owner_inbox::mark_channel_read_in_pool(&pool, channel)
+        .await
+        .unwrap();
+    assert_eq!(counts(&pool, &[]).await.unwrap().unread, 0);
+    sqlx::query("update messages set thread_followed=0 where id=?1")
+        .bind(root)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        counts(&pool, &[]).await.unwrap().total,
+        0,
+        "unfollowed read thread is excluded"
+    );
+    drop_test_schema(pool, path).await;
+}
+
+#[tokio::test]
+async fn deleted_cursor_and_newer_items_do_not_shift_forward_page() {
+    let (pool, path) = test_pool().await.expect("SQLite test database");
+    seed(&pool).await;
+    let first = page(
+        &pool,
+        FeedRequest {
+            filter: FeedFilter::Task,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let after = first.next_cursor.unwrap();
+    let expected = page(
+        &pool,
+        FeedRequest {
+            filter: FeedFilter::Task,
+            after: Some(after.clone()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    sqlx::query("delete from tasks where id=?1")
+        .bind(first.items.last().unwrap().task_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("update tasks set updated_at='2027-01-01T00:00:00Z' where id=?1")
+        .bind(first.items[0].task_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let actual = page(
+        &pool,
+        FeedRequest {
+            filter: FeedFilter::Task,
+            after: Some(after),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        expected.items.iter().map(|i| &i.id).collect::<Vec<_>>(),
+        actual.items.iter().map(|i| &i.id).collect::<Vec<_>>()
+    );
+    drop_test_schema(pool, path).await;
+}

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -185,6 +185,8 @@ pub(crate) fn spawn_web_server_if_configured(pool: SqlitePool, db_url: String) {
 fn web_router(state: Arc<WebState>, dist_dir: PathBuf) -> Router {
     let index = dist_dir.join("index.html");
     let app = Router::new()
+        .route("/api/load_activity_feed", post(api_load_activity_feed))
+        .route("/api/load_activity_counts", post(api_load_activity_counts))
         .route("/api/health", get(api_health))
         .route(
             "/api/bootstrap",
@@ -561,6 +563,26 @@ async fn api_load_activity_messages(
     Json(request): Json<LoadActivityMessagesRequest>,
 ) -> Result<impl IntoResponse, Response> {
     message_commands::load_activity_messages(&state.pool, request)
+        .await
+        .map(Json)
+        .map_err(api_error)
+}
+
+async fn api_load_activity_feed(
+    State(state): State<Arc<WebState>>,
+    Json(request): Json<crate::owner_inbox::feed::FeedPageRequest>,
+) -> Result<impl IntoResponse, Response> {
+    crate::owner_inbox::feed::page(&state.pool, request.request)
+        .await
+        .map(Json)
+        .map_err(api_error)
+}
+
+async fn api_load_activity_counts(
+    State(state): State<Arc<WebState>>,
+    Json(request): Json<crate::owner_inbox::feed::FeedCountsRequest>,
+) -> Result<impl IntoResponse, Response> {
+    crate::owner_inbox::feed::counts(&state.pool, &request.mention_handles)
         .await
         .map(Json)
         .map_err(api_error)

--- a/src/api-contract.ts
+++ b/src/api-contract.ts
@@ -1,4 +1,7 @@
 import type {
+  ActivityFeedRequest,
+  ActivityFeedPage,
+  ActivityFeedCounts,
   Agent,
   AgentActivity,
   AgentWorkItem,
@@ -53,6 +56,14 @@ type AgentDraftRequest = {
 };
 
 export type ApiContract = {
+  load_activity_feed: {
+    args: { request: ActivityFeedRequest };
+    result: ActivityFeedPage;
+  };
+  load_activity_counts: {
+    args: { mentionHandles: string[] };
+    result: ActivityFeedCounts;
+  };
   load_agent_detail: {
     args: { agentId: string };
     result: { agent: Agent; agent_activities: AgentActivity[]; agent_work_items: AgentWorkItem[] };
@@ -376,6 +387,8 @@ const API_COMMAND_NAMES = {
   load_channel_messages: true,
   load_channel_previews: true,
   load_activity_messages: true,
+  load_activity_feed: true,
+  load_activity_counts: true,
   search_messages: true,
   load_message: true,
   create_channel: true,

--- a/src/components/ActivityFeedModal.tsx
+++ b/src/components/ActivityFeedModal.tsx
@@ -1,24 +1,25 @@
 import { DialogSurface } from "./DialogSurface";
-import { ArrowUp, Bell, Check, Hash, Inbox, MessageSquare, UserRound, X } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { ArrowUp, ArrowLeft, ArrowRight, RefreshCw, Bell, Check, Hash, Inbox, MessageSquare, UserRound, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import type { CSSProperties, PointerEvent } from "react";
-import type { Agent, ActivityFeedItem, ActivityFeedKind, OwnerProfile } from "../types";
+import type { Agent, ActivityFeedItem, ActivityFeedKind, ActivityFeedFilter, ActivityFeedCounts, ActivityFeedPage, ActivityFeedCursor, OwnerProfile } from "../types";
 import { firstLines, formatTime, ownerAsAvatarAgent } from "../ui-utils";
 import { AgentAvatar } from "./AgentAvatar";
 
-type ActivityFeedFilter = "all" | "unread" | ActivityFeedKind;
+import { apiInvoke } from "../apiClient";
 
 type ActivityFeedModalProps = {
   open: boolean;
-  items: ActivityFeedItem[];
-  snapshotVersion: number;
+  counts: ActivityFeedCounts | null;
+  revision: object;
+  mentionHandles: string[];
   agents: Agent[];
   ownerProfile: OwnerProfile;
   onOpenItem: (item: ActivityFeedItem) => void;
-  onMarkItemRead: (item: ActivityFeedItem) => void;
-  onDismissItem: (item: ActivityFeedItem) => void;
-  onDismissItems: (items: ActivityFeedItem[]) => void;
-  onMarkAllRead: (items: ActivityFeedItem[]) => void;
+  onMarkItemRead: (item: ActivityFeedItem) => Promise<void>;
+  onDismissItem: (item: ActivityFeedItem) => Promise<void>;
+  onDismissItems: (items: ActivityFeedItem[]) => Promise<void>;
+  onMarkAllRead: (items: ActivityFeedItem[]) => Promise<void>;
   onClose: () => void;
 };
 
@@ -34,8 +35,6 @@ const FILTERS: { value: ActivityFeedFilter; label: string }[] = [
 
 const SWIPE_DISMISS_THRESHOLD_PX = 86;
 const SWIPE_REVEAL_MAX_PX = 96;
-const ACTIVITY_FEED_INITIAL_VISIBLE = 30;
-const ACTIVITY_FEED_LOAD_MORE_STEP = 30;
 
 function iconFor(kind: ActivityFeedKind) {
   if (kind === "reminder") return Bell;
@@ -54,22 +53,11 @@ function actorAvatarAgent(item: ActivityFeedItem, agents: Agent[], ownerProfile:
   return null;
 }
 
-function activityTimestampValue(item: ActivityFeedItem) {
-  const value = new Date(item.timestamp).getTime();
-  return Number.isFinite(value) ? value : 0;
-}
-
-function sortActivityFeedItems(items: ActivityFeedItem[]) {
-  return [...items].sort((left, right) => {
-    if (left.unread !== right.unread) return left.unread ? -1 : 1;
-    return activityTimestampValue(right) - activityTimestampValue(left);
-  });
-}
-
 export function ActivityFeedModal({
   open,
-  items,
-  snapshotVersion,
+  counts,
+  revision,
+  mentionHandles,
   agents,
   ownerProfile,
   onOpenItem,
@@ -80,82 +68,91 @@ export function ActivityFeedModal({
   onClose,
 }: ActivityFeedModalProps) {
   const [filter, setFilter] = useState<ActivityFeedFilter>("all");
-  const [visibleCount, setVisibleCount] = useState(ACTIVITY_FEED_INITIAL_VISIBLE);
-  const [displayItems, setDisplayItems] = useState<ActivityFeedItem[]>(() => sortActivityFeedItems(items));
+  const [cursor, setCursor] = useState<{ after?: ActivityFeedCursor; before?: ActivityFeedCursor }>({});
+  const [refresh, setRefresh] = useState(0);
+  const [page, setPage] = useState<ActivityFeedPage | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [acting, setActing] = useState(false);
+  const [hasUpdates, setHasUpdates] = useState(false);
+  const generation = useRef(0);
+  const running = useRef(false);
+  const pending = useRef<null | { id: number; request: { filter: ActivityFeedFilter; mentionHandles: string[]; after?: ActivityFeedCursor; before?: ActivityFeedCursor } }>(null);
+  const revisionRef = useRef(revision);
   const [swipeState, setSwipeState] = useState<{
-    itemId: string;
-    startX: number;
-    startY: number;
-    offsetX: number;
-    tracking: boolean;
+    itemId: string; startX: number; startY: number; offsetX: number; tracking: boolean;
   } | null>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
   const suppressNextClickRef = useRef(false);
-  const unreadCount = displayItems.filter((item) => item.unread).length;
-  const pendingItems = useMemo(() => {
-    const displayedById = new Map(displayItems.map((item) => [item.id, item]));
-    return items.filter((item) => {
-      const displayed = displayedById.get(item.id);
-      if (!displayed) return true;
-      return activityTimestampValue(item) > activityTimestampValue(displayed);
-    });
-  }, [displayItems, items]);
-  const filteredItems = useMemo(() => {
-    if (filter === "all") return displayItems;
-    if (filter === "unread") return displayItems.filter((item) => item.unread);
-    return displayItems.filter((item) => item.kind === filter);
-  }, [displayItems, filter]);
-  const filteredUnreadCount = filteredItems.filter((item) => item.unread).length;
-  const visibleItems = useMemo(
-    () => filteredItems.slice(0, visibleCount),
-    [filteredItems, visibleCount],
-  );
-  const hiddenCount = Math.max(0, filteredItems.length - visibleItems.length);
+  const visibleItems = page?.items ?? [];
+  const filteredUnreadCount = visibleItems.filter(item => item.unread).length;
 
   useEffect(() => {
-    setVisibleCount(ACTIVITY_FEED_INITIAL_VISIBLE);
-  }, [displayItems.length, filter]);
+    if (revisionRef.current !== revision) {
+      revisionRef.current = revision;
+      if (open) setHasUpdates(true);
+    }
+  }, [revision, open]);
 
   useEffect(() => {
-    if (!open) return;
-    setVisibleCount(ACTIVITY_FEED_INITIAL_VISIBLE);
-  }, [open]);
-
-  useEffect(() => {
-    if (!open || snapshotVersion === 0) return;
-    setDisplayItems(sortActivityFeedItems(items));
-    setVisibleCount(ACTIVITY_FEED_INITIAL_VISIBLE);
-  }, [open, snapshotVersion]);
-
-  useEffect(() => {
-    if (open) return;
-    setDisplayItems(sortActivityFeedItems(items));
-  }, [items, open]);
-
-  useEffect(() => {
-    if (!open) return;
-    setDisplayItems((current) => {
-      const latestById = new Map(items.map((item) => [item.id, item]));
-      let changed = false;
-      const next: ActivityFeedItem[] = [];
-
-      for (const displayed of current) {
-        const latest = latestById.get(displayed.id);
-        if (!latest) {
-          changed = true;
-          continue;
+    const id = ++generation.current;
+    pending.current = null;
+    setPage(null);
+    setSwipeState(null);
+    if (!open) {
+      setLoading(false);
+      setCursor(current => current.after || current.before ? {} : current);
+      return;
+    }
+    setLoading(true);
+    setError("");
+    setHasUpdates(false);
+    pending.current = { id, request: { filter, mentionHandles, ...cursor } };
+    // Serialize requests and retain only the latest queued selection.
+    async function drain() {
+      if (running.current) return;
+      running.current = true;
+      try {
+        while (pending.current) {
+          const job = pending.current;
+          pending.current = null;
+          try {
+            const result = await apiInvoke("load_activity_feed", { request: job.request });
+            if (generation.current !== job.id) continue;
+            setPage(result);
+            bodyRef.current?.scrollTo({ top: 0 });
+          } catch (err) {
+            if (generation.current === job.id) setError(String(err));
+          } finally {
+            if (generation.current === job.id) setLoading(false);
+          }
         }
-        if (activityTimestampValue(latest) <= activityTimestampValue(displayed)) {
-          if (latest !== displayed) changed = true;
-          next.push(latest);
-        } else {
-          next.push(displayed);
-        }
-      }
+      } finally { running.current = false; }
+    }
+    void drain();
+    return () => { generation.current++; pending.current = null; };
+  }, [open, filter, cursor, refresh, mentionHandles]);
 
-      return changed ? sortActivityFeedItems(next) : current;
-    });
-  }, [items, open]);
+  async function act(operation: () => Promise<void>) {
+    setActing(true);
+    setError("");
+    try { await operation(); setRefresh(value => value + 1); }
+    catch (err) { setError(String(err)); }
+    finally { setActing(false); }
+  }
+
+  function selectFilter(value: ActivityFeedFilter) {
+    setPage(null);
+    setLoading(true);
+    setFilter(value);
+    setCursor({});
+  }
+
+  function navigate(value: { before?: ActivityFeedCursor; after?: ActivityFeedCursor }) {
+    setPage(null);
+    setLoading(true);
+    setCursor(value);
+  }
 
   if (!open) return null;
 
@@ -197,7 +194,7 @@ export function ActivityFeedModal({
       }, 0);
     }
     if (current.offsetX <= -SWIPE_DISMISS_THRESHOLD_PX) {
-      onDismissItem(item);
+      if (!acting) void act(() => onDismissItem(item));
     }
   }
 
@@ -210,11 +207,8 @@ export function ActivityFeedModal({
   }
 
   function showPendingItems() {
-    setDisplayItems(items);
-    setVisibleCount(ACTIVITY_FEED_INITIAL_VISIBLE);
-    window.requestAnimationFrame(() => {
-      bodyRef.current?.scrollTo({ top: 0, behavior: "smooth" });
-    });
+    navigate({});
+    setRefresh(value => value + 1);
   }
 
   return (
@@ -222,22 +216,22 @@ export function ActivityFeedModal({
         <header className="activity-feed-head">
           <div>
             <h2>Activity</h2>
-            <p>{displayItems.length} active · {unreadCount} unread</p>
+            <p>{counts ? `${counts.total} active · ${counts.unread} unread` : "Activity"}</p>
           </div>
           <div className="activity-feed-head-actions">
             <button
               className="activity-feed-mark-all"
-              disabled={filteredUnreadCount === 0}
-              onClick={() => onMarkAllRead(filteredItems)}
+              disabled={acting || loading || filteredUnreadCount === 0}
+              onClick={() => void act(() => onMarkAllRead(visibleItems))}
             >
-              Mark all read
+              Mark page read
             </button>
             <button
               className="activity-feed-dismiss-all"
-              disabled={filteredItems.length === 0}
-              onClick={() => onDismissItems(filteredItems)}
+              disabled={acting || loading || visibleItems.length === 0}
+              onClick={() => void act(() => onDismissItems(visibleItems))}
             >
-              Dismiss all
+              Dismiss page
             </button>
           </div>
           <button className="activity-feed-back" onClick={onClose} aria-label="Close activity">
@@ -250,26 +244,29 @@ export function ActivityFeedModal({
             <button
               key={item.value}
               className={filter === item.value ? "active" : ""}
-              onClick={() => setFilter(item.value)}
+              disabled={acting}
+              onClick={() => selectFilter(item.value)}
             >
               {item.label}
             </button>
           ))}
         </div>
 
-        <div className="activity-feed-body" ref={bodyRef}>
-          {pendingItems.length > 0 && (
+        <div className="activity-feed-body" ref={bodyRef} aria-busy={loading}>
+          {loading && <p role="status">Loading activity...</p>}
+          {error && <div role="alert">{error}<button type="button" title="Retry loading activity" onClick={() => setRefresh(value => value + 1)}><RefreshCw size={16} /></button></div>}
+          {hasUpdates && !loading && (
             <div className="activity-feed-new-activity">
               <button type="button" onClick={showPendingItems}>
                 <ArrowUp size={16} />
                 <span>
-                  {pendingItems.length === 1 ? "1 new activity" : `${pendingItems.length} new activities`}
+                  Updates available
                 </span>
               </button>
             </div>
           )}
 
-          {filteredItems.length === 0 && (
+          {!loading && !error && visibleItems.length === 0 && (
             <div className="search-empty">
               <Inbox size={34} />
               <h3>No activity</h3>
@@ -337,9 +334,10 @@ export function ActivityFeedModal({
                       <button
                         className="activity-feed-check"
                         title="Mark read"
+                        disabled={acting || loading}
                         onClick={(event) => {
                           event.stopPropagation();
-                          onMarkItemRead(item);
+                          void act(() => onMarkItemRead(item));
                         }}
                       >
                         <Check size={19} />
@@ -348,9 +346,10 @@ export function ActivityFeedModal({
                     <button
                       className="activity-feed-dismiss"
                       title="Dismiss"
+                      disabled={acting || loading}
                       onClick={(event) => {
                         event.stopPropagation();
-                        onDismissItem(item);
+                        void act(() => onDismissItem(item));
                       }}
                     >
                       <X size={18} />
@@ -361,22 +360,14 @@ export function ActivityFeedModal({
             );
           })}
 
-          {hiddenCount > 0 && (
-            <div className="activity-feed-load-more">
-              <button
-                type="button"
-                onClick={() =>
-                  setVisibleCount((current) =>
-                    Math.min(filteredItems.length, current + ACTIVITY_FEED_LOAD_MORE_STEP),
-                  )
-                }
-              >
-                Show {Math.min(hiddenCount, ACTIVITY_FEED_LOAD_MORE_STEP)} more
-                <span>{hiddenCount} hidden</span>
-              </button>
-            </div>
-          )}
+
         </div>
+        <footer className="activity-feed-pagination">
+          <button type="button" title="Latest activity" disabled={loading || acting} onClick={showPendingItems}><RefreshCw size={18} /></button>
+          <button type="button" title="Previous page" disabled={loading || acting || !page?.previousCursor} onClick={() => navigate({ before: page!.previousCursor! })}><ArrowLeft size={18} /></button>
+          <span>{visibleItems.length} items</span>
+          <button type="button" title="Next page" disabled={loading || acting || !page?.nextCursor} onClick={() => navigate({ after: page!.nextCursor! })}><ArrowRight size={18} /></button>
+        </footer>
     </DialogSurface>
   );
 }

--- a/src/hooks/useActivityFeedCounts.ts
+++ b/src/hooks/useActivityFeedCounts.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from "react";
+import { apiInvoke } from "../apiClient";
+import type { ActivityFeedCounts } from "../types";
+
+export function useActivityFeedCounts(revision: object, mentionHandles: string[]) {
+  const [counts, setCounts] = useState<ActivityFeedCounts | null>(null);
+  const invalidate = useRef(() => {});
+  useEffect(() => {
+    let disposed = false;
+    let running = false;
+    let dirty = true;
+    let lastStarted = 0;
+    let timer: number | undefined;
+    function schedule() {
+      if (disposed || running || timer !== undefined || document.hidden || !dirty) return;
+      // Throttle, rather than debounce: continuous events cannot starve the badge.
+      timer = window.setTimeout(refresh, Math.max(100, 5000 - (Date.now() - lastStarted)));
+    }
+    async function refresh() {
+      timer = undefined;
+      if (disposed || document.hidden) return;
+      running = true;
+      dirty = false;
+      lastStarted = Date.now();
+      try {
+        const result = await apiInvoke("load_activity_counts", { mentionHandles });
+        if (!disposed) setCounts(result);
+      } catch {
+        // Keep the last successful badge; retry on the next state change.
+      } finally {
+        running = false;
+        schedule();
+      }
+    }
+    invalidate.current = () => { dirty = true; schedule(); };
+    document.addEventListener("visibilitychange", invalidate.current);
+    schedule();
+    return () => {
+      disposed = true;
+      window.clearTimeout(timer);
+      document.removeEventListener("visibilitychange", invalidate.current);
+      invalidate.current = () => {};
+    };
+  }, [mentionHandles]);
+  useEffect(() => { invalidate.current(); }, [revision]);
+  return counts;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -51,6 +51,7 @@ import { ConfirmModal } from "./components/ConfirmModal";
 import { Conversation } from "./components/Conversation";
 import { CreateChannelModal } from "./components/CreateChannelModal";
 import { ActivityFeedModal } from "./components/ActivityFeedModal";
+import { useActivityFeedCounts } from "./hooks/useActivityFeedCounts";
 import { ArtifactViewerModal } from "./components/ArtifactViewerModal";
 import { OwnerProfileModal, ownerProfileToForm, type OwnerProfileForm } from "./components/OwnerProfileModal";
 import { SavedMessagesModal } from "./components/SavedMessagesModal";
@@ -318,16 +319,6 @@ type AppErrorBoundaryState = {
 
 function phaseForActivity(kind: string) {
   return ACTIVITY_PHASE_LABELS[kind] ?? "Active";
-}
-
-function timestampSortValue(value: string) {
-  const parsed = new Date(value).getTime();
-  return Number.isFinite(parsed) ? parsed : 0;
-}
-
-function compareActivityFeedItems(left: ActivityFeedItem, right: ActivityFeedItem) {
-  if (left.unread !== right.unread) return left.unread ? -1 : 1;
-  return timestampSortValue(right.timestamp) - timestampSortValue(left.timestamp);
 }
 
 function isTextInput(target: EventTarget | null) {
@@ -788,7 +779,6 @@ function App() {
   const [messageSearchResults, setMessageSearchResults] = useState<Message[]>([]);
   const [messageSearchLoading, setMessageSearchLoading] = useState(false);
   const [wikiSearchResults, setWikiSearchResults] = useState<ChannelWikiSearchHit[]>([]);
-  const [activityFeedSnapshotVersion, setActivityFeedSnapshotVersion] = useState(0);
   const [newChannel, setNewChannel] = useState("");
   const [newChannelNameSubmitError, setNewChannelNameSubmitError] = useState<string | null>(null);
   const [newChannelAgentIds, setNewChannelAgentIds] = useState<Set<string>>(() => new Set());
@@ -931,14 +921,12 @@ function App() {
   const messageHydrationAttemptsRef = useRef<Map<string, number>>(new Map());
   const messageHydrationEpochRef = useRef<Map<string, number>>(new Map());
   const loadedHistoricalMessageIdsRef = useRef<Set<string>>(new Set());
-  const activityFeedMessageIdsRef = useRef<Set<string>>(new Set());
   const paginatedChannelIdsRef = useRef<Set<string>>(new Set());
   const initializedOlderChannelIdsRef = useRef<Set<string>>(new Set());
   const olderChannelBeforeSeqRef = useRef<Map<string, number>>(new Map());
   const loadingOlderChannelIdsRef = useRef<Set<string>>(new Set());
   const olderChannelRequestEpochRef = useRef<Map<string, number>>(new Map());
   const pendingChannelRestoreRef = useRef<Set<string>>(new Set());
-  const activityFeedRequestRef = useRef(0);
   const messageSearchRequestRef = useRef(0);
   const wikiSearchRequestRef = useRef(0);
   const loadingThreadIdsRef = useRef(new Set<string>());
@@ -1190,7 +1178,6 @@ function App() {
       snapshotInvalidated: refreshInvalidation !== refreshInvalidationRef.current,
       loadedHistoricalMessageIds: new Set([
         ...loadedHistoricalMessageIdsRef.current,
-        ...activityFeedMessageIdsRef.current,
       ]),
       paginatedChannelIds: paginatedChannelIdsRef.current,
       initializedChannelIds: initializedOlderChannelIdsRef.current,
@@ -1451,38 +1438,6 @@ function App() {
     };
   }, [activeThreadId, showThread, data?.ui_event_cursor]);
 
-  async function hydrateActivityFeedMessages() {
-    const requestId = activityFeedRequestRef.current + 1;
-    activityFeedRequestRef.current = requestId;
-    try {
-      const messages = await apiInvoke("load_activity_messages", {
-        mentionHandles: OWNER_MENTION_HANDLES,
-      });
-      if (activityFeedRequestRef.current !== requestId) return;
-
-      const known = knownMessageIdsRef.current ?? new Set(
-        data?.messages
-          .filter((message) => !isProgressOnlyMessage(message))
-          .map((message) => message.id) ?? [],
-      );
-      activityFeedMessageIdsRef.current = new Set(messages.map((message) => message.id));
-      for (const message of messages) {
-        hydratedMessageIdsRef.current.add(message.id);
-        hydratedMessageBodiesRef.current.set(message.id, message.body);
-        if (!isProgressOnlyMessage(message)) known.add(message.id);
-      }
-      knownMessageIdsRef.current = known;
-      setData((current) => current
-        ? { ...current, messages: mergeMessages(current.messages, messages) }
-        : current);
-      setActivityFeedSnapshotVersion((current) => current + 1);
-    } catch (err) {
-      if (activityFeedRequestRef.current !== requestId) return;
-      setAppError(errorMessage(err, "Failed to load Activity"));
-      console.error(err);
-    }
-  }
-
   async function loadChannelMessages(channelId: string) {
     const baselineActivities = new Map(data?.thread_activities.map(row => [row.thread_root_id, row]));
     if (
@@ -1674,7 +1629,6 @@ function App() {
       const result = applyBackendEvent(current, event);
       for (const messageId of result.deletedMessageIds) {
         loadedHistoricalMessageIdsRef.current.delete(messageId);
-        activityFeedMessageIdsRef.current.delete(messageId);
         knownMessageIdsRef.current?.delete(messageId);
       }
       if (result.needsRefresh) {
@@ -2992,227 +2946,12 @@ function App() {
     return new Map((data?.thread_activities ?? []).map((activity) => [activity.thread_root_id, activity]));
   }, [data?.thread_activities]);
 
-  const allThreadRootMessages = useMemo(() => {
-    const latestByRoot = new Map<string, number>();
-    for (const message of visibleMessages) {
-      if (!message.thread_root_id) continue;
-      const timestamp = new Date(message.created_at).getTime();
-      latestByRoot.set(message.thread_root_id, Math.max(latestByRoot.get(message.thread_root_id) ?? 0, timestamp));
-    }
-    for (const activity of data?.thread_activities ?? []) {
-      const timestamp = new Date(activity.latest_activity_at).getTime();
-      if (Number.isFinite(timestamp)) {
-        latestByRoot.set(activity.thread_root_id, Math.max(latestByRoot.get(activity.thread_root_id) ?? 0, timestamp));
-      }
-    }
-    return visibleMessages
-      .filter((message) =>
-        !message.thread_root_id &&
-        latestByRoot.has(message.id) &&
-        (message.thread_followed || (threadUnreadCounts[message.id] ?? 0) > 0) &&
-        !locallyUnfollowedThreadIds.has(message.id))
-      .sort((left, right) => (latestByRoot.get(right.id) ?? 0) - (latestByRoot.get(left.id) ?? 0));
-  }, [data?.thread_activities, visibleMessages, locallyUnfollowedThreadIds, threadUnreadCounts]);
-
-  const allActivityFeedItems = useMemo(() => {
-    if (!data) return [];
-    const channelsById = new Map(data.channels.map((item) => [item.id, item]));
-    const agentsById = new Map(data.agents.map((item) => [item.id, item]));
-    const latestByChannel = new Map<string, Message>();
-    const repliesByRoot = new Map<string, Message[]>();
-
-    for (const message of visibleMessages) {
-      const currentChannelLatest = latestByChannel.get(message.channel_id);
-      if (!currentChannelLatest || new Date(message.created_at) > new Date(currentChannelLatest.created_at)) {
-        latestByChannel.set(message.channel_id, message);
-      }
-      if (message.thread_root_id) {
-        const currentReplies = repliesByRoot.get(message.thread_root_id) ?? [];
-        currentReplies.push(message);
-        repliesByRoot.set(message.thread_root_id, currentReplies);
-      }
-    }
-    for (const replies of repliesByRoot.values()) {
-      replies.sort((left, right) => new Date(left.created_at).getTime() - new Date(right.created_at).getTime());
-    }
-
-    const channelLabel = (channelId: string | null) => {
-      if (!channelId) return APP_DISPLAY_NAME;
-      const target = channelsById.get(channelId);
-      if (!target) return "Unknown";
-      if (target.kind === "dm") {
-        const agent = target.dm_agent_id ? agentsById.get(target.dm_agent_id) : null;
-        return agent ? `@${agent.handle}` : "Direct message";
-      }
-      return `#${target.name}`;
-    };
-    const timestamp = (value: string | null | undefined) => value || new Date(0).toISOString();
-    const items: ActivityFeedItem[] = [];
-    const threadRootIdsForActivityFeed = new Set(allThreadRootMessages.map((message) => message.id));
-
-    for (const channel of data.channels) {
-      const unread = channel.unread_count > 0 || channelAlertIds.has(channel.id);
-      if (!unread) continue;
-      const latest = latestByChannel.get(channel.id);
-      if (latest?.thread_root_id && threadRootIdsForActivityFeed.has(latest.thread_root_id)) continue;
-      const dmAgent = channel.kind === "dm" && channel.dm_agent_id ? agentsById.get(channel.dm_agent_id) : null;
-      items.push({
-        id: `${channel.kind}:${channel.id}`,
-        dismissId: `${channel.kind}:${channel.id}`,
-        kind: channel.kind === "dm" ? "dm" : "channel",
-        title: channel.kind === "dm" ? `DM with @${dmAgent?.handle ?? "agent"}` : `New activity in #${channel.name}`,
-        excerpt: latest?.body ?? visibleChannelDescription(channel.description),
-        surface: channel.kind === "dm" ? "Direct message" : `#${channel.name}`,
-        actor: latest?.sender_name ?? "",
-        timestamp: timestamp(latest?.created_at),
-        unread: true,
-        actorAgentId: latest?.sender_agent_id ?? dmAgent?.id ?? null,
-        actorRole: latest?.sender_role ?? (channel.kind === "dm" ? "agent" : null),
-        channelId: channel.id,
-        threadId: latest?.thread_root_id ?? null,
-        messageId: latest?.id ?? null,
-        taskId: null,
-        reminderId: null,
-        replyCount: latest?.thread_root_id ? (threadReplyCounts[latest.thread_root_id] ?? 0) : 0,
-        newCount: channel.unread_count,
-      });
-    }
-
-    for (const root of allThreadRootMessages) {
-      const replies = repliesByRoot.get(root.id) ?? [];
-      const threadActivity = threadActivitiesByRoot.get(root.id);
-      const unreadCount = threadUnreadCounts[root.id] ?? threadActivity?.unread_count ?? 0;
-      const latestActivity = threadActivity
-        ? messagesById.get(threadActivity.latest_message_id) ?? replies[replies.length - 1] ?? root
-        : replies[replies.length - 1] ?? root;
-      const unread = unreadCount > 0;
-      // Jump to the first unread reply rather than the latest message —
-      // landing on the newest message is indistinguishable from just opening
-      // the thread at the bottom.
-      const firstUnread = unread && replies.length > 0
-        ? replies[Math.max(0, replies.length - unreadCount)] ?? replies[0]
-        : null;
-      items.push({
-        id: `thread:${root.id}`,
-        dismissId: `thread:${root.id}`,
-        kind: "thread",
-        title: firstLines(latestActivity.body, 1),
-        excerpt: latestActivity.body,
-        surface: channelLabel(root.channel_id),
-        actor: latestActivity.sender_name,
-        timestamp: timestamp(latestActivity.created_at),
-        unread,
-        actorAgentId: latestActivity.sender_agent_id,
-        actorRole: latestActivity.sender_role,
-        channelId: root.channel_id,
-        threadId: root.id,
-        messageId: firstUnread?.id ?? latestActivity.id,
-        taskId: null,
-        reminderId: null,
-        replyCount: threadReplyCounts[root.id] ?? 0,
-        newCount: unreadCount,
-      });
-    }
-
-    visibleMessages
-      .filter((message) => message.sender_role !== "owner" && messageMentionsOwner(message))
-      .sort((left, right) => new Date(right.created_at).getTime() - new Date(left.created_at).getTime())
-      .forEach((message) => {
-        const rootId = message.thread_root_id ?? message.id;
-        items.push({
-          id: `mention:${message.id}`,
-          dismissId: `mention:${message.id}`,
-          kind: "mention",
-          title: firstLines(message.body, 1),
-          excerpt: message.body,
-          surface: channelLabel(message.channel_id),
-          actor: message.sender_name,
-          timestamp: message.created_at,
-          unread: channelAlertIds.has(message.channel_id) || (message.thread_root_id ? (threadUnreadCounts[message.thread_root_id] ?? 0) > 0 : false),
-          actorAgentId: message.sender_agent_id,
-          actorRole: message.sender_role,
-          channelId: message.channel_id,
-          threadId: rootId,
-          messageId: message.id,
-          taskId: null,
-          reminderId: null,
-          replyCount: threadReplyCounts[rootId] ?? 0,
-          newCount: message.thread_root_id ? (threadUnreadCounts[message.thread_root_id] ?? 0) : 0,
-        });
-      });
-
-    data.tasks
-      .filter((task) => task.status !== "done")
-      .forEach((task) => {
-        items.push({
-          id: `task:${task.id}`,
-          dismissId: `task:${task.id}`,
-          kind: "task",
-          title: `Task #${task.number}: ${task.title}`,
-          excerpt: task.assignee_name ? `Assigned to ${task.assignee_name}` : "Unassigned",
-          surface: `#${task.channel_name}`,
-          actor: task.status.replace("_", " "),
-          timestamp: task.updated_at,
-          unread: task.status === "in_review",
-          actorAgentId: task.assignee_id,
-          actorRole: task.assignee_id ? "agent" : null,
-          channelId: task.channel_id,
-          threadId: task.message_id,
-          messageId: task.message_id,
-          taskId: task.id,
-          reminderId: null,
-          replyCount: threadReplyCounts[task.message_id] ?? 0,
-          newCount: 0,
-        });
-      });
-
-    data.reminders
-      .filter((reminder) => reminder.status === "fired")
-      .forEach((reminder) => {
-        items.push({
-          id: `reminder:${reminder.id}`,
-          dismissId: `reminder:${reminder.id}`,
-          kind: "reminder",
-          title: reminder.title,
-          excerpt: reminder.note,
-          surface: reminder.channel_id ? channelLabel(reminder.channel_id) : "Reminder",
-          actor: "Reminder due",
-          timestamp: reminder.fired_at ?? reminder.due_at,
-          unread: true,
-          channelId: reminder.channel_id,
-          threadId: reminder.thread_root_id,
-          messageId: reminder.message_id,
-          taskId: null,
-          reminderId: reminder.id,
-          replyCount: reminder.thread_root_id ? (threadReplyCounts[reminder.thread_root_id] ?? 0) : 0,
-          newCount: 1,
-        });
-      });
-
-    return items;
-  }, [allThreadRootMessages, channelAlertIds, data, messagesById, threadActivitiesByRoot, threadReplyCounts, threadUnreadCounts, visibleMessages]);
-
-  const activityFeedItems = useMemo(() => {
-    return allActivityFeedItems
-      .filter((item) => {
-        const dismissedAt = dismissedActivityFeedItems[item.dismissId];
-        if (!dismissedAt) return true;
-        return new Date(item.timestamp).getTime() > new Date(dismissedAt).getTime();
-      })
-      .map((item) => {
-        const readAt = readActivityFeedItems[item.id];
-        if (!readAt || new Date(item.timestamp).getTime() > new Date(readAt).getTime()) {
-          return item;
-        }
-        return { ...item, unread: false };
-      })
-      .sort(compareActivityFeedItems)
-      .slice(0, 120);
-  }, [allActivityFeedItems, dismissedActivityFeedItems, readActivityFeedItems]);
-
-  const activityFeedUnreadCount = useMemo(() => {
-    return activityFeedItems.filter((item) => item.unread).length;
-  }, [activityFeedItems]);
+  const activityFeedRevision = useMemo(() => ({}), [
+    data?.messages, data?.channels, data?.tasks, data?.reminders,
+    data?.thread_activities, data?.read_inbox_items, data?.dismissed_inbox_items, showActivityFeedModal,
+  ]);
+  const activityFeedCounts = useActivityFeedCounts(activityFeedRevision, OWNER_MENTION_HANDLES);
+  const activityFeedUnreadCount = activityFeedCounts?.unread ?? 0;
 
   const savedMessageIds = useMemo(() => {
     return new Set(data?.saved_messages.map((item) => item.message_id) ?? []);
@@ -3706,7 +3445,6 @@ function App() {
           for (const message of current.messages) {
             if (message.channel_id !== channelToDelete.id) continue;
             loadedHistoricalMessageIdsRef.current.delete(message.id);
-            activityFeedMessageIdsRef.current.delete(message.id);
             knownMessageIdsRef.current?.delete(message.id);
           }
           return applyOptimisticMutation(current, {
@@ -4094,7 +3832,6 @@ function App() {
     setShowSavedModal(false);
     setShowActivityFeedModal(true);
     void Promise.all([
-      hydrateActivityFeedMessages(),
       reloadUiState(["thread_activities", "read_inbox_items", "dismissed_inbox_items"]),
     ]).catch((err) => setAppError(errorMessage(err, "Failed to load Activity context")));
   }
@@ -4776,14 +4513,13 @@ function App() {
   }
 
   function activityFeedItemCutoff(item: ActivityFeedItem) {
-    const itemTime = new Date(item.timestamp).getTime();
-    const cutoffTime = Math.max(Date.now(), Number.isFinite(itemTime) ? itemTime : 0);
-    return new Date(cutoffTime).toISOString();
+    return item.timestamp;
   }
 
   async function openActivityFeedItem(item: ActivityFeedItem) {
     if (item.unread) {
-      void markActivityFeedItemRead(item);
+      void markActivityFeedItemRead(item)
+        .catch(err => setAppError(errorMessage(err, "Failed to mark Activity read")));
     }
     const targetThreadId = item.threadId ?? item.messageId;
     if (item.messageId || targetThreadId) {
@@ -4805,37 +4541,11 @@ function App() {
   }
 
   async function markActivityFeedItemRead(item: ActivityFeedItem) {
-    if (!item.unread) return;
-    const dismissedUntil = activityFeedItemCutoff(item);
-    setReadActivityFeedItems((current) => ({ ...current, [item.id]: dismissedUntil }));
-    const operations: Promise<unknown>[] = [persistReadActivityFeedItems([item], dismissedUntil)];
-    if (item.threadId) {
-      setThreadUnreadCounts((current) => {
-        if (!current[item.threadId!]) return current;
-        const next = { ...current };
-        delete next[item.threadId!];
-        return next;
-      });
-      operations.push(persistThreadReadMarkers([{ threadId: item.threadId, dismissedUntil }]));
-    }
-    if (item.channelId) {
-      setChannelAlertIds((current) => {
-        if (!current.has(item.channelId!)) return current;
-        const next = new Set(current);
-        next.delete(item.channelId!);
-        return next;
-      });
-      operations.push(apiInvoke("mark_channel_read", { channelId: item.channelId }));
-    }
-    await Promise.all(operations);
-    await reloadUiState(["read_inbox_items", "dismissed_inbox_items", "channels"]);
+    await markAllActivityFeedRead([item]);
   }
 
   async function dismissActivityFeedItem(item: ActivityFeedItem) {
-    const dismissedUntil = activityFeedItemCutoff(item);
-    setDismissedActivityFeedItems((current) => ({ ...current, [item.dismissId]: dismissedUntil }));
-    await persistDismissedActivityFeedItems([item], dismissedUntil);
-    await reloadUiState(["read_inbox_items", "dismissed_inbox_items", "channels"]);
+    await dismissActivityFeedItems([item]);
   }
 
   async function dismissActivityFeedItems(items: ActivityFeedItem[]) {
@@ -4848,62 +4558,15 @@ function App() {
         cutoffByDismissId.set(item.dismissId, cutoff);
       }
     }
-    setDismissedActivityFeedItems((current) => {
-      const next = { ...current };
-      for (const [dismissId, dismissedUntil] of cutoffByDismissId) {
-        next[dismissId] = dismissedUntil;
-      }
-      return next;
-    });
     await persistDismissedActivityFeedItems(items, (item) => cutoffByDismissId.get(item.dismissId) ?? item.timestamp);
     await reloadUiState(["read_inbox_items", "dismissed_inbox_items", "channels"]);
   }
 
   async function markAllActivityFeedRead(items: ActivityFeedItem[]) {
-    const markReadItems = items.filter((item) => item.unread);
-    if (markReadItems.length === 0) return;
-    const cutoffByItemId = new Map(markReadItems.map((item) => [item.id, activityFeedItemCutoff(item)]));
-    setReadActivityFeedItems((current) => {
-      const next = { ...current };
-      for (const item of markReadItems) {
-        next[item.id] = cutoffByItemId.get(item.id) ?? item.timestamp;
-      }
-      return next;
-    });
-    setChannelAlertIds((current) => {
-      const channelIds = new Set(markReadItems.map((item) => item.channelId).filter((id): id is string => Boolean(id)));
-      if (channelIds.size === 0) return current;
-      const next = new Set(current);
-      for (const channelId of channelIds) {
-        next.delete(channelId);
-      }
-      return next;
-    });
-    setThreadUnreadCounts((current) => {
-      const threadIds = new Set(markReadItems.map((item) => item.threadId).filter((id): id is string => Boolean(id)));
-      if (threadIds.size === 0) return current;
-      const next = { ...current };
-      for (const threadId of threadIds) {
-        delete next[threadId];
-      }
-      return next;
-    });
-    await Promise.all([
-      persistReadActivityFeedItems(markReadItems, (item) => cutoffByItemId.get(item.id) ?? item.timestamp),
-      persistThreadReadMarkers(
-        markReadItems
-          .filter((item): item is ActivityFeedItem & { threadId: string } => Boolean(item.threadId))
-          .map((item) => ({
-            threadId: item.threadId,
-            dismissedUntil: cutoffByItemId.get(item.id) ?? item.timestamp,
-          })),
-      ),
-      ...Array.from(
-        new Set(markReadItems.map((item) => item.channelId).filter((id): id is string => Boolean(id))),
-        (channelId) => apiInvoke("mark_channel_read", { channelId }),
-      ),
-    ]);
-    await reloadUiState(["read_inbox_items", "dismissed_inbox_items", "channels"]);
+    const unread = items.filter(item => item.unread);
+    if (unread.length === 0) return;
+    await persistReadActivityFeedItems(unread, item => item.timestamp);
+    await reloadUiState(["read_inbox_items", "dismissed_inbox_items", "thread_activities", "channels"]);
   }
 
   function startSidebarResize(event: ReactPointerEvent<HTMLButtonElement>) {
@@ -5177,8 +4840,9 @@ function App() {
 
       <ActivityFeedModal
         open={showActivityFeedModal}
-        items={activityFeedItems}
-        snapshotVersion={activityFeedSnapshotVersion}
+        counts={activityFeedCounts}
+        revision={activityFeedRevision}
+        mentionHandles={OWNER_MENTION_HANDLES}
         agents={data.agents}
         ownerProfile={data.owner_profile}
         onOpenItem={openActivityFeedItem}

--- a/src/styles.css
+++ b/src/styles.css
@@ -10867,7 +10867,7 @@ body.resizing-column * {
 
 .activity-feed-panel {
   display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
   width: min(1180px, calc(100vw - 56px));
   max-height: calc(100vh - 56px);
   overflow: hidden;
@@ -10988,6 +10988,31 @@ body.resizing-column * {
   overflow-x: hidden;
   padding: 4px 0 20px;
   scrollbar-gutter: stable;
+}
+
+.activity-feed-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  flex: 0 0 auto;
+  padding: 10px 20px;
+  border-top: 1px solid var(--activity-feed-panel-border);
+}
+
+.activity-feed-pagination button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  flex: 0 0 36px;
+}
+
+@media (max-width: 760px) {
+  .activity-feed-panel {
+    padding-bottom: calc(76px + env(safe-area-inset-bottom));
+  }
 }
 
 .activity-feed-new-activity {

--- a/src/types.ts
+++ b/src/types.ts
@@ -554,6 +554,21 @@ export type SearchResult = {
 
 export type ActivityFeedKind = "mention" | "dm" | "thread" | "task" | "reminder" | "channel";
 
+export type ActivityFeedFilter = "all" | "unread" | ActivityFeedKind;
+export type ActivityFeedCursor = { timestamp: string; id: string };
+export type ActivityFeedPage = {
+  items: ActivityFeedItem[];
+  nextCursor: ActivityFeedCursor | null;
+  previousCursor: ActivityFeedCursor | null;
+};
+export type ActivityFeedRequest = {
+  filter: ActivityFeedFilter;
+  mentionHandles: string[];
+  after?: ActivityFeedCursor | null;
+  before?: ActivityFeedCursor | null;
+};
+export type ActivityFeedCounts = { total: number; unread: number };
+
 export type ActivityFeedItem = {
   id: string;
   dismissId: string;

--- a/tests/activity-feed.e2e.mjs
+++ b/tests/activity-feed.e2e.mjs
@@ -1,0 +1,235 @@
+// Production UI against an isolated API; never reads or changes live inbox state.
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { readFile, mkdir } from "node:fs/promises";
+import { resolve, join } from "node:path";
+import { chromium } from "playwright";
+
+const id = n => `00000000-0000-4000-8000-${String(n).padStart(12, "0")}`;
+const now = new Date().toISOString();
+const earlier = new Date(Date.now() - 3_600_000).toISOString();
+const channelId = id(1);
+const message = (n, extra = {}) => ({
+  id: id(n), seq: n, channel_id: channelId, thread_root_id: null,
+  sender_agent_id: null, sender_name: "Test owner", sender_role: "owner",
+  body: "Followed discussion", is_task: false, thread_followed: true,
+  delivery_state: "complete", stream_key: "", task_number: null, task_status: null,
+  attachments: [], artifacts: [], created_at: earlier, updated_at: earlier, ...extra,
+});
+const root = message(2);
+const reply = message(3, { thread_root_id: root.id, body: "Waiting for an agent reply", created_at: now, updated_at: now });
+const oldTasks = count => Array.from({ length: count }, (_, index) => ({
+  id: id(100 + index), number: index + 1, message_id: root.id, channel_id: channelId,
+  title: `Old review ${index + 1}`, status: "in_review", version: 1,
+  channel_name: "activity-test", assignee_id: null, assignee_name: null,
+  created_at: earlier, updated_at: earlier,
+}));
+const state = {
+  db_url: "synthetic://activity-feed", web_base_url: null,
+  owner_profile: { display_name: "Test owner", avatar: "T", description: "" },
+  channels: [{ id: channelId, name: "activity-test", description: "", kind: "channel",
+    dm_agent_id: null, unread_count: 0, github_unread_count: 0, github_review_synced_at: null }],
+  messages: [root, reply], channel_message_history: [{ channel_id: channelId, before_seq: null, has_more: false }],
+  agents: [], tasks: oldTasks(35), channel_members: [],
+  thread_activities: [{ thread_root_id: root.id, channel_id: channelId, reply_count: 1,
+    unread_count: 0, latest_message_id: reply.id, latest_activity_at: now }],
+  saved_messages: [], dismissed_inbox_items: {}, read_inbox_items: {}, artifacts: [], reminders: [],
+  agent_schedules: [], agent_runs: [], agent_work_items: [], agent_activities: [],
+  supervisor: { pid: null, status: "stopped", updated_at: null },
+  launch_agent: { label: "", plist_path: "", installed: false, loaded: false }, ui_event_cursor: 0,
+};
+function feedItems() {
+  const tasks = state.tasks.map(task => ({
+    id: `task:${task.id}`, dismissId: `task:${task.id}`, kind: "task",
+    title: task.title, excerpt: "Unassigned", surface: "#activity-test", actor: "in review",
+    timestamp: task.updated_at, unread: true, actorAgentId: null, actorRole: null,
+    channelId, threadId: root.id, messageId: root.id, taskId: task.id, reminderId: null, replyCount: 0, newCount: 0,
+  }));
+  const threads = state.messages.filter(m => m.thread_root_id).map(m => ({
+    id: `thread:${m.thread_root_id}`, dismissId: `thread:${m.thread_root_id}`, kind: "thread",
+    title: m.body, excerpt: m.body, surface: "#activity-test", actor: m.sender_name,
+    timestamp: m.created_at, unread: false, actorAgentId: null, actorRole: "owner",
+    channelId, threadId: m.thread_root_id, messageId: m.id, taskId: null, reminderId: null, replyCount: 1, newCount: 0,
+  }));
+  return [...tasks, ...threads].filter(item => !state.dismissed_inbox_items[item.id])
+    .map(item => ({ ...item, unread: item.unread && !state.read_inbox_items[item.id] }))
+    .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp) || b.id.localeCompare(a.id));
+}
+let failNextFeed = false;
+let heldFeed = null;
+let inFlightFeeds = 0;
+let maxInFlightFeeds = 0;
+const requests = [];
+const clients = new Set();
+let activityLoads = 0;
+const api = createServer(async (req, res) => {
+  const url = new URL(req.url, "http://localhost");
+  if (!url.pathname.startsWith("/api/")) {
+    const file = resolve("dist", url.pathname === "/" ? "index.html" : url.pathname.slice(1));
+    if (!file.startsWith(resolve("dist") + "/")) { res.writeHead(404).end(); return; }
+    try {
+      const mime = { html: "text/html", js: "application/javascript", css: "text/css", woff2: "font/woff2" };
+      res.writeHead(200, { "content-type": mime[file.split(".").pop()] || "application/octet-stream" }).end(await readFile(file));
+    } catch { res.writeHead(404).end(); }
+    return;
+  }
+  if (url.pathname === "/api/events") {
+    res.writeHead(200, { "content-type": "text/event-stream" }); res.write(": ready\n\n");
+    clients.add(res); res.on("close", () => clients.delete(res)); return;
+  }
+  let raw = ""; for await (const chunk of req) raw += chunk;
+  const args = raw ? JSON.parse(raw) : {};
+  requests.push({ path: url.pathname, args });
+  let result = { ok: true };
+  switch (url.pathname) {
+    case "/api/bootstrap": result = state; break;
+    case "/api/load_activity_messages": throw new Error("Activity must not hydrate full messages");
+    case "/api/load_activity_counts": {
+      const items = feedItems(); result = { total: items.length, unread: items.filter(i => i.unread).length }; break;
+    }
+    case "/api/load_activity_feed": {
+      activityLoads++;
+      inFlightFeeds++; maxInFlightFeeds = Math.max(maxInFlightFeeds, inFlightFeeds);
+      const request = args.request;
+      let items = feedItems().filter(i => request.filter === "all" || (request.filter === "unread" ? i.unread : i.kind === request.filter));
+      const cursor = request.after ?? request.before;
+      const compare = i => Date.parse(i.timestamp) - Date.parse(cursor.timestamp) || i.id.localeCompare(cursor.id);
+      if (cursor) items = items.filter(i => request.before ? compare(i) > 0 : compare(i) < 0);
+      if (request.before) items.reverse();
+      const more = items.length > 30;
+      items = items.slice(0, 30);
+      if (request.before) items.reverse();
+      const toCursor = i => i ? { id: i.id, timestamp: i.timestamp } : null;
+      result = { items,
+        nextCursor: (request.before || more) ? toCursor(items.at(-1)) : null,
+        previousCursor: (request.before ? more : request.after) ? toCursor(items[0]) : null,
+      };
+      if (heldFeed && !heldFeed.started) { heldFeed.started = true; await heldFeed.promise; }
+      inFlightFeeds--;
+      if (failNextFeed) { failNextFeed = false; res.writeHead(500, { "content-type": "application/json" }).end(JSON.stringify({ error: "Fixture query failure" })); return; }
+      break;
+    }
+    case "/api/mark_inbox_items_read":
+      for (const item of args.items) state.read_inbox_items[item.itemId] = item.dismissedUntil;
+      break;
+    case "/api/dismiss_inbox_items":
+      for (const item of args.items) state.dismissed_inbox_items[item.itemId] = item.dismissedUntil;
+      break;
+    case "/api/load_channel_previews": result = []; break;
+    case "/api/load_channel_messages": result = { messages: state.messages, next_before_seq: null, has_more: false }; break;
+    case "/api/load_thread_messages": result = state.messages; break;
+    case "/api/load_ui_state": result = Object.fromEntries(args.scopes.map(scope => [scope, state[scope]])); break;
+    case "/api/replay_ui_events": result = { cursor: 0, replayGap: false, events: [] }; break;
+  }
+  res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify(result));
+});
+await new Promise(done => api.listen(0, "127.0.0.1", done));
+let browser;
+try {
+  browser = await chromium.launch();
+  for (const width of [1440, 390]) {
+    const context = await browser.newContext({ serviceWorkers: "block", viewport: { width, height: 960 } });
+    const page = await context.newPage(); page.setDefaultTimeout(5000);
+    const errors = []; page.on("pageerror", error => errors.push(error.message));
+    for (const [taskCount, readThreadCount] of [[35, 0], [125, 0], [35, 125]]) {
+      state.tasks = oldTasks(taskCount);
+      state.read_inbox_items = {};
+      state.dismissed_inbox_items = {};
+      state.messages = [root, reply];
+      for (let index = 0; index < readThreadCount; index++) {
+        const otherRoot = message(1000 + index * 2);
+        state.messages.push(otherRoot, message(1001 + index * 2, {
+          thread_root_id: otherRoot.id, body: `Another read thread ${index}`,
+          created_at: new Date(Date.parse(now) - 1000).toISOString(),
+        }));
+      }
+      const before = activityLoads;
+      await page.goto(`http://127.0.0.1:${api.address().port}`, { waitUntil: "domcontentloaded" });
+      const trigger = page.locator(width > 760 ? ".sidebar" : ".mobile-bottom-nav").getByRole("button", { name: /Activity/ });
+      await trigger.click();
+      const dialog = page.getByRole("dialog", { name: "Activity", exact: true });
+      await dialog.waitFor();
+      for (let i = 0; i < 100 && activityLoads === before; i++) await page.waitForTimeout(20);
+      assert.ok(activityLoads > before, "Activity loads its messages");
+      await dialog.locator(".activity-feed-row").first().waitFor();
+      const ownerRow = dialog.locator(".activity-feed-row").filter({ hasText: reply.body });
+      await dialog.getByRole("button", { name: "Threads", exact: true }).click();
+      await ownerRow.waitFor();
+      assert.equal(await ownerRow.count(), 1, "followed owner reply is independently fetched in Threads");
+      await dialog.getByRole("button", { name: "All", exact: true }).click();
+      await ownerRow.waitFor();
+      assert.equal(await ownerRow.count(), 1, "All shows the latest owner reply without loading older pages");
+      assert.ok((await dialog.locator(".activity-feed-row").first().innerText()).includes(reply.body), "All is newest first regardless of unread state");
+      assert.equal(await ownerRow.locator('[aria-label="Unread"]').count(), 0, "self-sent messages do not become unread");
+      if (process.env.LANTOR_UI_SCREENSHOTS) {
+        await mkdir(process.env.LANTOR_UI_SCREENSHOTS, { recursive: true });
+        await page.screenshot({ path: join(process.env.LANTOR_UI_SCREENSHOTS, `activity-all-${width}-${taskCount}-${readThreadCount}.png`) });
+      }
+      await dialog.getByRole("button", { name: "Unread", exact: true }).click();
+      await dialog.locator(".activity-feed-row").first().waitFor();
+      assert.equal(await ownerRow.count(), 0, "Unread still excludes the owner's read thread");
+      assert.equal(await dialog.locator(".activity-feed-row").count(), 30, "Unread still includes old review tasks");
+      const firstPageTitle = await dialog.locator(".activity-feed-row h3").first().innerText();
+      await dialog.getByRole("button", { name: "Next page", exact: true }).click();
+      await dialog.locator(".activity-feed-row").first().waitFor();
+      assert.ok(await dialog.locator(".activity-feed-row").count() <= 30, "next page replaces, never appends DOM");
+      assert.notEqual(await dialog.locator(".activity-feed-row h3").first().innerText(), firstPageTitle);
+      const footerBox = await dialog.locator(".activity-feed-pagination").boundingBox();
+      assert.ok(footerBox && footerBox.y >= 0 && footerBox.y + footerBox.height <= 960, "pagination remains inside viewport");
+      await dialog.getByRole("button", { name: "Previous page", exact: true }).click();
+      await dialog.locator(".activity-feed-row").first().waitFor();
+      assert.equal(await dialog.locator(".activity-feed-row h3").first().innerText(), firstPageTitle);
+      await dialog.getByRole("button", { name: "All", exact: true }).click();
+      await ownerRow.waitFor();
+      assert.equal(await ownerRow.count(), 1, "switching filters restores the latest thread");
+      assert.ok(await dialog.evaluate(e => e.scrollWidth <= e.clientWidth + 1), "Activity has no horizontal overflow");
+      await page.keyboard.press("Escape");
+      await dialog.waitFor({ state: "detached" });
+    }
+    await page.locator(width > 760 ? ".sidebar" : ".mobile-bottom-nav").getByRole("button", { name: /Activity/ }).click();
+    const dialog = page.getByRole("dialog", { name: "Activity", exact: true });
+    await dialog.locator(".activity-feed-row").first().waitFor();
+    let release;
+    heldFeed = { started: false, promise: new Promise(resolve => { release = resolve; }) };
+    await dialog.getByRole("button", { name: "Threads", exact: true }).click();
+    for (let i = 0; i < 100 && !heldFeed.started; i++) await page.waitForTimeout(20);
+    assert.ok(heldFeed.started);
+    await dialog.getByRole("button", { name: "Unread", exact: true }).click();
+    await dialog.getByRole("button", { name: "Tasks", exact: true }).click();
+    release(); heldFeed = null;
+    await dialog.locator(".activity-feed-row").first().waitFor();
+    assert.ok((await dialog.locator(".activity-feed-row h3").first().innerText()).includes("Old review"), "late Threads response cannot populate Tasks");
+    assert.equal(maxInFlightFeeds, 1, "rapid filter changes keep only one request in flight");
+    failNextFeed = true;
+    await dialog.getByRole("button", { name: "Latest activity", exact: true }).click();
+    await dialog.getByRole("alert").waitFor();
+    assert.equal(await dialog.locator(".activity-feed-row").count(), 0, "failed page does not expose stale rows as current");
+    await dialog.getByRole("button", { name: "Retry loading activity", exact: true }).click();
+    await dialog.locator(".activity-feed-row").first().waitFor();
+    await dialog.getByRole("button", { name: "Mark page read", exact: true }).click();
+    await page.waitForFunction(() => !document.querySelector(".activity-feed-body[aria-busy=true]") && document.querySelectorAll(".activity-feed-row").length > 0);
+    assert.equal(Object.keys(state.read_inbox_items).length, 30, "bulk read covers only the current page");
+    await dialog.getByRole("button", { name: "Dismiss page", exact: true }).click();
+    await page.waitForFunction(() => !document.querySelector(".activity-feed-body[aria-busy=true]") && document.querySelectorAll(".activity-feed-row").length === 5);
+    assert.equal(Object.keys(state.dismissed_inbox_items).length, 30, "bulk dismissal covers only the current page");
+    await dialog.getByRole("button", { name: "Threads", exact: true }).click();
+    await dialog.locator(".activity-feed-row").first().waitFor();
+    await dialog.getByRole("button", { name: "Next page", exact: true }).click();
+    await dialog.locator(".activity-feed-row").first().waitFor();
+    await dialog.getByRole("button", { name: "Close activity", exact: true }).click();
+    await dialog.waitFor({ state: "detached" });
+    await page.locator(width > 760 ? ".sidebar" : ".mobile-bottom-nav").getByRole("button", { name: /Activity/ }).click();
+    await dialog.locator(".activity-feed-row").first().waitFor();
+    assert.ok((await dialog.locator(".activity-feed-row h3").first().innerText()).includes(reply.body), "reopening starts at latest page");
+    assert.ok(requests.some(r => r.path === "/api/load_activity_counts"), "badge has an independent count query");
+    assert.equal(requests.some(r => r.path === "/api/load_activity_messages"), false);
+    assert.deepEqual(errors, []);
+    await context.close();
+    console.log(`PASS ${width}px: All/Threads owner reply, Unread semantics, more than 120 read/unread items`);
+  }
+} finally {
+  await browser?.close();
+  for (const client of clients) client.end();
+  api.closeAllConnections();
+  await new Promise(done => api.close(done));
+}

--- a/tests/ui-panels.e2e.mjs
+++ b/tests/ui-panels.e2e.mjs
@@ -49,6 +49,8 @@ const api = createServer(async (req, res) => {
   switch (url.pathname) {
     case "/api/bootstrap": result = { ...state, ui_event_cursor: cursor }; break;
     case "/api/load_channel_previews": case "/api/load_activity_messages": case "/api/search_messages": result = []; break;
+    case "/api/load_activity_feed": result = { items: [], nextCursor: null, previousCursor: null }; break;
+    case "/api/load_activity_counts": result = { total: 0, unread: 0 }; break;
     case "/api/load_channel_messages": result = { messages: state.messages.filter(m => m.channel_id === args.channelId), next_before_seq: null, has_more: false }; break;
     case "/api/load_thread_messages": result = state.messages.filter(m => m.id === args.threadRootId || m.thread_root_id === args.threadRootId); break;
     case "/api/load_ui_state": result = Object.fromEntries(args.scopes.map(scope => [scope, state[scope]])); break;


### PR DESCRIPTION
Owner Activity currently hydrates messages into the shared chat cache and applies a global candidate limit before the user selects a filter. Unread-first ordering can bury a newly sent owner reply, while changing only the ordering can exclude older unread items from that limited candidate set.

This change queries Activity independently: SQLite applies filtering and read/dismiss eligibility before timestamp-and-ID cursor pagination, returning at most 30 bounded summaries per page. All filters sort newest first, including owner replies without counting them as unread. Separate counts keep badges independent of the visible page.

The modal retains one page, replaces rows on navigation, serializes requests, discards stale responses, and supports retry and explicit refresh. Badge queries are throttled and pause in hidden tabs. Bulk actions explicitly apply to the current page and use displayed timestamps so activity arriving during an action remains eligible.

Database aggregation still scales with history; this bounds payloads, frontend cache, and rendered rows. A disposable SQLite fixture with 5,000 threads / 10,000 messages returned a 30-row page of approximately 84 KB in approximately 190 ms on the development machine.

Validation:
- 67 frontend unit tests, production build, and CSS token gate.
- Full Rust suite: 303 passed, 5 ignored; `cargo check`, formatting, and Clippy with warnings denied passed.
- 13 inbox tests covering all kinds, unread filtering beyond 120 candidates, equal timestamps, forward/backward cursors, deleted cursor rows, bounded excerpts, and read/dismiss races.
- Chromium desktop/mobile Activity regression covering navigation, stale requests, retry, page actions, and reopening.
