### PR TITLE
fix: prevent scroll render loops and concurrent agent start failures

### DIFF
--- a/src-tauri/src/runtime/streaming.rs
+++ b/src-tauri/src/runtime/streaming.rs
@@ -562,7 +562,13 @@ pub(crate) async fn ensure_streaming_agent_message(
         .map_err(to_string)?;
     let sender_name: String = sender.get("display_name");
     let sender_role: String = sender.get("role");
-    let mut transaction = pool.begin().await.map_err(to_string)?;
+    // Claim the writer before preparing the insert. Concurrent warm starts
+    // must wait at BEGIN instead of failing a deferred transaction's upgrade
+    // while SQLite prepares the message/FTS trigger writes.
+    let mut transaction = pool
+        .begin_with("BEGIN IMMEDIATE")
+        .await
+        .map_err(to_string)?;
     let message_id: Uuid = sqlx::query_scalar(
         r#"
         insert into messages (

--- a/src-tauri/src/tests/runtime_streaming.rs
+++ b/src-tauri/src/tests/runtime_streaming.rs
@@ -16,6 +16,50 @@ use sqlx::Row;
 use uuid::Uuid;
 
 #[tokio::test]
+async fn streaming_placeholders_handle_concurrent_starts() {
+    let (pool, schema) = crate::test_support::test_pool_with_connections(8)
+        .await
+        .expect("create concurrent streaming test database");
+    let result: Result<(), String> = async {
+        let agent_id = insert_test_agent(&pool, "concurrent-streamer").await?;
+        let channel_id = insert_test_channel(&pool, "concurrent-streaming").await?;
+        let mut pending = tokio::task::JoinSet::new();
+        for index in 0..64 {
+            let pool = pool.clone();
+            pending.spawn(async move {
+                ensure_streaming_agent_message(
+                    &pool,
+                    agent_id,
+                    channel_id,
+                    None,
+                    &format!("concurrent-start-{index}"),
+                )
+                .await
+            });
+        }
+        let mut failures = Vec::new();
+        while let Some(outcome) = pending.join_next().await {
+            if let Err(error) = outcome.map_err(|error| error.to_string())? {
+                failures.push(error);
+            }
+        }
+        if !failures.is_empty() {
+            return Err(format!("concurrent placeholder failures: {failures:?}"));
+        }
+        let count: i64 = sqlx::query_scalar("select count(*) from messages where channel_id = $1")
+            .bind(channel_id)
+            .fetch_one(&pool)
+            .await
+            .map_err(|error| error.to_string())?;
+        assert_eq!(count, 64);
+        Ok(())
+    }
+    .await;
+    drop_test_schema(pool, schema).await;
+    result.unwrap();
+}
+
+#[tokio::test]
 async fn streaming_agent_messages_append_and_finish() {
     let Some((pool, schema)) = test_pool().await else {
         return;

--- a/src/hooks/useChannelMessageScroll.ts
+++ b/src/hooks/useChannelMessageScroll.ts
@@ -46,7 +46,7 @@ export function useChannelMessageScroll(options: Options) {
     let anchor = saved?.anchor ?? null;
     let follow = !saved || saved.atBottom;
     let initial = true, placing = false, disposed = false, inFlight = false;
-    let frame = 0, settleFrame = 0, loadFrame = 0, userUntil = 0;
+    let frame = 0, settleFrame = 0, loadFrame = 0, reportFrame = 0, userUntil = 0;
     let focusId: string | null = null, lastFocusId: string | null = null;
     let lastReported: ChannelReadLocation | null = null;
     let failedRestore = false;
@@ -78,8 +78,8 @@ export function useChannelMessageScroll(options: Options) {
       if (!preserveSavedPosition && anchor && lastRoot()) rememberChannelPosition(channelId!, { anchor, atBottom: distance() <= 2, latestRootId: lastRoot()!.id });
     }
     function cancelFrames() {
-      cancelAnimationFrame(frame); cancelAnimationFrame(settleFrame);
-      frame = settleFrame = 0;
+      cancelAnimationFrame(frame); cancelAnimationFrame(settleFrame); cancelAnimationFrame(reportFrame);
+      frame = settleFrame = reportFrame = 0;
     }
     function finishPlacement() {
       if (!isLive()) return;
@@ -185,7 +185,15 @@ export function useChannelMessageScroll(options: Options) {
       const id = latest.current.focusedMessageId;
       if (id && id !== lastFocusId) { focusId = id; follow = false; }
       lastFocusId = id;
-      report(); schedule();
+      // This runs from a layout effect. Reporting here can update the parent,
+      // commit another message snapshot and re-enter this effect before the
+      // browser gets a frame. Coalesce reports without waiting for history
+      // restoration, which still needs to invalidate an old read location.
+      if (!reportFrame) reportFrame = requestAnimationFrame(() => {
+        reportFrame = 0;
+        if (isLive()) report();
+      });
+      schedule();
     }
     controller.current = {
       viewport, changed, userScroll, resize: schedule,

--- a/tests/channel-reading-position.e2e.mjs
+++ b/tests/channel-reading-position.e2e.mjs
@@ -73,6 +73,15 @@ if (process.argv.includes("--serve")) {
         assert.equal((await state()).channel, 1);
         assert.ok((await state()).distance <= 2, "late history response cannot move another channel");
         assert.equal((await state()).pages, 1);
+        await page.goto(`${url}/?reset&ready&snapshot-chain`);
+        await page.waitForFunction(() => {
+          const text = document.querySelector('[aria-label="Reading diagnostics"]')?.textContent;
+          return text?.trim().startsWith("{") && JSON.parse(text).location?.latestRootId === "0-180";
+        });
+        await bottom();
+        assert.equal((await state()).rowCount, 140, "parent snapshot reconciliation finishes without nested render updates");
+        await page.waitForTimeout(400);
+        assert.equal((await state()).receipts.at(-1).throughSeq, 180, "read receipt follows the settled final snapshot");
         assert.deepEqual(errors, []);
         console.log(`${engine.name()}: channel restoration and read-receipt regressions passed`);
       } finally { await browser.close(); }

--- a/tests/fixtures/channel-reading-position/main.tsx
+++ b/tests/fixtures/channel-reading-position/main.tsx
@@ -69,6 +69,13 @@ function Fixture() {
     list.scrollTop = toTop ? 0 : list.scrollTop - 600;
   }
   function append(c = channel) { setRoots(before => before.map((items, index) => index === c ? [...items, message(items.at(-1)!.seq + 1, c)] : items)); }
+  function readLocationChanged(next: ChannelReadLocation) {
+    setLocation(next);
+    // Model a parent reconciling buffered message snapshots when the viewport
+    // reports its position. These updates must yield to layout, not recurse
+    // through the scroll hook's layout effect in the same React commit.
+    if (params.has("snapshot-chain") && next.channelId === channels[0].id && Number(next.latestRootId?.split("-")[1]) < 180) append(0);
+  }
   const shared = { channel: channels[channel], channels, agents: [], channelAgents: [], ownerProfile: { display_name: "Owner", avatar: "O", description: "" },
     agentActivities: [], agentRuns: [], agentWorkItems: [], messages: shown, activeRoot: null, taskTitleDrafts: {}, setTaskTitleDraft: noop, saveTaskTitle: noop,
     claimTask: noop, updateTaskStatus: noop, openAgentDetail: noop, openArtifact: noop, onReferenceMessageJump: noop, onReferenceThreadJump: noop,
@@ -80,7 +87,7 @@ function Fixture() {
       openTask={noop} createGithubReviewTask={async () => {throw Error("unused");}} createGithubIssueTask={async () => {throw Error("unused");}}
       setDraft={setDraft} addDraftAttachments={noop} removeDraftAttachment={noop} sendRootMessage={() => append()} hasMoreRootMessages={channel === 0 && roots[0][0].seq > 1}
       historyBeforeSeq={channel === 0 ? (roots[0].some(row => row.seq === 1) ? 1 : 41) : undefined}
-      isLoadingOlderRootMessages={loading} onLoadOlderRootMessages={older} isChannelReady={hydrated} onReadLocation={setLocation} />
+      isLoadingOlderRootMessages={loading} onLoadOlderRootMessages={older} isChannelReady={hydrated} onReadLocation={readLocationChanged} />
     <aside style={{overflow: "auto", padding: 12, fontSize: 12}}>
       <h2>Reading regression controls</h2>
       <button onClick={() => setReady(true)}>Hydrate channel</button>


### PR DESCRIPTION
Channel scroll reports ran synchronously inside a React layout effect. When the parent reconciled another message snapshot from that report, the effect could re-enter until the UI crashed with React error #185. Coalesce reports in an animation frame, cancel them with the viewport lifecycle, and keep read-location invalidation independent of history loading.

Concurrent agent launches could also fail while creating streaming message placeholders with SQLite `database is locked`. Acquire the write transaction with `BEGIN IMMEDIATE` before preparing the insert and its triggers. An isolated test with 8 connections and 64 concurrent starts failed 7 requests before this change; all 64 now succeed. These fixes are separate commits.

Validation:

- Reading-position and new nested-update regression in Chromium and WebKit; the added scenario reproduces the original React error before the fix.
- Mobile-performance and message-state-race browser suites.
- 67 frontend tests and 298 Rust tests passed; 5 explicitly manual Rust tests ignored.
- Production build, CSS gate, Rust fmt, strict Clippy, and `git diff --check` passed.
